### PR TITLE
Replace EM value

### DIFF
--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1632,7 +1632,7 @@ static uint16_t getBitcodeMachineKind(StringRef path, const Triple &t) {
   case Triple::mips64el:
     return EM_MIPS;
   case Triple::mos:
-    return EM_MOS;
+    return EM_MCS6502;
   case Triple::msp430:
     return EM_MSP430;
   case Triple::ppc:

--- a/lld/ELF/Target.cpp
+++ b/lld/ELF/Target.cpp
@@ -87,7 +87,7 @@ TargetInfo *elf::getTarget() {
     return getSPARCV9TargetInfo();
   case EM_X86_64:
     return getX86_64TargetInfo();
-  case EM_MOS:
+  case EM_MCS6502:
     return getMOSTargetInfo();
   }
   llvm_unreachable("unknown target machine");

--- a/lld/test/ELF/basic-mos.s
+++ b/lld/test/ELF/basic-mos.s
@@ -38,7 +38,7 @@ _start:
   lda #42
   rts
 
-// CHECK:      Format: elf32-mos
+// CHECK:      Format: elf32-mcs6502
 // CHECK-NEXT: Arch: mos
 // CHECK-NEXT: AddressSize: 32bit
 // CHECK-NEXT: LoadName: <Not found>
@@ -53,7 +53,7 @@ _start:
 // CHECK-NEXT:     Unused: (00 00 00 00 00 00 00)
 // CHECK-NEXT:   }
 // CHECK-NEXT:   Type: Executable (0x2)
-// CHECK-NEXT:   Machine: EM_MOS (0x1966)
+// CHECK-NEXT:   Machine: EM_MCS6502 (0xFE)
 // CHECK-NEXT:   Version: 1
 // CHECK-NEXT:   Entry: 0x100B4
 // CHECK-NEXT:   ProgramHeaderOffset: 0x34

--- a/llvm/include/llvm/BinaryFormat/ELF.h
+++ b/llvm/include/llvm/BinaryFormat/ELF.h
@@ -318,7 +318,7 @@ enum {
   EM_VE = 251,            // NEC SX-Aurora VE
   EM_CSKY = 252,          // C-SKY 32-bit processor
 
-  EM_MOS = 6502,      // MOS Technologies 65xx
+  EM_MCS6502 = 254,       // MOS Technologies 65xx
 };
 
 // Object file classes.

--- a/llvm/include/llvm/Object/ELFObjectFile.h
+++ b/llvm/include/llvm/Object/ELFObjectFile.h
@@ -1177,8 +1177,8 @@ StringRef ELFObjectFile<ELFT>::getFileFormatName() const {
       return "elf32-lanai";
     case ELF::EM_MIPS:
       return "elf32-mips";
-    case ELF::EM_MOS:
-     return "elf32-mos";
+    case ELF::EM_MCS6502:
+     return "elf32-mcs6502";
     case ELF::EM_MSP430:
       return "elf32-msp430";
     case ELF::EM_PPC:
@@ -1257,7 +1257,7 @@ template <class ELFT> Triple::ArchType ELFObjectFile<ELFT>::getArch() const {
     default:
       report_fatal_error("Invalid ELFCLASS!");
     }
-  case ELF::EM_MOS:
+  case ELF::EM_MCS6502:
     return Triple::mos;
   case ELF::EM_MSP430:
     return Triple::msp430;

--- a/llvm/lib/Object/ELF.cpp
+++ b/llvm/lib/Object/ELF.cpp
@@ -94,7 +94,7 @@ StringRef llvm::object::getELFRelocationTypeName(uint32_t Machine,
       break;
     }
     break;
-  case ELF::EM_MOS:
+  case ELF::EM_MCS6502:
     switch (Type) {
 #include "llvm/BinaryFormat/ELFRelocs/MOS.def"
     default:

--- a/llvm/lib/ObjectYAML/ELFYAML.cpp
+++ b/llvm/lib/ObjectYAML/ELFYAML.cpp
@@ -328,7 +328,7 @@ void ScalarEnumerationTraits<ELFYAML::ELF_EM>::enumeration(
   ECase(EM_BPF);
   ECase(EM_VE);
   ECase(EM_CSKY);
-  ECase(EM_MOS);
+  ECase(EM_MCS6502);
 #undef ECase
   IO.enumFallback<Hex16>(Value);
 }
@@ -699,7 +699,7 @@ void ScalarBitSetTraits<ELFYAML::ELF_SHF>::bitset(IO &IO,
   case ELF::EM_X86_64:
     BCase(SHF_X86_64_LARGE);
     break;
-  case ELF::EM_MOS:
+  case ELF::EM_MCS6502:
     BCase(SHF_MOS_ZEROPAGE);
     break;
   default:
@@ -821,7 +821,7 @@ void ScalarEnumerationTraits<ELFYAML::ELF_REL>::enumeration(
   case ELF::EM_68K:
 #include "llvm/BinaryFormat/ELFRelocs/M68k.def"
     break;
-  case ELF::EM_MOS:
+  case ELF::EM_MCS6502:
 #include "llvm/BinaryFormat/ELFRelocs/MOS.def"
     break;
   default:

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSAsmBackend.h
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSAsmBackend.h
@@ -33,8 +33,8 @@ struct MCFixupKindInfo;
 class MOSObjectTargetWriter : public MCELFObjectTargetWriter {
 public:
   MOSObjectTargetWriter()
-      : MCELFObjectTargetWriter(false, 0, ELF::EM_MOS, false) {
-    val = ELF::EM_MOS;
+      : MCELFObjectTargetWriter(false, 0, ELF::EM_MCS6502, false) {
+    val = ELF::EM_MCS6502;
   }
 
   ~MOSObjectTargetWriter() override { val = 0; }

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSELFObjectWriter.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSELFObjectWriter.cpp
@@ -33,7 +33,7 @@ public:
 };
 
 MOSELFObjectWriter::MOSELFObjectWriter(uint8_t OSABI)
-    : MCELFObjectTargetWriter(false, OSABI, ELF::EM_MOS, true) {}
+    : MCELFObjectTargetWriter(false, OSABI, ELF::EM_MCS6502, true) {}
 
 unsigned MOSELFObjectWriter::getRelocType(MCContext &Ctx,
                                           const MCValue &Target,

--- a/llvm/test/MC/MOS/eflags-ir.ll
+++ b/llvm/test/MC/MOS/eflags-ir.ll
@@ -7,7 +7,7 @@
 ; RUN: sed -e 's/__mos_target_cpu/mosw65el02/' %s | llc -mtriple=mos -filetype=obj | llvm-readobj --file-headers - | FileCheck -check-prefixes=CHECK,65EL02 %s
 ; RUN: sed -e 's/__mos_target_cpu/mosw65ce02/' %s | llc -mtriple=mos -filetype=obj | llvm-readobj --file-headers - | FileCheck -check-prefixes=CHECK,65CE02 %s
 
-; CHECK:        Machine: EM_MOS (0x1966)
+; CHECK:        Machine: EM_MCS6502 (0xFE)
 ; 6502:         Flags [ (0x3)
 ; 6502-NEXT:      EF_MOS_ARCH_6502 (0x1)
 ; 6502-NEXT:      EF_MOS_ARCH_6502_BCD (0x2)

--- a/llvm/test/MC/MOS/eflags.s
+++ b/llvm/test/MC/MOS/eflags.s
@@ -13,7 +13,7 @@ _start:
   lda #42
   rts
 
-// CHECK:       Machine: EM_MOS (0x1966)
+// CHECK:       Machine: EM_MCS6502 (0xFE)
 //  6502:       Flags [ (0x3)
 //  6502-NEXT:     EF_MOS_ARCH_6502 (0x1)
 //  6502-NEXT:     EF_MOS_ARCH_6502_BCD (0x2)

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -1167,7 +1167,7 @@ static const EnumEntry<unsigned> ElfMachineType[] = {
   ENUM_ENT(EM_LANAI,         "EM_LANAI"),
   ENUM_ENT(EM_BPF,           "EM_BPF"),
   ENUM_ENT(EM_VE,            "NEC SX-Aurora Vector Engine"),
-  ENUM_ENT(EM_MOS,           "MOS Technologies")
+  ENUM_ENT(EM_MCS6502,       "MOS Technologies")
 };
 
 static const EnumEntry<unsigned> ElfSymbolBindings[] = {
@@ -1265,7 +1265,7 @@ getSectionFlagsForTarget(unsigned EMachine) {
     Ret.insert(Ret.end(), std::begin(ElfXCoreSectionFlags),
                std::end(ElfXCoreSectionFlags));
     break;
-  case EM_MOS:
+  case EM_MCS6502:
     Ret.insert(Ret.end(), std::begin(ElfMOSSectionFlags),
                std::end(ElfMOSSectionFlags));
     break;
@@ -3238,7 +3238,7 @@ template <class ELFT> void GNUELFDumper<ELFT>::printFileHeaders() {
                    unsigned(ELF::EF_MIPS_MACH));
   else if (e.e_machine == EM_RISCV)
     ElfFlags = printFlags(e.e_flags, makeArrayRef(ElfHeaderRISCVFlags));
-  else if (e.e_machine == EM_MOS)
+  else if (e.e_machine == EM_MCS6502)
     ElfFlags = printFlags(e.e_flags, MOS::ElfHeaderMOSFlags);
   Str = "0x" + to_hexString(e.e_flags);
   if (!ElfFlags.empty())
@@ -3559,7 +3559,7 @@ static void printSectionDescription(formatted_raw_ostream &OS,
     OS << ", l (large)";
   else if (EMachine == EM_ARM)
     OS << ", y (purecode)";
-  else if (EMachine == EM_MOS)
+  else if (EMachine == EM_MCS6502)
     OS << ", z (zeropage)";
 
   OS << ", p (processor specific)\n";
@@ -6223,7 +6223,7 @@ template <class ELFT> void LLVMELFDumper<ELFT>::printFileHeaders() {
       }
     } else if (E.e_machine == EM_RISCV)
       W.printFlags("Flags", E.e_flags, makeArrayRef(ElfHeaderRISCVFlags));
-    else if (E.e_machine == EM_MOS)
+    else if (E.e_machine == EM_MCS6502)
       W.printFlags("Flags", E.e_flags, MOS::ElfHeaderMOSFlags);
     else
       W.printFlags("Flags", E.e_flags);


### PR DESCRIPTION
Fixes #86.

Essentially a find/replace of EM_MOS with EM_MCS6502 and an edit of the number (6502 -> 254; 0x1966 -> 0xFE in tests). Regression tests are still in progress locally.