### PR TITLE
Refactor handling of EF_MOS_ flags

### DIFF
--- a/lld/test/ELF/basic-mos.s
+++ b/lld/test/ELF/basic-mos.s
@@ -1,7 +1,36 @@
 # REQUIRES: mos
-# RUN: llvm-mc -filetype=obj -triple=mos %s -o %t.o
-# RUN: ld.lld %t.o -o %t
-# RUN: llvm-readobj --file-headers --sections -l %t | FileCheck %s
+
+# RUN: llvm-mc -filetype=obj -triple=mos %s -o %t.o.6502
+# RUN: ld.lld %t.o.6502 -o %t.6502
+# RUN: llvm-readobj --file-headers --sections -l %t.6502 | FileCheck %s -check-prefixes=CHECK,6502
+
+# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mos6502x %s -o %t.o.6502x
+# RUN: ld.lld %t.o.6502x -o %t.6502x
+# RUN: llvm-readobj --file-headers --sections -l %t.6502x | FileCheck %s -check-prefixes=CHECK,6502X
+
+# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mos65c02 %s -o %t.o.65c02
+# RUN: ld.lld %t.o.65c02 -o %t.65c02
+# RUN: llvm-readobj --file-headers --sections -l %t.65c02 | FileCheck %s -check-prefixes=CHECK,65C02
+
+# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mosr65c02 %s -o %t.o.r65c02
+# RUN: ld.lld %t.o.r65c02 -o %t.r65c02
+# RUN: llvm-readobj --file-headers --sections -l %t.r65c02 | FileCheck %s -check-prefixes=CHECK,R65C02
+
+# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mosw65c02 %s -o %t.o.w65c02
+# RUN: ld.lld %t.o.w65c02 -o %t.w65c02
+# RUN: llvm-readobj --file-headers --sections -l %t.w65c02 | FileCheck %s -check-prefixes=CHECK,W65C02
+
+# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mosw65816 %s -o %t.o.w65816
+# RUN: ld.lld %t.o.w65816 -o %t.w65816
+# RUN: llvm-readobj --file-headers --sections -l %t.w65816 | FileCheck %s -check-prefixes=CHECK,W65816
+
+# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mosw65el02 %s -o %t.o.65el02
+# RUN: ld.lld %t.o.65el02 -o %t.65el02
+# RUN: llvm-readobj --file-headers --sections -l %t.65el02 | FileCheck %s -check-prefixes=CHECK,65EL02
+
+# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mosw65ce02 %s -o %t.o.65ce02
+# RUN: ld.lld %t.o.65ce02 -o %t.65ce02
+# RUN: llvm-readobj --file-headers --sections -l %t.65ce02 | FileCheck %s -check-prefixes=CHECK,65CE02
 
 # returns with 42 in accumulator
 .globl _start
@@ -29,7 +58,44 @@ _start:
 // CHECK-NEXT:   Entry: 0x100B4
 // CHECK-NEXT:   ProgramHeaderOffset: 0x34
 // CHECK-NEXT:   SectionHeaderOffset: 0x114
-// CHECK-NEXT:   Flags [ (0x0)
+//  6502-NEXT:   Flags [ (0x3)
+//  6502-NEXT:     EF_MOS_ARCH_6502 (0x1)
+//  6502-NEXT:     EF_MOS_ARCH_6502_BCD (0x2)
+// 6502X-NEXT:   Flags [ (0x7)
+// 6502X-NEXT:     EF_MOS_ARCH_6502 (0x1)
+// 6502X-NEXT:     EF_MOS_ARCH_6502X (0x4)
+// 6502X-NEXT:     EF_MOS_ARCH_6502_BCD (0x2)
+// 65C02-NEXT:   Flags [ (0xB)
+// 65C02-NEXT:     EF_MOS_ARCH_6502 (0x1)
+// 65C02-NEXT:     EF_MOS_ARCH_6502_BCD (0x2)
+// 65C02-NEXT:     EF_MOS_ARCH_65C02 (0x8)
+// R65C02-NEXT:  Flags [ (0x19)
+// R65C02-NEXT:    EF_MOS_ARCH_6502 (0x1)
+// R65C02-NEXT:    EF_MOS_ARCH_65C02 (0x8)
+// R65C02-NEXT:    EF_MOS_ARCH_R65C02 (0x10)
+// W65C02-NEXT:  Flags [ (0x39)
+// W65C02-NEXT:    EF_MOS_ARCH_6502 (0x1)
+// W65C02-NEXT:    EF_MOS_ARCH_65C02 (0x8)
+// W65C02-NEXT:    EF_MOS_ARCH_R65C02 (0x10)
+// W65C02-NEXT:    EF_MOS_ARCH_W65C02 (0x20)
+// W65816-NEXT:  Flags [ (0x139)
+// W65816-NEXT:    EF_MOS_ARCH_6502 (0x1)
+// W65816-NEXT:    EF_MOS_ARCH_65C02 (0x8)
+// W65816-NEXT:    EF_MOS_ARCH_R65C02 (0x10)
+// W65816-NEXT:    EF_MOS_ARCH_W65816 (0x100)
+// W65816-NEXT:    EF_MOS_ARCH_W65C02 (0x20)
+// 65EL02-NEXT:  Flags [ (0x239)
+// 65EL02-NEXT:    EF_MOS_ARCH_6502 (0x1)
+// 65EL02-NEXT:    EF_MOS_ARCH_65C02 (0x8)
+// 65EL02-NEXT:    EF_MOS_ARCH_65EL02 (0x200)
+// 65EL02-NEXT:    EF_MOS_ARCH_R65C02 (0x10)
+// 65EL02-NEXT:    EF_MOS_ARCH_W65C02 (0x20)
+// 65CE02-NEXT:  Flags [ (0x439)
+// 65CE02-NEXT:    EF_MOS_ARCH_6502 (0x1)
+// 65CE02-NEXT:    EF_MOS_ARCH_65C02 (0x8)
+// 65CE02-NEXT:    EF_MOS_ARCH_65CE02 (0x400)
+// 65CE02-NEXT:    EF_MOS_ARCH_R65C02 (0x10)
+// 65CE02-NEXT:    EF_MOS_ARCH_W65C02 (0x20)
 // CHECK-NEXT:   ]
 // CHECK-NEXT:   HeaderSize: 52
 // CHECK-NEXT:   ProgramHeaderEntrySize: 32

--- a/lld/test/ELF/mos-eflags-fail.s
+++ b/lld/test/ELF/mos-eflags-fail.s
@@ -1,0 +1,21 @@
+# REQUIRES: mos
+# RUN: llvm-mc -filetype=obj -triple=mos %s -o %t.o.6502
+# RUN: sed -e 's/_start/_start2/' %s | llvm-mc -filetype=obj -triple=mos -mcpu=mosr65c02 -o %t.o.r65c02
+# RUN: not ld.lld %t.o.6502 %t.o.r65c02 -o %t 2>&1 | FileCheck %s
+
+# returns with 42 in accumulator
+.globl _start
+_start:
+  lda #42
+  rts
+
+; CHECK: error: Input file '{{.*\.o\.r65c02}}' uses bad MOS feature combination from rest of output file.
+; CHECK-NEXT: Input file: Flags [ (0x19)
+; CHECK-NEXT:   EF_MOS_ARCH_6502 (0x1)
+; CHECK-NEXT:   EF_MOS_ARCH_65C02 (0x8)
+; CHECK-NEXT:   EF_MOS_ARCH_R65C02 (0x10)
+; CHECK-NEXT: ]
+; CHECK-NEXT: Output file: Flags [ (0x3)
+; CHECK-NEXT:   EF_MOS_ARCH_6502 (0x1)
+; CHECK-NEXT:   EF_MOS_ARCH_6502_BCD (0x2)
+; CHECK-NEXT: ]

--- a/llvm/include/llvm/BinaryFormat/ELF.h
+++ b/llvm/include/llvm/BinaryFormat/ELF.h
@@ -497,16 +497,16 @@ enum {
 
 // https://github.com/johnwbyrd/llvm-mos/wiki/ELF-format-for-MOS-compatible-processors
 enum : unsigned {
-  EM_MOS_ARCH_6502 = 0x00000001, // Core NMOS 6502 instruction set, no BCD
-  EM_MOS_ARCH_6502_BCD = 0x00000002, // BCD support, including CLD and SED
-  EM_MOS_ARCH_6502X = 0x00000004, // "Illegal" NMOS 6502 instructions
-  EM_MOS_ARCH_65C02 = 0x00000008, // Core 65C02 instruction set
-  EM_MOS_ARCH_R65C02 = 0x00000010, // Rockwell and WDC extended 65C02 insns
-  EM_MOS_ARCH_W65C02 = 0x00000020, // WDC only 65C02 instructions
-  EM_MOS_ARCH_W65816 = 0x00000100, // 65816 instructions
-  EM_MOS_ARCH_65EL02 = 0x00000200, // 65EL02 instructions
-  EM_MOS_ARCH_65CE02 = 0x00000400,  // 65CE02 instructions
-  EM_MOS_ARCH_SWEET16 = 0x00010000  // SWEET16 instructions
+  EF_MOS_ARCH_6502 = 0x00000001, // Core NMOS 6502 instruction set, no BCD
+  EF_MOS_ARCH_6502_BCD = 0x00000002, // BCD support, including CLD and SED
+  EF_MOS_ARCH_6502X = 0x00000004, // "Illegal" NMOS 6502 instructions
+  EF_MOS_ARCH_65C02 = 0x00000008, // Core 65C02 instruction set
+  EF_MOS_ARCH_R65C02 = 0x00000010, // Rockwell and WDC extended 65C02 insns
+  EF_MOS_ARCH_W65C02 = 0x00000020, // WDC only 65C02 instructions
+  EF_MOS_ARCH_W65816 = 0x00000100, // 65816 instructions
+  EF_MOS_ARCH_65EL02 = 0x00000200, // 65EL02 instructions
+  EF_MOS_ARCH_65CE02 = 0x00000400,  // 65CE02 instructions
+  EF_MOS_ARCH_SWEET16 = 0x00010000  // SWEET16 instructions
 };
 
 // ELF Relocation types for AVR

--- a/llvm/include/llvm/BinaryFormat/MOSFlags.h
+++ b/llvm/include/llvm/BinaryFormat/MOSFlags.h
@@ -1,0 +1,38 @@
+//===- MOSFlags.h - MOS ELF e_flags tools -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header contains shared EF_MOS_* information and verification tools for
+// targeting MOS.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_BINARYFORMAT_MOSFLAGS_H
+#define LLVM_BINARYFORMAT_MOSFLAGS_H
+
+#include "llvm/Support/ScopedPrinter.h"
+
+namespace llvm {
+
+class FeatureBitset;
+
+namespace MOS {
+
+/// EnumEntries for general EF_MOS_* printing.
+extern const ArrayRef<EnumEntry<unsigned>> ElfHeaderMOSFlags;
+
+/// Makes a string describing all set EF_MOS_* bits.
+std::string makeEFlagsString(unsigned EFlags);
+
+/// Checks if functions generated for a subtarget are compatible with e_flags
+/// combinations in a module under assembly.
+bool checkEFlagsCompatibility(unsigned EFlags, unsigned ModuleEFlags);
+
+} // namespace MOS
+} // namespace llvm
+
+#endif // LLVM_BINARYFORMAT_MOSFLAGS_H

--- a/llvm/lib/BinaryFormat/CMakeLists.txt
+++ b/llvm/lib/BinaryFormat/CMakeLists.txt
@@ -4,6 +4,7 @@ add_llvm_component_library(LLVMBinaryFormat
   MachO.cpp
   Magic.cpp
   Minidump.cpp
+  MOSFlags.cpp
   MsgPackDocument.cpp
   MsgPackDocumentYAML.cpp
   MsgPackReader.cpp

--- a/llvm/lib/BinaryFormat/MOSFlags.cpp
+++ b/llvm/lib/BinaryFormat/MOSFlags.cpp
@@ -37,16 +37,13 @@ std::string makeEFlagsString(unsigned EFlags) {
   return Str;
 }
 
-static bool equalsMask(unsigned Flags, unsigned Mask) {
-  return (Flags & Mask) == Mask;
-}
-
 bool checkEFlagsCompatibility(unsigned EFlags, unsigned ModuleEFlags) {
+  const unsigned Flags = EFlags | ModuleEFlags;
   // Mixing sweet16 with native or R65C02 with BCD is prohibited
-  return !!(ModuleEFlags & ELF::EF_MOS_ARCH_SWEET16) ==
-             !!(EFlags & ELF::EF_MOS_ARCH_SWEET16) &&
-         !equalsMask(EFlags | ModuleEFlags,
-                     ELF::EF_MOS_ARCH_6502_BCD | ELF::EF_MOS_ARCH_R65C02);
+  return (!(Flags & ELF::EF_MOS_ARCH_SWEET16) ||
+          !(Flags & ~ELF::EF_MOS_ARCH_SWEET16)) &&
+         (!(Flags & ELF::EF_MOS_ARCH_6502_BCD) ||
+          !(Flags & ELF::EF_MOS_ARCH_R65C02));
 }
 
 } // namespace MOS

--- a/llvm/lib/BinaryFormat/MOSFlags.cpp
+++ b/llvm/lib/BinaryFormat/MOSFlags.cpp
@@ -1,0 +1,53 @@
+//===-- MOSFlags.cpp - MOS ELF e_flags tools ---------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/BinaryFormat/MOSFlags.h"
+#include "llvm/BinaryFormat/ELF.h"
+
+namespace llvm {
+namespace MOS {
+
+#define ENUM_ENT(enum, altName)                                                \
+  { #enum, altName, ELF::enum }
+
+static const EnumEntry<unsigned> ElfHeaderMOSFlagsEntries[] = {
+    ENUM_ENT(EF_MOS_ARCH_6502, "mos6502"),
+    ENUM_ENT(EF_MOS_ARCH_6502_BCD, "mos6502bcd"),
+    ENUM_ENT(EF_MOS_ARCH_6502X, "mos6502x"),
+    ENUM_ENT(EF_MOS_ARCH_65C02, "mos65c02"),
+    ENUM_ENT(EF_MOS_ARCH_R65C02, "mosr65c02"),
+    ENUM_ENT(EF_MOS_ARCH_W65C02, "mosw65c02"),
+    ENUM_ENT(EF_MOS_ARCH_W65816, "mosw65816"),
+    ENUM_ENT(EF_MOS_ARCH_65EL02, "mosw65el02"),
+    ENUM_ENT(EF_MOS_ARCH_65CE02, "mosw65ce02"),
+    ENUM_ENT(EF_MOS_ARCH_SWEET16, "mossweet16")};
+const ArrayRef<EnumEntry<unsigned>> ElfHeaderMOSFlags{ElfHeaderMOSFlagsEntries};
+
+std::string makeEFlagsString(unsigned EFlags) {
+  std::string Str;
+  raw_string_ostream Stream(Str);
+  ScopedPrinter Printer(Stream);
+  Printer.printFlags("Flags", EFlags, ElfHeaderMOSFlags);
+  Stream.flush();
+  return Str;
+}
+
+static bool equalsMask(unsigned Flags, unsigned Mask) {
+  return (Flags & Mask) == Mask;
+}
+
+bool checkEFlagsCompatibility(unsigned EFlags, unsigned ModuleEFlags) {
+  // Mixing sweet16 with native or R65C02 with BCD is prohibited
+  return !!(ModuleEFlags & ELF::EF_MOS_ARCH_SWEET16) ==
+             !!(EFlags & ELF::EF_MOS_ARCH_SWEET16) &&
+         !equalsMask(EFlags | ModuleEFlags,
+                     ELF::EF_MOS_ARCH_6502_BCD | ELF::EF_MOS_ARCH_R65C02);
+}
+
+} // namespace MOS
+} // namespace llvm

--- a/llvm/lib/Target/MOS/AsmParser/MOSAsmParser.cpp
+++ b/llvm/lib/Target/MOS/AsmParser/MOSAsmParser.cpp
@@ -224,6 +224,9 @@ public:
     MRI = getContext().getRegisterInfo();
 
     setAvailableFeatures(ComputeAvailableFeatures(STI.getFeatureBits()));
+
+    if (MCAssembler *Asm = Parser.getStreamer().getAssemblerPtr())
+      Asm->setELFHeaderEFlags(MOS_MC::makeEFlags(STI.getFeatureBits()));
   }
   MCAsmLexer &getLexer() const { return Parser.getLexer(); }
   MCAsmParser &getParser() const { return Parser; }
@@ -606,7 +609,7 @@ public:
 #include "MOSGenAsmMatcher.inc"
 
 // Parse only registers that can be considered parameters to real MOS
-// instructions.  The instruction parser considers x, y, and s to be 
+// instructions.  The instruction parser considers x, y, and s to be
 // strings, not registers, so make a point of filtering those cases out
 // of what's acceptable.
 OperandMatchResultTy

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCTargetDesc.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCTargetDesc.cpp
@@ -17,6 +17,7 @@
 #include "MOSMCELFStreamer.h"
 #include "MOSTargetStreamer.h"
 
+#include "llvm/BinaryFormat/ELF.h"
 #include "llvm/MC/MCAsmBackend.h"
 #include "llvm/MC/MCCodeEmitter.h"
 #include "llvm/MC/MCELFStreamer.h"
@@ -35,6 +36,36 @@
 #include "MOSGenRegisterInfo.inc"
 
 using namespace llvm;
+
+namespace llvm {
+namespace MOS_MC {
+/// Makes an e_flags value based on subtarget features.
+unsigned makeEFlags(const FeatureBitset &Features) {
+  unsigned ELFArch = 0;
+  if (Features[MOS::Feature65C02])
+    ELFArch |= ELF::EF_MOS_ARCH_65C02;
+  if (Features[MOS::Feature65CE02])
+    ELFArch |= ELF::EF_MOS_ARCH_65CE02;
+  if (Features[MOS::Feature65EL02])
+    ELFArch |= ELF::EF_MOS_ARCH_65EL02;
+  if (Features[MOS::Feature6502])
+    ELFArch |= ELF::EF_MOS_ARCH_6502;
+  if (Features[MOS::Feature6502BCD])
+    ELFArch |= ELF::EF_MOS_ARCH_6502_BCD;
+  if (Features[MOS::Feature6502X])
+    ELFArch |= ELF::EF_MOS_ARCH_6502X;
+  if (Features[MOS::FeatureR65C02])
+    ELFArch |= ELF::EF_MOS_ARCH_R65C02;
+  if (Features[MOS::FeatureSWEET16])
+    ELFArch |= ELF::EF_MOS_ARCH_SWEET16;
+  if (Features[MOS::FeatureW65C02])
+    ELFArch |= ELF::EF_MOS_ARCH_W65C02;
+  if (Features[MOS::FeatureW65816])
+    ELFArch |= ELF::EF_MOS_ARCH_W65816;
+  return ELFArch;
+}
+} // namespace MOS_MC
+} // end namespace llvm
 
 MCInstrInfo *llvm::createMOSMCInstrInfo() {
   MCInstrInfo *X = new MCInstrInfo();

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCTargetDesc.h
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCTargetDesc.h
@@ -19,6 +19,7 @@
 
 namespace llvm {
 
+class FeatureBitset;
 class MCAsmBackend;
 class MCCodeEmitter;
 class MCContext;
@@ -48,6 +49,11 @@ MCAsmBackend *createMOSAsmBackend(const Target &T, const MCSubtargetInfo &STI,
 
 /// Creates an ELF object writer for MOS.
 std::unique_ptr<MCObjectTargetWriter> createMOSELFObjectWriter(uint8_t OSABI);
+
+namespace MOS_MC {
+/// Makes an e_flags value based on subtarget features.
+unsigned makeEFlags(const FeatureBitset &Features);
+} // namespace MOS_MC
 
 } // end namespace llvm
 

--- a/llvm/lib/Target/MOS/MOSDevices.td
+++ b/llvm/lib/Target/MOS/MOSDevices.td
@@ -118,20 +118,6 @@ def FamilySWEET16
       "MOS 6502 compatible with SWEET16 virtual machine support", 
       [FeatureSWEET16]>;
 
-class ELFArch<string name>  : SubtargetFeature<"", "ELFArch",
-                                    !strconcat("ELF::",name), "">;
-// ELF e_flags architecture values
-def ELFArchMOS6502 : ELFArch<"EM_MOS_ARCH_6502">;
-def ELFArchMOS6502BCD : ELFArch<"EM_MOS_ARCH_6502_BCD">;
-def ELFArchMOS6502X : ELFArch<"EM_MOS_ARCH_6502X">;
-def ELFArchMOS65C02 : ELFArch<"EM_MOS_ARCH_65C02">;
-def ELFArchMOSR65C02 : ELFArch<"EM_MOS_ARCH_R65C02">;
-def ELFArchMOSW65C02 : ELFArch<"EM_MOS_ARCH_W65C02">;
-def ELFArchMOSW65816 : ELFArch<"EM_MOS_ARCH_W65816">;
-def ELFArchMOS65EL02 : ELFArch<"EM_MOS_ARCH_65EL02">;
-def ELFArchMOS65CE02 : ELFArch<"EM_MOS_ARCH_65CE02">;
-def ELFArchMOSSWEET16 : ELFArch<"EM_MOS_ARCH_SWEET16">;
-
 //===---------------------------------------------------------------------===//
 // MOS Families
 //===---------------------------------------------------------------------===//
@@ -144,17 +130,16 @@ def MOSSchedModel : SchedMachineModel {
   let CompleteModel = false;
 }
 
-class Device<string Name, Family Fam, ELFArch Arch,
+class Device<string Name, Family Fam,
              list<SubtargetFeature> ExtraFeatures = []>
-  : ProcessorModel<Name, MOSSchedModel, !listconcat([Fam,Arch],ExtraFeatures)>;
+  : ProcessorModel<Name, MOSSchedModel, !listconcat([Fam],ExtraFeatures)>;
 
-def : Device<"mos6502",  Family6502, ELFArchMOS6502>;
-def : Device<"mos6502x", Family6502X, ELFArchMOS6502X>;
-def : Device<"mos65c02", Family65C02, ELFArchMOS65C02>;
-def : Device<"mosr65c02", FamilyR65C02, ELFArchMOSR65C02>;
-def : Device<"mosw65c02", FamilyR65C02, ELFArchMOSW65C02>;
-def : Device<"mosw65816", FamilyW65816, ELFArchMOSW65816>;
-def : Device<"mosw65el02", Family65EL02, ELFArchMOS65EL02>;
-def : Device<"mosw65ce02", Family65CE02, ELFArchMOS65CE02>;
-def : Device<"mossweet16", FamilySWEET16, ELFArchMOSSWEET16>;
-
+def : Device<"mos6502",  Family6502>;
+def : Device<"mos6502x", Family6502X>;
+def : Device<"mos65c02", Family65C02>;
+def : Device<"mosr65c02", FamilyR65C02>;
+def : Device<"mosw65c02", FamilyW65C02>;
+def : Device<"mosw65816", FamilyW65816>;
+def : Device<"mosw65el02", Family65EL02>;
+def : Device<"mosw65ce02", Family65CE02>;
+def : Device<"mossweet16", FamilySWEET16>;

--- a/llvm/lib/Target/MOS/MOSSubtarget.h
+++ b/llvm/lib/Target/MOS/MOSSubtarget.h
@@ -42,23 +42,42 @@ public:
   MOSSubtarget(const Triple &TT, const std::string &CPU, const std::string &FS,
                const MOSTargetMachine &TM);
 
-  /// Gets the ELF architecture for the e_flags field
-  /// of an ELF object file.
-  unsigned getELFArch() const {
-    assert(ELFArch != 0 &&
-           "every device must have an associate ELF architecture");
-    return ELFArch;
+  /// Gets the e_flags value of an ELF object file.
+  unsigned getEFlags() const {
+    assert(EFlags != 0 &&
+           "every MOS subtarget must set at least one architecture feature");
+    return EFlags;
   }
 
-  const MOSFrameLowering *getFrameLowering() const override;
-  const MOSInstrInfo *getInstrInfo() const override;
-  const MOSRegisterInfo *getRegisterInfo() const override;
-  const MOSTargetLowering *getTargetLowering() const override;
-  const CallLowering *getCallLowering() const override;
-  const LegalizerInfo *getLegalizerInfo() const override;
-  const RegisterBankInfo *getRegBankInfo() const override;
-  InstructionSelector *getInstructionSelector() const override;
-  const InlineAsmLowering *getInlineAsmLowering() const override;
+  const MOSFrameLowering *getFrameLowering() const override {
+    return &FrameLowering;
+  }
+
+  const MOSInstrInfo *getInstrInfo() const override { return &InstrInfo; }
+
+  const MOSRegisterInfo *getRegisterInfo() const override { return &RegInfo; }
+
+  const MOSTargetLowering *getTargetLowering() const override {
+    return &TLInfo;
+  }
+
+  const CallLowering *getCallLowering() const override {
+    return &CallLoweringInfo;
+  }
+
+  const LegalizerInfo *getLegalizerInfo() const override { return &Legalizer; }
+
+  const RegisterBankInfo *getRegBankInfo() const override {
+    return &RegBankInfo;
+  }
+
+  InstructionSelector *getInstructionSelector() const override {
+    return InstSelector.get();
+  }
+
+  const InlineAsmLowering *getInlineAsmLowering() const override {
+    return &InlineAsmLoweringInfo;
+  }
 
   bool enableMachineScheduler() const override { return true; }
   bool enableSubRegLiveness() const override { return true; }
@@ -81,8 +100,8 @@ public:
   bool has65C02() const { return Has65C02Insns; }
 
 private:
-  /// The ELF e_flags architecture.
-  unsigned ELFArch;
+  /// The ELF e_flags architecture features.
+  unsigned EFlags = 0;
 
   // Subtarget feature settings
   // See MOS.td for details.
@@ -118,4 +137,4 @@ private:
 
 } // end namespace llvm
 
-#endif // LLVM_MOS_SUBTARGET_
+#endif // LLVM_MOS_SUBTARGET_H

--- a/llvm/test/MC/MOS/eflags-fail.ll
+++ b/llvm/test/MC/MOS/eflags-fail.ll
@@ -1,0 +1,26 @@
+; RUN: not --crash llc -mtriple=mos -filetype=obj < %s 2>&1 | FileCheck %s
+
+define void @func0() #0 {
+entry:
+  ret void
+}
+
+define void @func1() #1 {
+entry:
+  ret void
+}
+
+; R65C02 and BCD features cannot be mixed
+attributes #0 = { "target-cpu"="mos6502" }
+attributes #1 = { "target-cpu"="mosr65c02" }
+
+; CHECK: error: Function 'func1' uses bad MOS feature combination from rest of module.
+; CHECK-NEXT: Function: Flags [ (0x19)
+; CHECK-NEXT:   EF_MOS_ARCH_6502 (0x1)
+; CHECK-NEXT:   EF_MOS_ARCH_65C02 (0x8)
+; CHECK-NEXT:   EF_MOS_ARCH_R65C02 (0x10)
+; CHECK-NEXT: ]
+; CHECK-NEXT: Module: Flags [ (0x3)
+; CHECK-NEXT:   EF_MOS_ARCH_6502 (0x1)
+; CHECK-NEXT:   EF_MOS_ARCH_6502_BCD (0x2)
+; CHECK-NEXT: ]

--- a/llvm/test/MC/MOS/eflags-ir.ll
+++ b/llvm/test/MC/MOS/eflags-ir.ll
@@ -1,0 +1,56 @@
+; RUN: sed -e 's/__mos_target_cpu/mos6502/' %s | llc -mtriple=mos -filetype=obj | llvm-readobj --file-headers - | FileCheck -check-prefixes=CHECK,6502 %s
+; RUN: sed -e 's/__mos_target_cpu/mos6502x/' %s | llc -mtriple=mos -filetype=obj | llvm-readobj --file-headers - | FileCheck -check-prefixes=CHECK,6502X %s
+; RUN: sed -e 's/__mos_target_cpu/mos65c02/' %s | llc -mtriple=mos -filetype=obj | llvm-readobj --file-headers - | FileCheck -check-prefixes=CHECK,65C02 %s
+; RUN: sed -e 's/__mos_target_cpu/mosr65c02/' %s | llc -mtriple=mos -filetype=obj | llvm-readobj --file-headers - | FileCheck -check-prefixes=CHECK,R65C02 %s
+; RUN: sed -e 's/__mos_target_cpu/mosw65c02/' %s | llc -mtriple=mos -filetype=obj | llvm-readobj --file-headers - | FileCheck -check-prefixes=CHECK,W65C02 %s
+; RUN: sed -e 's/__mos_target_cpu/mosw65816/' %s | llc -mtriple=mos -filetype=obj | llvm-readobj --file-headers - | FileCheck -check-prefixes=CHECK,W65816 %s
+; RUN: sed -e 's/__mos_target_cpu/mosw65el02/' %s | llc -mtriple=mos -filetype=obj | llvm-readobj --file-headers - | FileCheck -check-prefixes=CHECK,65EL02 %s
+; RUN: sed -e 's/__mos_target_cpu/mosw65ce02/' %s | llc -mtriple=mos -filetype=obj | llvm-readobj --file-headers - | FileCheck -check-prefixes=CHECK,65CE02 %s
+
+; CHECK:        Machine: EM_MOS (0x1966)
+; 6502:         Flags [ (0x3)
+; 6502-NEXT:      EF_MOS_ARCH_6502 (0x1)
+; 6502-NEXT:      EF_MOS_ARCH_6502_BCD (0x2)
+; 6502X:        Flags [ (0x7)
+; 6502X-NEXT:     EF_MOS_ARCH_6502 (0x1)
+; 6502X-NEXT:     EF_MOS_ARCH_6502X (0x4)
+; 6502X-NEXT:     EF_MOS_ARCH_6502_BCD (0x2)
+; 65C02:        Flags [ (0xB)
+; 65C02-NEXT:     EF_MOS_ARCH_6502 (0x1)
+; 65C02-NEXT:     EF_MOS_ARCH_6502_BCD (0x2)
+; 65C02-NEXT:     EF_MOS_ARCH_65C02 (0x8)
+; R65C02:       Flags [ (0x19)
+; R65C02-NEXT:    EF_MOS_ARCH_6502 (0x1)
+; R65C02-NEXT:    EF_MOS_ARCH_65C02 (0x8)
+; R65C02-NEXT:    EF_MOS_ARCH_R65C02 (0x10)
+; W65C02:       Flags [ (0x39)
+; W65C02-NEXT:    EF_MOS_ARCH_6502 (0x1)
+; W65C02-NEXT:    EF_MOS_ARCH_65C02 (0x8)
+; W65C02-NEXT:    EF_MOS_ARCH_R65C02 (0x10)
+; W65C02-NEXT:    EF_MOS_ARCH_W65C02 (0x20)
+; W65816:       Flags [ (0x139)
+; W65816-NEXT:    EF_MOS_ARCH_6502 (0x1)
+; W65816-NEXT:    EF_MOS_ARCH_65C02 (0x8)
+; W65816-NEXT:    EF_MOS_ARCH_R65C02 (0x10)
+; W65816-NEXT:    EF_MOS_ARCH_W65816 (0x100)
+; W65816-NEXT:    EF_MOS_ARCH_W65C02 (0x20)
+; 65EL02:       Flags [ (0x239)
+; 65EL02-NEXT:    EF_MOS_ARCH_6502 (0x1)
+; 65EL02-NEXT:    EF_MOS_ARCH_65C02 (0x8)
+; 65EL02-NEXT:    EF_MOS_ARCH_65EL02 (0x200)
+; 65EL02-NEXT:    EF_MOS_ARCH_R65C02 (0x10)
+; 65EL02-NEXT:    EF_MOS_ARCH_W65C02 (0x20)
+; 65CE02:       Flags [ (0x439)
+; 65CE02-NEXT:    EF_MOS_ARCH_6502 (0x1)
+; 65CE02-NEXT:    EF_MOS_ARCH_65C02 (0x8)
+; 65CE02-NEXT:    EF_MOS_ARCH_65CE02 (0x400)
+; 65CE02-NEXT:    EF_MOS_ARCH_R65C02 (0x10)
+; 65CE02-NEXT:    EF_MOS_ARCH_W65C02 (0x20)
+; CHECK-NEXT:   ]
+
+define void @func0() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { "target-cpu"="__mos_target_cpu" }

--- a/llvm/test/MC/MOS/eflags.s
+++ b/llvm/test/MC/MOS/eflags.s
@@ -1,0 +1,55 @@
+# RUN: llvm-mc -filetype=obj -triple=mos %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,6502
+# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mos6502x %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,6502X
+# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mos65c02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,65C02
+# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mosr65c02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,R65C02
+# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mosw65c02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,W65C02
+# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mosw65816 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,W65816
+# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mosw65el02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,65EL02
+# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mosw65ce02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,65CE02
+
+# returns with 42 in accumulator
+.globl _start
+_start:
+  lda #42
+  rts
+
+// CHECK:       Machine: EM_MOS (0x1966)
+//  6502:       Flags [ (0x3)
+//  6502-NEXT:     EF_MOS_ARCH_6502 (0x1)
+//  6502-NEXT:     EF_MOS_ARCH_6502_BCD (0x2)
+// 6502X:       Flags [ (0x7)
+// 6502X-NEXT:     EF_MOS_ARCH_6502 (0x1)
+// 6502X-NEXT:     EF_MOS_ARCH_6502X (0x4)
+// 6502X-NEXT:     EF_MOS_ARCH_6502_BCD (0x2)
+// 65C02:       Flags [ (0xB)
+// 65C02-NEXT:     EF_MOS_ARCH_6502 (0x1)
+// 65C02-NEXT:     EF_MOS_ARCH_6502_BCD (0x2)
+// 65C02-NEXT:     EF_MOS_ARCH_65C02 (0x8)
+// R65C02:      Flags [ (0x19)
+// R65C02-NEXT:    EF_MOS_ARCH_6502 (0x1)
+// R65C02-NEXT:    EF_MOS_ARCH_65C02 (0x8)
+// R65C02-NEXT:    EF_MOS_ARCH_R65C02 (0x10)
+// W65C02:      Flags [ (0x39)
+// W65C02-NEXT:    EF_MOS_ARCH_6502 (0x1)
+// W65C02-NEXT:    EF_MOS_ARCH_65C02 (0x8)
+// W65C02-NEXT:    EF_MOS_ARCH_R65C02 (0x10)
+// W65C02-NEXT:    EF_MOS_ARCH_W65C02 (0x20)
+// W65816:      Flags [ (0x139)
+// W65816-NEXT:    EF_MOS_ARCH_6502 (0x1)
+// W65816-NEXT:    EF_MOS_ARCH_65C02 (0x8)
+// W65816-NEXT:    EF_MOS_ARCH_R65C02 (0x10)
+// W65816-NEXT:    EF_MOS_ARCH_W65816 (0x100)
+// W65816-NEXT:    EF_MOS_ARCH_W65C02 (0x20)
+// 65EL02:      Flags [ (0x239)
+// 65EL02-NEXT:    EF_MOS_ARCH_6502 (0x1)
+// 65EL02-NEXT:    EF_MOS_ARCH_65C02 (0x8)
+// 65EL02-NEXT:    EF_MOS_ARCH_65EL02 (0x200)
+// 65EL02-NEXT:    EF_MOS_ARCH_R65C02 (0x10)
+// 65EL02-NEXT:    EF_MOS_ARCH_W65C02 (0x20)
+// 65CE02:      Flags [ (0x439)
+// 65CE02-NEXT:    EF_MOS_ARCH_6502 (0x1)
+// 65CE02-NEXT:    EF_MOS_ARCH_65C02 (0x8)
+// 65CE02-NEXT:    EF_MOS_ARCH_65CE02 (0x400)
+// 65CE02-NEXT:    EF_MOS_ARCH_R65C02 (0x10)
+// 65CE02-NEXT:    EF_MOS_ARCH_W65C02 (0x20)
+// CHECK-NEXT:   ]

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -30,6 +30,7 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/AMDGPUMetadataVerifier.h"
 #include "llvm/BinaryFormat/ELF.h"
+#include "llvm/BinaryFormat/MOSFlags.h"
 #include "llvm/Demangle/Demangle.h"
 #include "llvm/Object/ELF.h"
 #include "llvm/Object/ELFObjectFile.h"
@@ -3237,6 +3238,8 @@ template <class ELFT> void GNUELFDumper<ELFT>::printFileHeaders() {
                    unsigned(ELF::EF_MIPS_MACH));
   else if (e.e_machine == EM_RISCV)
     ElfFlags = printFlags(e.e_flags, makeArrayRef(ElfHeaderRISCVFlags));
+  else if (e.e_machine == EM_MOS)
+    ElfFlags = printFlags(e.e_flags, MOS::ElfHeaderMOSFlags);
   Str = "0x" + to_hexString(e.e_flags);
   if (!ElfFlags.empty())
     Str = Str + ", " + ElfFlags;
@@ -6220,6 +6223,8 @@ template <class ELFT> void LLVMELFDumper<ELFT>::printFileHeaders() {
       }
     } else if (E.e_machine == EM_RISCV)
       W.printFlags("Flags", E.e_flags, makeArrayRef(ElfHeaderRISCVFlags));
+    else if (E.e_machine == EM_MOS)
+      W.printFlags("Flags", E.e_flags, MOS::ElfHeaderMOSFlags);
     else
       W.printFlags("Flags", E.e_flags);
     W.printNumber("HeaderSize", E.e_ehsize);


### PR DESCRIPTION
TableGen's SubtargetEmitter does not support bitwise feature values and also lacks visibility to other tools like lld and llvm-readobj. This refactor provides shared functions for handling EF_MOS_ logic across LLVM, including conflict detection and generation of flag strings.

Flag conflicts are detected per-IR-Function in the LLVM backend and per-object in LLD. This way, information about the first entity to cause a conflict is displayed to the user.

Crucially, ELF objects now have populated e_flags fields according to the llvm-mos ELF specification.

Closes #31