### PR TITLE
Add bounds support to lld custom output formats.

### DIFF
--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -243,8 +243,10 @@ struct ByteCommand : SectionCommand {
 
 // Include a LMA memory region in a custom output format.
 struct MemoryRegionCommand : SectionCommand {
-  MemoryRegionCommand(MemoryRegion *memRegion, bool full)
-      : SectionCommand(MemoryRegionKind), memRegion(memRegion), full(full) {}
+  MemoryRegionCommand(MemoryRegion *memRegion, bool full,
+    Expr start = nullptr, Expr length = nullptr)
+      : SectionCommand(MemoryRegionKind), memRegion(memRegion), full(full),
+        start(start), length(length) {}
 
   static bool classof(const SectionCommand *c) {
     return c->kind == MemoryRegionKind;
@@ -255,6 +257,10 @@ struct MemoryRegionCommand : SectionCommand {
   // Whether the entire memory region or only the portion up to the last byte
   // covered by an output LMA should be inserted.
   bool full;
+
+  // The start position and length of the region to be inserted.
+  Expr start;
+  Expr length;
 };
 
 struct InsertCommand {

--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -1285,15 +1285,23 @@ MemoryRegionCommand *ScriptParser::readMemoryRegionCommand(StringRef tok) {
   if (isFull == -1)
     return nullptr;
 
+  Expr regionStart = nullptr;
+  Expr regionLength = nullptr;
   expect("(");
   StringRef name = next();
+  if (consume(",")) {
+    regionStart = readExpr();
+    if (consume(",")) {
+      regionLength = readExpr();
+    }
+  }
   expect(")");
   auto iter = script->memoryRegions.find(name);
   if (iter == script->memoryRegions.end()) {
     setError("memory region '" + name + "' is not defined");
     return nullptr;
   }
-  return make<MemoryRegionCommand>(iter->second, isFull);
+  return make<MemoryRegionCommand>(iter->second, isFull, regionStart, regionLength);
 }
 
 static std::optional<uint64_t> parseFlag(StringRef tok) {

--- a/lld/test/ELF/custom-output-format.s
+++ b/lld/test/ELF/custom-output-format.s
@@ -33,6 +33,22 @@
 # TRUNCATE-CHECK:      000000 11 22 ff
 # TRUNCATE-CHECK-NEXT: 000003
 
+# RUN: echo "MEMORY {lma : ORIGIN = 0x1000 , LENGTH = 8 vma : ORIGIN = 0x2000, LENGTH = 8} SECTIONS { .mysec : AT (0x1001) { *(.mysec.*) } >vma } OUTPUT_FORMAT {BYTE(0x11) FULL(lma, 1, 5) BYTE(0xff)}" > %t.script
+# RUN: ld.lld -o %t2.out --script %t.script %t
+# RUN: od -t x1 -v %t2.out | FileCheck --check-prefix=FULL-PART-CHECK %s
+# RUN: ls %t2.out.elf | count 1
+
+# FULL-PART-CHECK:      000000 11 11 22 33 00 00 ff
+# FULL-PART-CHECK-NEXT: 000007
+
+# RUN: echo "MEMORY {lma : ORIGIN = 0x1000 , LENGTH = 8 vma : ORIGIN = 0x2000, LENGTH = 8} SECTIONS { .mysec : AT (0x1001) { *(.mysec.*) } >vma } OUTPUT_FORMAT {BYTE(0x11) TRIM(lma, 1, 4) BYTE(0xff)}" > %t.script
+# RUN: ld.lld -o %t2.out --script %t.script %t
+# RUN: od -t x1 -v %t2.out | FileCheck --check-prefix=TRIM-PART-CHECK %s
+# RUN: ls %t2.out.elf | count 1
+
+# TRIM-PART-CHECK:      000000 11 11 22 33 ff
+# TRIM-PART-CHECK-NEXT: 000005
+
 .section        .mysec.1,"ax"
 .byte   0x11
 


### PR DESCRIPTION
This adds two new arguments: "start" and "length" to TRIM and FULL.

For example, "FULL(sec, 0, 4)" will only output 4 bytes, starting from position 0, of the section "sec". If "sec" is smaller than 4 bytes, it will only output as many bytes as the size of "sec".

As discussed on the llvm-mos Discord, with some thoughts after having used it.