### PR TITLE
Fix some compilation warnings

### DIFF
--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSInstPrinter.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSInstPrinter.cpp
@@ -37,8 +37,7 @@ void MOSInstPrinter::printInst(const MCInst *MI, uint64_t Address,
                                raw_ostream &OS) {
   std::string AiryOperands;
   raw_string_ostream AiryOperandStream(AiryOperands);
-  auto MnemonicInfo = getMnemonic(MI);
-  assert(MnemonicInfo.second && "Missing opcode for instruction.");
+  assert(getMnemonic(MI).second && "Missing opcode for instruction.");
   printInstruction(MI, Address, AiryOperandStream);
   AiryOperands = AiryOperandStream.str();
   size_t SpacesSeen = 0;

--- a/llvm/lib/Target/MOS/MOSInstrInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSInstrInfo.cpp
@@ -568,10 +568,9 @@ void MOSInstrInfo::copyPhysRegImpl(MachineIRBuilder &Builder, Register DestReg,
       SrcReg = SrcReg8;
       if (DestReg8) {
         DestReg = DestReg8;
-        const MachineInstr &MI = *Builder.getInsertPt();
         // MOS defines LSB writes to write the whole 8-bit register, not just
         // part of it.
-        assert(!MI.readsRegister(DestReg));
+        assert(!Builder.getInsertPt()->readsRegister(DestReg));
 
         copyPhysRegImpl(Builder, DestReg, SrcReg);
       } else {

--- a/llvm/lib/Target/MOS/MOSInstructionSelector.cpp
+++ b/llvm/lib/Target/MOS/MOSInstructionSelector.cpp
@@ -1542,16 +1542,13 @@ bool MOSInstructionSelector::selectLshrShlE(MachineInstr &MI) {
 bool MOSInstructionSelector::selectTrunc(MachineInstr &MI) {
   MachineIRBuilder Builder(MI);
 
-  LLT S16 = LLT::scalar(16);
   LLT S8 = LLT::scalar(8);
-  LLT S1 = LLT::scalar(1);
 
   Register From = MI.getOperand(1).getReg();
-  Register To = MI.getOperand(0).getReg();
 
-  LLT FromType = Builder.getMRI()->getType(From);
-  LLT ToType = Builder.getMRI()->getType(To);
-  assert(FromType == S16 && ToType == S1);
+  assert(Builder.getMRI()->getType(From) == LLT::scalar(16));
+  assert(Builder.getMRI()->getType(MI.getOperand(0).getReg()) ==
+         LLT::scalar(1));
 
   MachineInstrSpan MIS(MI, MI.getParent());
   MI.getOperand(1).setReg(Builder.buildTrunc(S8, From).getReg(0));

--- a/llvm/lib/Target/MOS/MOSLegalizerInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSLegalizerInfo.cpp
@@ -468,9 +468,8 @@ bool MOSLegalizerInfo::legalizeZExt(LegalizerHelper &Helper,
   Register Src = MI.getOperand(1).getReg();
 
   LLT DstTy = MRI.getType(Dst);
-  LLT SrcTy = MRI.getType(Src);
 
-  assert(SrcTy == LLT::scalar(1));
+  assert(MRI.getType(Src) == LLT::scalar(1));
   auto One = Builder.buildConstant(DstTy, 1);
   auto Zero = Builder.buildConstant(DstTy, 0);
   Builder.buildSelect(Dst, Src, One, Zero);
@@ -485,9 +484,8 @@ bool MOSLegalizerInfo::legalizeZExt(LegalizerHelper &Helper,
 bool MOSLegalizerInfo::legalizeBSwap(LegalizerHelper &Helper,
                                      MachineRegisterInfo &MRI,
                                      MachineInstr &MI) const {
-  LLT S8 = LLT::scalar(8);
-  assert(MRI.getType(MI.getOperand(0).getReg()) == S8);
-  assert(MRI.getType(MI.getOperand(1).getReg()) == S8);
+  assert(MRI.getType(MI.getOperand(0).getReg()) == LLT::scalar(8));
+  assert(MRI.getType(MI.getOperand(1).getReg()) == LLT::scalar(8));
   Helper.Observer.changingInstr(MI);
   MI.setDesc(Helper.MIRBuilder.getTII().get(COPY));
   Helper.Observer.changedInstr(MI);
@@ -505,8 +503,7 @@ bool MOSLegalizerInfo::legalizeAddSub(LegalizerHelper &Helper,
   LLT S8 = LLT::scalar(8);
 
   Register Dst = MI.getOperand(0).getReg();
-  LLT DstTy = MRI.getType(Dst);
-  assert(DstTy.isByteSized());
+  assert(MRI.getType(Dst).isByteSized());
   Register Src = MI.getOperand(1).getReg();
 
   auto RHSConst =
@@ -1190,11 +1187,15 @@ bool MOSLegalizerInfo::legalizeSelect(LegalizerHelper &Helper,
                                       MachineInstr &MI) const {
   MachineIRBuilder &Builder = Helper.MIRBuilder;
 
+#ifndef NDEBUG
   LLT P = LLT::pointer(0, 16);
+#endif
   LLT S16 = LLT::scalar(16);
 
   Register Dst = MI.getOperand(0).getReg();
+#ifndef NDEBUG
   Register Test = MI.getOperand(1).getReg();
+#endif
   Register LHS = MI.getOperand(2).getReg();
   Register RHS = MI.getOperand(3).getReg();
 
@@ -1623,8 +1624,10 @@ bool MOSLegalizerInfo::legalizeBrJt(LegalizerHelper &Helper,
   LLT S8 = LLT::scalar(8);
   MachineIRBuilder &Builder = Helper.MIRBuilder;
 
+#ifndef NDEBUG
   const MachineInstr *Base =
       getOpcodeDef(G_JUMP_TABLE, MI.getOperand(0).getReg(), MRI);
+#endif
   assert(Base && "Invalid first argument to G_BRJT; expected G_JUMP_TABLE.");
 
   assert(MI.getOperand(1).isJTI());

--- a/llvm/lib/Target/MOS/MOSLowerSelect.cpp
+++ b/llvm/lib/Target/MOS/MOSLowerSelect.cpp
@@ -369,8 +369,7 @@ void MOSLowerSelect::moveAwayFromCalls(MachineFunction &MF) {
       for (; J->getOpcode() != MOS::ADJCALLSTACKDOWN; --J) {
         if (J->getOpcode() == MOS::G_SELECT || DefinesUsedReg(*J)) {
           // Conservatively assume there was a store.
-          bool SawStore = true;
-          assert(J->isSafeToMove(nullptr, SawStore));
+          assert(J->isSafeToMove(nullptr, /*SawStore=*/true));
           TrackUsedRegs(*J);
           auto NewJ = std::next(J);
           PushedMIs.push_back(J->removeFromParent());

--- a/llvm/lib/Target/MOS/MOSZeroPageAlloc.cpp
+++ b/llvm/lib/Target/MOS/MOSZeroPageAlloc.cpp
@@ -130,10 +130,12 @@ private:
 Freq operator*(uint64_t Scalar, const Freq &F) { return Freq(Scalar) * F; }
 } // namespace
 
+#ifndef NDEBUG
 static raw_ostream &operator<<(raw_ostream &OS, const Freq &Freq) {
   OS << Freq.Num << '/' << Freq.Denom;
   return OS;
 }
+#endif
 
 namespace {
 
@@ -164,6 +166,7 @@ struct EntryCandidate {
 
 } // namespace
 
+#ifndef NDEBUG
 raw_ostream &operator<<(raw_ostream &OS, const Candidate &C) {
   OS << C.MF->getName() << ", ";
   if (C.CSR)
@@ -182,6 +185,7 @@ raw_ostream &operator<<(raw_ostream &OS, const EntryCandidate &EC) {
   OS << *EC.Cand << ", Global benefit " << EC.Benefit;
   return OS;
 }
+#endif
 
 namespace {
 

--- a/llvm/utils/TableGen/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/CodeGenRegisters.cpp
@@ -1993,7 +1993,7 @@ void CodeGenRegBank::computeRegUnitSets() {
       RegUnitSets.back().Name =
         RegUnitSets[Idx].Name + "_with_" + RegUnitSets[SearchIdx].Name;
       RegUnitSets.back().IsFineGrained =
-        RegUnitSets[Idx].IsFineGrained | RegUnitSets[SearchIdx].IsFineGrained;
+        RegUnitSets[Idx].IsFineGrained || RegUnitSets[SearchIdx].IsFineGrained;
 
       std::set_union(RegUnitSets[Idx].Units.begin(),
                      RegUnitSets[Idx].Units.end(),


### PR DESCRIPTION
A `clang-14` build following the instructions of `README.md` emitted a number of warnings, which this pull request would fix.