### PR TITLE
Take into account slower LDImag8/STImag8 on HuC6280.

### DIFF
--- a/llvm/lib/Target/MOS/MOSRegisterInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSRegisterInfo.cpp
@@ -840,10 +840,14 @@ int MOSRegisterInfo::copyCost(Register DestReg, Register SrcReg,
   }
   if (AreClasses(MOS::Imag8RegClass, MOS::GPRRegClass)) {
     // STImag8
+    if (STI.hasHUC6280())
+      return 6;
     return 5;
   }
   if (AreClasses(MOS::GPRRegClass, MOS::Imag8RegClass)) {
     // LDImag8
+    if (STI.hasHUC6280())
+      return 6;
     return 5;
   }
   if (AreClasses(MOS::Imag8RegClass, MOS::Imag8RegClass)) {


### PR DESCRIPTION
On HuC6280 (possibly due to the indirection introduced by the banking system), unindexed memory reads (Zero Page, Absolute) take the same number of cycles as X/Y-indexed memory reads; that is, one more cycle than they would on a regular 6502.