### PR TITLE
Fix "void main" violating the C and C++ standards.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ LLVM-MOS is a LLVM fork supporting the MOS 65xx series of microprocessors.
 ```C
 #include <stdio.h>
 
-void main(void) {
+int main(void) {
   printf("HELLO, 6502!\n");
 }
 ```


### PR DESCRIPTION
Common error. :) `clang` issues a warning. `clang++` issues an error.

BTW. Maybe the resulting disassembly should be updated as well? For instance, aren't `jsr`+`rts` coalesced into `jmp` now? Don't know how to recreate: `-O2 -S -fno-lto` emits `jmp puts` and `mos-c64-clang -O2 -Wall hi.c` unrolls.