### PR TITLE
Fix ELF relocation and relaxation for multi-operand 65C02/HuC6280 opcodes.

### DIFF
--- a/lld/ELF/Arch/MOS.cpp
+++ b/lld/ELF/Arch/MOS.cpp
@@ -96,6 +96,7 @@ void MOS::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
   case R_MOS_ADDR24_BANK:
     *loc = static_cast<unsigned char>(val >> 16);
     break;
+  case R_MOS_IMM16:
   case R_MOS_ADDR16:
   case R_MOS_ADDR24_SEGMENT:
     write16le(loc, static_cast<unsigned short>(val));

--- a/lld/test/ELF/mos-relocs-huc6280.s
+++ b/lld/test/ELF/mos-relocs-huc6280.s
@@ -1,7 +1,7 @@
 # REQUIRES: mos
 # RUN: llvm-mc -filetype=obj -triple=mos --mcpu=moshuc6280 %s -o %t.o
 # RUN: llvm-objdump -r %t.o | FileCheck %s --check-prefix=RELOCS
-# RUN: ld.lld %t.o --defsym=sym1=0x1234 --defsym=sym2=0x5678 --defsym=sym3=0x9abc -o %t
+# RUN: ld.lld %t.o --defsym=sym1=0x1234 --defsym=sym2=0x5678 --defsym=sym3=0x9abc --defsym=sym4=0x5a -o %t
 # RUN: llvm-objdump -d --no-show-raw-insn --print-imm-hex %t | FileCheck %s
 
 .section .multiarg_huc_block_move,"ax",@progbits
@@ -13,3 +13,12 @@
 # RELOCS-NEXT: 00000005 R_MOS_IMM16              sym3
 # CHECK-LABEL: section .multiarg_huc_block_move:
 # CHECK: tii $1234,$5678,#$9abc
+
+.section .multiarg_huc_tst,"ax",@progbits
+  tst #sym4, sym1
+# RELOCS-LABEL: RELOCATION RECORDS FOR [.multiarg_huc_tst]:
+# RELOCS-NEXT: OFFSET   TYPE                     VALUE
+# RELOCS-NEXT: 00000001 R_MOS_IMM8               sym4
+# RELOCS-NEXT: 00000002 R_MOS_ADDR16             sym1
+# CHECK-LABEL: section .multiarg_huc_tst:
+# CHECK: tst #$5a,$1234

--- a/lld/test/ELF/mos-relocs-huc6280.s
+++ b/lld/test/ELF/mos-relocs-huc6280.s
@@ -1,0 +1,15 @@
+# REQUIRES: mos
+# RUN: llvm-mc -filetype=obj -triple=mos --mcpu=moshuc6280 %s -o %t.o
+# RUN: llvm-objdump -r %t.o | FileCheck %s --check-prefix=RELOCS
+# RUN: ld.lld %t.o --defsym=sym1=0x1234 --defsym=sym2=0x5678 --defsym=sym3=0x9abc -o %t
+# RUN: llvm-objdump -d --no-show-raw-insn --print-imm-hex %t | FileCheck %s
+
+.section .multiarg_huc_block_move,"ax",@progbits
+  tii sym1, sym2, #sym3
+# RELOCS-LABEL: RELOCATION RECORDS FOR [.multiarg_huc_block_move]:
+# RELOCS-NEXT: OFFSET   TYPE                     VALUE
+# RELOCS-NEXT: 00000001 R_MOS_ADDR16             sym1
+# RELOCS-NEXT: 00000003 R_MOS_ADDR16             sym2
+# RELOCS-NEXT: 00000005 R_MOS_IMM16              sym3
+# CHECK-LABEL: section .multiarg_huc_block_move:
+# CHECK: tii $1234,$5678,#$9abc

--- a/llvm/include/llvm/BinaryFormat/ELFRelocs/MOS.def
+++ b/llvm/include/llvm/BinaryFormat/ELFRelocs/MOS.def
@@ -62,3 +62,6 @@ ELF_RELOC(R_MOS_FK_DATA_8,             14)
 
 // Decimal ASCII address encoding.
 ELF_RELOC(R_MOS_ADDR_ASCIZ,            15)
+
+// A 16-bit immediate value.
+ELF_RELOC(R_MOS_IMM16,                 16)

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSAsmBackend.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSAsmBackend.cpp
@@ -312,8 +312,8 @@ static bool visitRelaxableOperand(const MCInst &Inst,
   bool BankRelax = false;
   unsigned RelaxTo = MOSAsmBackend::relaxInstructionTo(Inst, STI, BankRelax);
 
-  return RelaxTo && Inst.getNumOperands() == 1 &&
-         Visit(Inst.getOperand(0), RelaxTo, BankRelax);
+  return RelaxTo && Inst.getNumOperands() <= 2 &&
+         Visit(Inst.getOperand(Inst.getNumOperands() - 1), RelaxTo, BankRelax);
 }
 
 static bool isImmediateBankRelaxable(const MCSubtargetInfo &STI,

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSELFObjectWriter.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSELFObjectWriter.cpp
@@ -96,6 +96,8 @@ unsigned MOSELFObjectWriter::getRelocType(MCContext &Ctx, const MCValue &Target,
     return ELF::R_MOS_FK_DATA_8;
   case MOS::AddrAsciz:
     return ELF::R_MOS_ADDR_ASCIZ;
+  case MOS::Imm16:
+    return ELF::R_MOS_IMM16;
 
   default:
     llvm_unreachable("invalid fixup kind!");

--- a/llvm/lib/Target/MOS/MOSInstrFormats.td
+++ b/llvm/lib/Target/MOS/MOSInstrFormats.td
@@ -130,67 +130,80 @@ class Addr16Operand<string name> : MOSAsmOperand<name>;
 class Addr24Operand<string name> : MOSAsmOperand<name>;
 
 /// This operand will only match a value from 0 to 255 inclusive.
-def imm8 : Operand<i32> {
+class imm8at<int offset> : Operand<i32> {
   let ParserMatchClass = ImmediateAsmOperand<"Imm8">;
-  let EncoderMethod = "encodeImm<MOS::Imm8, 1>";
+  let EncoderMethod = "encodeImm<MOS::Imm8, " # offset # ">";
   let OperandType = "OPERAND_IMM8";
   let OperandNamespace = "MOSOp";
   let Type = i8;
 }
+def imm8 : imm8at<1>;
+def imm8at2 : imm8at<2>;
 
 /// This operand will only match a value from 0 to 65535 inclusive.
 /// Only 16-bit variants and virtual instructions should need this.
-def imm16 : Operand<i32> {
+class imm16at<int offset> : Operand<i32> {
   let ParserMatchClass = ImmediateAsmOperand<"Imm16">;
-  let EncoderMethod = "encodeImm<MOS::Imm16, 1>";
+  let EncoderMethod = "encodeImm<MOS::Imm16, " # offset # ">";
 }
+def imm16 : imm16at<1>;
+def imm16at5 : imm16at<5>;
 
 /// An 8-bit pc-relative reference, for branch instructions.
-def pcrel8 : Operand<i32> {
+class pcrel8at<int offset> : Operand<i32> {
   let ParserMatchClass = PCRelativeOperand<"PCRel8">;
-  let EncoderMethod = "encodeImm<MOS::PCRel8, 1>";
+  let EncoderMethod = "encodeImm<MOS::PCRel8, " # offset # ">";
   let PrintMethod = "printBranchOperand";
   let OperandType = "OPERAND_PCREL";
 }
+def pcrel8 : pcrel8at<1>;
+def pcrel8at2 : pcrel8at<2>;
 
 /// An 16-bit pc-relative reference, for 65816 BRL instruction.
-def pcrel16 : Operand<i32> {
+class pcrel16at<int offset> : Operand<i32> {
   let ParserMatchClass = PCRelativeOperand<"PCRel16">;
-  let EncoderMethod = "encodeImm<MOS::PCRel16, 1>";
+  let EncoderMethod = "encodeImm<MOS::PCRel16, " # offset # ">";
 }
+def pcrel16 : pcrel16at<1>;
 
-def addr8 : Operand<i32> {
+class addr8at<int offset> : Operand<i32> {
   let ParserMatchClass = Addr8Operand<"Addr8">;
-  let EncoderMethod = "encodeImm<MOS::Addr8, 1>";
+  let EncoderMethod = "encodeImm<MOS::Addr8, " # offset # ">";
   let OperandType = "OPERAND_ADDR8";
   let OperandNamespace = "MOSOp";
   let Type = i8;
 }
+def addr8 : addr8at<1>;
 
-def addr16 : Operand<i32> {
+class addr16at<int offset> : Operand<i32> {
   let ParserMatchClass = Addr16Operand<"Addr16">;
-  let EncoderMethod = "encodeImm<MOS::Addr16, 1>";
+  let EncoderMethod = "encodeImm<MOS::Addr16, " # offset # ">";
   let OperandType = "OPERAND_ADDR16";
   let OperandNamespace = "MOSOp";
   let Type = i16;
 }
+def addr16 : addr16at<1>;
+def addr16at3 : addr16at<3>;
 
-def addr24 : Operand<i32> {
+class addr24at<int offset> : Operand<i32> {
   let ParserMatchClass = Addr24Operand<"Addr24">;
-  let EncoderMethod = "encodeImm<MOS::Addr24, 1>";
+  let EncoderMethod = "encodeImm<MOS::Addr24, " # offset # ">";
 }
+def addr24 : addr24at<1>;
 
 /// This operand will only match a value from 256 to 65535 inclusive.
-def imm8to16 : Operand<i32> {
+class imm8To16at<int offset> : Operand<i32> {
   let ParserMatchClass = ImmediateAsmOperand<"Imm8To16">;
-  let EncoderMethod = "encodeImm<MOS::Addr16, 1>";
+  let EncoderMethod = "encodeImm<MOS::Addr16, " # offset # ">";
 }
+def imm8To16 : imm8To16at<1>;
 
 /// This operand will only match a value from 65536 to 16777215 inclusive.
-def imm16To24 : Operand<i32> {
+class imm16To24at<int offset> : Operand<i32> {
   let ParserMatchClass = ImmediateAsmOperand<"Imm16To24">;
-  let EncoderMethod = "encodeImm<MOS::Addr24, 1>";
+  let EncoderMethod = "encodeImm<MOS::Addr24, " # offset # ">";
 }
+def imm16To24 : imm16To24at<1>;
 
 /// All non-virtual MOS opcodes are 8 bits long.
 class Opcode<bits<8> opcode = 0> {
@@ -470,7 +483,7 @@ class InstBranchBit<string opcodestr, Opcode op = DefaultOpcode> :
   bits<8> location;
 
   Opcode opcode = op;
-  let InOperandList = (ins addr8:$source, pcrel8:$location);
+  let InOperandList = (ins addr8:$source, pcrel8at2:$location);
   string OperandsStr;
   let OperandsStr = "$source , $location";
 
@@ -490,7 +503,7 @@ class InstHuCBlockMove<string opcodestr, Opcode op = DefaultOpcode> :
   bits<16> blength;
 
   Opcode opcode = op;
-  let InOperandList = (ins addr16:$bsource, addr16:$bdest, imm16:$blength);
+  let InOperandList = (ins addr16:$bsource, addr16at3:$bdest, imm16at5:$blength);
   string OperandsStr;
   let OperandsStr = "$bsource , $bdest , #$blength";
 
@@ -510,7 +523,7 @@ class Inst816MemoryMove<string opcodestr, Opcode op = DefaultOpcode> :
   bits<8> destinationBank;
 
   Opcode opcode = op;
-  let InOperandList = (ins imm8:$sourceBank, imm8:$destinationBank);
+  let InOperandList = (ins imm8:$sourceBank, imm8at2:$destinationBank);
   string OperandsStr;
   let OperandsStr = "#$sourceBank , #$destinationBank";
 

--- a/llvm/lib/Target/MOS/MOSInstrFormats.td
+++ b/llvm/lib/Target/MOS/MOSInstrFormats.td
@@ -141,7 +141,6 @@ def imm8 : imm8at<1>;
 def imm8at2 : imm8at<2>;
 
 /// This operand will only match a value from 0 to 65535 inclusive.
-/// Only 16-bit variants and virtual instructions should need this.
 class imm16at<int offset> : Operand<i32> {
   let ParserMatchClass = ImmediateAsmOperand<"Imm16">;
   let EncoderMethod = "encodeImm<MOS::Imm16, " # offset # ">";
@@ -174,6 +173,7 @@ class addr8at<int offset> : Operand<i32> {
   let Type = i8;
 }
 def addr8 : addr8at<1>;
+def addr8at2 : addr8at<2>;
 
 class addr16at<int offset> : Operand<i32> {
   let ParserMatchClass = Addr16Operand<"Addr16">;
@@ -183,6 +183,7 @@ class addr16at<int offset> : Operand<i32> {
   let Type = i16;
 }
 def addr16 : addr16at<1>;
+def addr16at2 : addr16at<2>;
 def addr16at3 : addr16at<3>;
 
 class addr24at<int offset> : Operand<i32> {
@@ -373,6 +374,26 @@ def RStackRelative : AddressingMode {
 def IndirectRStackRelativeY : AddressingMode {
   let OperandsStr = "( $param , rp ) , y";
   let InOperandList = (ins addr8:$param);
+}
+
+def ZeroPageAt2 : AddressingMode {
+  let OperandsStr = "$param";
+  let InOperandList = (ins addr8at2:$param);
+}
+
+def ZeroPageXAt2 : AddressingMode {
+  let OperandsStr = "$param , x";
+  let InOperandList = (ins addr8at2:$param);
+}
+
+def AbsoluteAt2 : AddressingMode {
+  let OperandsStr = "$param";
+  let InOperandList = (ins addr16at2:$param);
+}
+
+def AbsoluteXAt2 : AddressingMode {
+  let OperandsStr = "$param , x";
+  let InOperandList = (ins addr16at2:$param);
 }
 
 /// An unsized MOS instruction, to which an addressing mode may be applied.

--- a/llvm/lib/Target/MOS/MOSInstrInfo.td
+++ b/llvm/lib/Target/MOS/MOSInstrInfo.td
@@ -521,10 +521,10 @@ def TIA_HuCBlockMove : InstHuCBlockMove<"tia", Opcode<0xE3>>; /// Transfer Incre
 def TAI_HuCBlockMove : InstHuCBlockMove<"tai", Opcode<0xF3>>; /// Transfer Alternate Increment
 
 /// Test
-def TST_ZeroPage : InstImmediate24<"tst", Opcode<0x83>, ZeroPage>; // Test Immediate with Zero Page
-def TST_Absolute : InstImmediate32<"tst", Opcode<0x93>, Absolute>; // Test Immediate with Absolute
-def TST_ZeroPageX : InstImmediate24<"tst", Opcode<0xA3>, ZeroPageX>; // Test Immediate with Zero Page, X
-def TST_AbsoluteX : InstImmediate32<"tst", Opcode<0xB3>, AbsoluteX>; // Test Immediate with Absolute, X
+def TST_ZeroPage : InstImmediate24<"tst", Opcode<0x83>, ZeroPageAt2>; // Test Immediate with Zero Page
+def TST_Absolute : InstImmediate32<"tst", Opcode<0x93>, AbsoluteAt2>; // Test Immediate with Absolute
+def TST_ZeroPageX : InstImmediate24<"tst", Opcode<0xA3>, ZeroPageXAt2>; // Test Immediate with Zero Page, X
+def TST_AbsoluteX : InstImmediate32<"tst", Opcode<0xB3>, AbsoluteXAt2>; // Test Immediate with Absolute, X
 
 /// Relative Branch
 def BSR_Relative : Inst16<"bsr", Opcode<0x44>, Relative>;


### PR DESCRIPTION
* Introduce R_MOS_IMM16 ELF relocation - see below;
* Fix emitting operand relocations for multi-operand instructions;
* Fix relaxation of HuC6280's TST instruction - the code assumed only one-operand instructions need relaxation, which was no longer true after adding this instruction;
* Introduce tests for the two fixes above.

I'd like to raise attention to the added R_MOS_IMM16 ELF relocation, as it requires a change to the ELF specification. My intended usecase here is using the HuC6280 block copy instruction for copying data in crt0, as in:

```asm
    ; Copy __data_size bytes from __data_start to __data_load_start.
    tii __data_start, __data_load_start, #__data_size
```

This requires a symbol relocation in the form of a 16-bit immediate value.