### PR TITLE
Perform legalizer info verification, fix `G_BRJT` rule.

### DIFF
--- a/llvm/lib/Target/MOS/MOSCombiner.cpp
+++ b/llvm/lib/Target/MOS/MOSCombiner.cpp
@@ -18,6 +18,7 @@
 #include "MCTargetDesc/MOSMCTargetDesc.h"
 #include "MOS.h"
 #include "MOSLegalizerInfo.h"
+#include "MOSSubtarget.h"
 
 #include "llvm/CodeGen/GlobalISel/Combiner.h"
 #include "llvm/CodeGen/GlobalISel/CombinerHelper.h"
@@ -227,7 +228,7 @@ bool MOSCombinerHelperState::applyExtractLowBit(MachineInstr &MI,
     B.buildNot(MI.getOperand(0).getReg(), EvenShift.getReg(1));
   else
     B.buildCopy(MI.getOperand(0).getReg(), EvenShift.getReg(1));
-  MOSLegalizerInfo Legalizer;
+  MOSLegalizerInfo Legalizer(B.getMF().getSubtarget<MOSSubtarget>());
   LegalizerHelper LegalizerHelper(B.getMF(), Legalizer, Observer, B);
   B.setInsertPt(B.getMBB(), *EvenShift);
   if (!Legalizer.legalizeLshrEShlE(LegalizerHelper, MRI, *EvenShift))

--- a/llvm/lib/Target/MOS/MOSLegalizerInfo.h
+++ b/llvm/lib/Target/MOS/MOSLegalizerInfo.h
@@ -18,9 +18,11 @@
 
 namespace llvm {
 
+class MOSSubtarget;
+
 class MOSLegalizerInfo : public LegalizerInfo {
 public:
-  MOSLegalizerInfo();
+  MOSLegalizerInfo(const MOSSubtarget &STI);
 
   bool legalizeIntrinsic(LegalizerHelper &Helper,
                          MachineInstr &MI) const override;

--- a/llvm/lib/Target/MOS/MOSSubtarget.cpp
+++ b/llvm/lib/Target/MOS/MOSSubtarget.cpp
@@ -39,7 +39,7 @@ MOSSubtarget::MOSSubtarget(const Triple &TT, const std::string &CPU,
     : MOSGenSubtargetInfo(TT, CPU, /* TuneCPU */ CPU, FS), InstrInfo(),
       RegInfo(), FrameLowering(),
       TLInfo(TM, initializeSubtargetDependencies(CPU, FS, TM)),
-      CallLoweringInfo(&TLInfo),
+      CallLoweringInfo(&TLInfo), Legalizer(*this),
       InstSelector(createMOSInstructionSelector(TM, *this, RegBankInfo)),
       InlineAsmLoweringInfo(&TLInfo) {}
 


### PR DESCRIPTION
Call `LegacyLegalizerInfo::computeTables` and `LegalizerInfo::verify` as
part of the legalizer setup like other targets do. The only effect of
computing legacy tables is setting a flag indicating it has been called.
For opcodes without legalizer rules, this results in a more informative
assert:

```
LLVM ERROR: unable to legalize instruction: %178:_(s1) = G_FCMP floatpred(ule), %177:_(s64), %105:_ (in function: _ftoa)
```

as opposed to "backend forgot to call computeTables".

`G_BRJT` did not cover the scalar generic type with its rule, so a
compound predicate is used instead to ensure compatibility with the
emitted `G_TRUNC`.