### PR TITLE
Recover mos-insns-* features from e_flags.

### DIFF
--- a/llvm/include/llvm/Object/ELFObjectFile.h
+++ b/llvm/include/llvm/Object/ELFObjectFile.h
@@ -54,6 +54,7 @@ class ELFObjectFileBase : public ObjectFile {
   SubtargetFeatures getMIPSFeatures() const;
   SubtargetFeatures getARMFeatures() const;
   SubtargetFeatures getRISCVFeatures() const;
+  SubtargetFeatures getMOSFeatures() const;
 
   StringRef getAMDGPUCPUName() const;
 

--- a/llvm/lib/Target/MOS/MOSDevices.td
+++ b/llvm/lib/Target/MOS/MOSDevices.td
@@ -13,7 +13,7 @@ def Feature6502
                        "The original documented 6502 instruction set">;
 
 def Feature6502BCD
-    : SubtargetFeature<"mos-insns-6502-bcd", "Has6502BCDInsns", "true",
+    : SubtargetFeature<"mos-insns-6502bcd", "Has6502BCDInsns", "true",
                        "BCD instruction support, including SED and CLD (most "
                        "6502 series CPUs support this)">;
 


### PR DESCRIPTION
This enables tools like objdump to decode the correct instruction set.