### PR TITLE
LDZ pseudo instruction for zero-stores to imaginaries as STZ.

### DIFF
--- a/llvm/lib/Target/MOS/MOSInstrInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSInstrInfo.cpp
@@ -703,6 +703,9 @@ bool MOSInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
   case MOS::LDImm1:
     expandLDImm1(Builder);
     break;
+  case MOS::LDZ:
+    expandLDZ(Builder);
+    break;
 
   // Soft stack
   case MOS::SetSPLo:
@@ -804,6 +807,20 @@ void MOSInstrInfo::expandLDImm1(MachineIRBuilder &Builder) const {
   }
 
   MI.setDesc(Builder.getTII().get(Opcode));
+}
+
+void MOSInstrInfo::expandLDZ(MachineIRBuilder &Builder) const {
+  auto &MI = *Builder.getInsertPt();
+  Register DestReg = MI.getOperand(0).getReg();
+
+  if (MOS::Imag8RegClass.contains(DestReg)) {
+    MI.setDesc(Builder.getTII().get(MOS::STZImag8));
+  } else if (MOS::GPRRegClass.contains(DestReg)) {
+    MI.setDesc(Builder.getTII().get(MOS::LDImm));
+    MI.addOperand(MachineOperand::CreateImm(0));
+  } else {
+    llvm_unreachable("Unexpected register class for LDZ.");
+  }
 }
 
 void MOSInstrInfo::expandIncDec(MachineIRBuilder &Builder) const {

--- a/llvm/lib/Target/MOS/MOSInstrInfo.h
+++ b/llvm/lib/Target/MOS/MOSInstrInfo.h
@@ -110,6 +110,7 @@ private:
   // Post RA pseudos
   void expandLDIdx(MachineIRBuilder &Builder) const;
   void expandLDImm1(MachineIRBuilder &Builder) const;
+  void expandLDZ(MachineIRBuilder &Builder) const;
   void expandIncDec(MachineIRBuilder &Builder) const;
 
   // Soft stack pseudos

--- a/llvm/lib/Target/MOS/MOSInstrLogical.td
+++ b/llvm/lib/Target/MOS/MOSInstrLogical.td
@@ -377,6 +377,10 @@ let Predicates = [Has65C02] in {
   def STZIdx : MOSStore, PseudoInstExpansion<(STZ_AbsoluteX addr16:$addr)> {
     dag InOperandList = (ins i16imm:$addr, Xc:$idx);
   }
+  // STZ zp
+  def STZImag8 : MOSStore, PseudoInstExpansion<(STZ_ZeroPage addr8:$addr)> {
+    dag OutOperandList = (outs Imag8:$addr);
+  }
 }
 
 //===---------------------------------------------------------------------===//

--- a/llvm/lib/Target/MOS/MOSInstrPseudos.td
+++ b/llvm/lib/Target/MOS/MOSInstrPseudos.td
@@ -58,6 +58,17 @@ def LDImm1 : MOSPseudo {
   let isReMaterializable = true;
 }
 
+// Expands to LDImm 0 for GPR or STZImag8 for Imag8.
+def LDZ : MOSPseudo {
+  let Predicates = [Has65C02];
+  dag OutOperandList = (outs GPRImag8:$dst);
+  let Pattern = [(set GPRImag8:$dst, 0)];
+
+  let isAsCheapAsAMove = true;
+  let isMoveImm = true;
+  let isReMaterializable = true;
+}
+
 def INC : MOSPseudo {
   dag OutOperandList = (outs GPRImag8:$dst);
   dag InOperandList = (ins GPRImag8:$src);

--- a/llvm/test/CodeGen/MOS/asm-printer.mir
+++ b/llvm/test/CodeGen/MOS/asm-printer.mir
@@ -213,6 +213,36 @@ body: |
     ; CHECK-NEXT: rts
 ...
 ---
+name: stz_absolute
+# CHECK-LABEL: stz_absolute
+body: |
+  bb.0.entry:
+    STZAbs 1234
+    ; CHECK: stz 1234
+    RTS
+    ; CHECK-NEXT: rts
+...
+---
+name: stz_absolutex
+# CHECK-LABEL: stz_absolutex
+body: |
+  bb.0.entry:
+    STZIdx 1234, $x
+    ; CHECK: stz 1234,x
+    RTS
+    ; CHECK-NEXT: rts
+...
+---
+name: stz_zeropage
+# CHECK-LABEL: stz_zeropage
+body: |
+  bb.0.entry:
+    $rc0 = STZImag8
+    ; CHECK: stz mos8(__rc0)
+    RTS
+    ; CHECK-NEXT: rts
+...
+---
 name: txa_implied
 # CHECK-LABEL: txa_implied
 body: |

--- a/llvm/test/CodeGen/MOS/char-stats.ll
+++ b/llvm/test/CodeGen/MOS/char-stats.ll
@@ -131,8 +131,7 @@ define void @char_stats() local_unnamed_addr #0 {
 ; CMOS-NEXT:    ; in Loop: Header=BB0_2 Depth=1
 ; CMOS-NEXT:    asl
 ; CMOS-NEXT:    sta mos8(__rc2)
-; CMOS-NEXT:    lda #0
-; CMOS-NEXT:    sta mos8(__rc3)
+; CMOS-NEXT:    stz mos8(__rc3)
 ; CMOS-NEXT:    rol mos8(__rc3)
 ; CMOS-NEXT:    clc
 ; CMOS-NEXT:    lda mos8(__rc0)

--- a/llvm/test/CodeGen/MOS/postrapseudos.mir
+++ b/llvm/test/CodeGen/MOS/postrapseudos.mir
@@ -248,3 +248,19 @@ body: |
     ; CHECK: $rc1 = STImag8 $a
     SetSPHi $a, implicit-def $rs0, implicit $rs0
 ...
+---
+name: ldzimag8
+body: |
+  bb.0.entry:
+    ; CHECK-LABEL: name: ldzimag8
+    ; CHECK: $rc0 = STZImag8
+    $rc0 = LDZ
+...
+---
+name: ldzgpr
+body: |
+  bb.0.entry:
+    ; CHECK-LABEL: name: ldzgpr
+    ; CHECK: $a = LDImm 0
+    $a = LDZ
+...


### PR DESCRIPTION
For 65C02 subtarget, zero constants are selected as LDZ. After register
allocation, this is expanded as LDImm 0 for GPRs or STZImag8 for Imag8s.
The application of STZ_ZeroPage is effectively applied to zero-loads on
imaginary registers.