### PR TITLE
Support emitting CLA/CLX/CLY on HuC6280.

### DIFF
--- a/llvm/lib/Target/MOS/MOSInstrInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSInstrInfo.cpp
@@ -1031,12 +1031,17 @@ void MOSInstrInfo::expandLDImm16Remat(MachineIRBuilder &Builder) const {
 void MOSInstrInfo::expandLDZ(MachineIRBuilder &Builder) const {
   auto &MI = *Builder.getInsertPt();
   Register DestReg = MI.getOperand(0).getReg();
+  const MOSSubtarget &STI = Builder.getMF().getSubtarget<MOSSubtarget>();
 
   if (MOS::Imag8RegClass.contains(DestReg)) {
     MI.setDesc(Builder.getTII().get(MOS::STZImag8));
   } else if (MOS::GPRRegClass.contains(DestReg)) {
-    MI.setDesc(Builder.getTII().get(MOS::LDImm));
-    MI.addOperand(MachineOperand::CreateImm(0));
+    if (STI.hasHUC6280()) {
+      MI.setDesc(Builder.getTII().get(MOS::CL));
+    } else {
+      MI.setDesc(Builder.getTII().get(MOS::LDImm));
+      MI.addOperand(MachineOperand::CreateImm(0));
+    }
   } else {
     llvm_unreachable("Unexpected register class for LDZ.");
   }

--- a/llvm/lib/Target/MOS/MOSInstrLogical.td
+++ b/llvm/lib/Target/MOS/MOSInstrLogical.td
@@ -322,6 +322,13 @@ def LDCImm : MOSImmediateLoad<Cc, i1imm>;
 // LDA imm, LDX imm, LDY imm
 def LDImm : MOSImmediateLoad<GPR, imm8>;
 
+// CLA, CLX, CLY
+let Predicates = [HasHUC6280] in {
+  def CL : MOSImmediateLoad<GPR, imm8> {
+    dag InOperandList = (ins);
+  }
+}
+
 //===---------------------------------------------------------------------===//
 // Comparison Instructions
 //===---------------------------------------------------------------------===//

--- a/llvm/lib/Target/MOS/MOSLateOptimization.cpp
+++ b/llvm/lib/Target/MOS/MOSLateOptimization.cpp
@@ -59,6 +59,8 @@ bool MOSLateOptimization::runOnMachineFunction(MachineFunction &MF) {
 }
 
 static bool definesNZ(const MachineInstr &MI, Register Val) {
+  if (MI.getOpcode() == MOS::CL)
+    return false;
   if (MI.getOpcode() == MOS::STImag8)
     return false;
   if (MI.definesRegister(Val))
@@ -101,6 +103,7 @@ bool MOSLateOptimization::lowerCMPTermZs(MachineBasicBlock &MBB) const {
         ClobbersNZ = false;
       else
         switch (J.getOpcode()) {
+        case MOS::CL:
         case MOS::CLV:
         case MOS::LDCImm:
         case MOS::STImag8:

--- a/llvm/lib/Target/MOS/MOSMCInstLower.cpp
+++ b/llvm/lib/Target/MOS/MOSMCInstLower.cpp
@@ -561,6 +561,21 @@ void MOSMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI) {
       OutMI.setOpcode(MOS::TYA_Implied);
       return;
     }
+  case MOS::CL: {
+    switch (MI->getOperand(0).getReg()) {
+    default:
+      llvm_unreachable("Unexpected register.");
+    case MOS::A:
+      OutMI.setOpcode(MOS::CLA_Implied);
+      return;
+    case MOS::X:
+      OutMI.setOpcode(MOS::CLX_Implied);
+      return;
+    case MOS::Y:
+      OutMI.setOpcode(MOS::CLY_Implied);
+      return;
+    }
+  }
   }
 
   // Handle any real instructions that weren't generated from a pseudo.


### PR DESCRIPTION
This is the first HuC6280-specific optimization I am proposing for llvm-mos, and it's by far the simplest one to implement.

The HuC6280 is an extended Rockwell-standard 65C02 which provides [some additional opcodes](http://shu.emuunlim.com/download/pcedocs/pce_cpu.html). Among them is `CLA`, `CLX`, and `CLY`: they act like `LDA #$00`, `LDX #$00` and `LDY #$00` respectively, taking the same amount of clock cycles, but with two differences:

1. They take up only one byte instead of two (but the same number of clock cycles, that is 2 clock cycles),
2. They do not modify the NZ flags.

As llvm-mos already includes a pseudo-instruction to "load zero into a register", it was possible to extend it to recognize this scenario.