### PR TITLE
Add support for 65C02 indirect-without-indexing addressing mode.

### DIFF
--- a/llvm/lib/Target/MOS/MOSInstrGISel.td
+++ b/llvm/lib/Target/MOS/MOSInstrGISel.td
@@ -71,6 +71,7 @@ def G_LOAD_ABS_IDX : MOSGenericInstruction {
 // Generalized 8-bit load using the indirect addressing mode. Additionally
 // expects a MachineMemOperand.
 def G_LOAD_INDIR : MOSGenericInstruction {
+  let Predicates = [Has65C02];
   let OutOperandList = (outs type0:$dst);
   let InOperandList = (ins ptype1:$base);
   let mayLoad = true;
@@ -106,6 +107,7 @@ def G_STORE_ABS_IDX : MOSGenericInstruction {
 // Generalized 8-bit store using the indirect addressing mode. Additionally
 // expects a MachineMemOperand.
 def G_STORE_INDIR : MOSGenericInstruction {
+  let Predicates = [Has65C02];
   let OutOperandList = (outs);
   let InOperandList = (ins type0:$src, ptype1:$base);
   let mayStore = true;

--- a/llvm/lib/Target/MOS/MOSInstrGISel.td
+++ b/llvm/lib/Target/MOS/MOSInstrGISel.td
@@ -68,6 +68,14 @@ def G_LOAD_ABS_IDX : MOSGenericInstruction {
   let mayLoad = true;
 }
 
+// Generalized 8-bit load using the indirect addressing mode. Additionally
+// expects a MachineMemOperand.
+def G_LOAD_INDIR : MOSGenericInstruction {
+  let OutOperandList = (outs type0:$dst);
+  let InOperandList = (ins ptype1:$base);
+  let mayLoad = true;
+}
+
 // Generalized 8-bit load using the indirect indexed addressing mode. The index
 // argument is an 8-bit scalar. Additionally expects a MachineMemOperand.
 def G_LOAD_INDIR_IDX : MOSGenericInstruction {
@@ -92,6 +100,14 @@ def G_STORE_ABS : MOSGenericInstruction {
 def G_STORE_ABS_IDX : MOSGenericInstruction {
   let OutOperandList = (outs);
   let InOperandList = (ins type0:$src, unknown:$base, type1:$index);
+  let mayStore = true;
+}
+
+// Generalized 8-bit store using the indirect addressing mode. Additionally
+// expects a MachineMemOperand.
+def G_STORE_INDIR : MOSGenericInstruction {
+  let OutOperandList = (outs);
+  let InOperandList = (ins type0:$src, ptype1:$base);
   let mayStore = true;
 }
 

--- a/llvm/lib/Target/MOS/MOSInstrInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSInstrInfo.cpp
@@ -919,6 +919,7 @@ bool MOSInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
   case MOS::CMPTermImag8:
   case MOS::CMPTermAbs:
   case MOS::CMPTermIndir:
+  case MOS::CMPTermIndirIdx:
   case MOS::CMPTermIdx:
     expandCMPTerm(Builder);
     break;
@@ -1171,6 +1172,9 @@ void MOSInstrInfo::expandCMPTerm(MachineIRBuilder &Builder) const {
     MI.setDesc(Builder.getTII().get(MOS::CMPAbsIdx));
     break;
   case MOS::CMPTermIndir:
+    MI.setDesc(Builder.getTII().get(MOS::CMPIndir));
+    break;
+  case MOS::CMPTermIndirIdx:
     MI.setDesc(Builder.getTII().get(MOS::CMPIndirIdx));
     break;
   }

--- a/llvm/lib/Target/MOS/MOSInstrLogical.td
+++ b/llvm/lib/Target/MOS/MOSInstrLogical.td
@@ -98,6 +98,7 @@ let isAdd = true in {
     }
     def ADCIndir :
         MOSAddSub, PseudoInstExpansion<(ADC_Indirect addr8:$addr)> {
+      let Predicates = [Has65C02];
       dag InOperandList = (ins Ac:$l, Imag16:$addr, Cc:$carryin);
     }
     def ADCIndirIdx :
@@ -117,6 +118,7 @@ let mayLoad = true in {
   }
   def SBCIndir :
       MOSAddSub, PseudoInstExpansion<(SBC_Indirect addr8:$addr)> {
+    let Predicates = [Has65C02];
     dag InOperandList = (ins Ac:$l, Imag16:$addr, Cc:$carryin);
   }
   def SBCIndirIdx :
@@ -367,6 +369,7 @@ let mayLoad = true in {
   def CMPAbs : MOSCMP { dag InOperandList = (ins GPR:$l, addr16:$addr); }
   def CMPAbsIdx : MOSCMP { dag InOperandList = (ins Ac:$l, addr16:$addr, XY:$idx); }
   def CMPIndir : MOSCMP, PseudoInstExpansion<(CMP_Indirect addr8:$addr)> {
+    let Predicates = [Has65C02];
     dag InOperandList = (ins Ac:$l, Imag16:$addr);
   }
   def CMPIndirIdx : MOSCMP, PseudoInstExpansion<(CMP_IndirectIndexed addr8:$addr)> {
@@ -515,6 +518,7 @@ def LDYAbsIdx : MOSLoadIndexed<Yc, Xc>;
 
 // LDA (zp)
 def LDIndir : MOSLoad, PseudoInstExpansion<(LDA_Indirect addr8:$addr)> {
+  let Predicates = [Has65C02];
   dag OutOperandList = (outs Ac:$dst);
   dag InOperandList = (ins Imag16:$addr);
 }
@@ -539,6 +543,7 @@ def STAbsIdx : MOSStore {
 
 // STA (zp)
 def STIndir : MOSStore, PseudoInstExpansion<(STA_Indirect addr8:$addr)> {
+  let Predicates = [Has65C02];
   dag InOperandList = (ins Ac:$src, Imag16:$addr);
 }
 

--- a/llvm/lib/Target/MOS/MOSInstrLogical.td
+++ b/llvm/lib/Target/MOS/MOSInstrLogical.td
@@ -96,6 +96,10 @@ let isAdd = true in {
     def ADCAbsIdx : MOSAddSub {
       dag InOperandList = (ins Ac:$l, addr16:$addr, XY:$idx, Cc:$carryin);
     }
+    def ADCIndir :
+        MOSAddSub, PseudoInstExpansion<(ADC_Indirect addr8:$addr)> {
+      dag InOperandList = (ins Ac:$l, Imag16:$addr, Cc:$carryin);
+    }
     def ADCIndirIdx :
         MOSAddSub, PseudoInstExpansion<(ADC_IndirectIndexed addr8:$addr)> {
       dag InOperandList = (ins Ac:$l, Imag16:$addr, Yc:$idx, Cc:$carryin);
@@ -110,6 +114,10 @@ let mayLoad = true in {
       MOSAddSubOp<addr16>, PseudoInstExpansion<(SBC_ZeroPage addr8:$r)>;
   def SBCAbsIdx : MOSAddSub {
     dag InOperandList = (ins Ac:$l, addr16:$addr, XY:$idx, Cc:$carryin);
+  }
+  def SBCIndir :
+      MOSAddSub, PseudoInstExpansion<(SBC_Indirect addr8:$addr)> {
+    dag InOperandList = (ins Ac:$l, Imag16:$addr, Cc:$carryin);
   }
   def SBCIndirIdx :
       MOSAddSub, PseudoInstExpansion<(SBC_IndirectIndexed addr8:$addr)> {
@@ -155,6 +163,13 @@ multiclass MOSBitwiseInstr<SDNode node> {
 
     def AbsIdx : MOSBitwiseBase {
       let InOperandList = (ins Ac:$l, addr16:$addr, XY:$idx);
+    }
+
+    def Indir :
+       MOSBitwiseBase,
+       PseudoInstExpansion<
+           (!cast<Instruction>(NAME#"_Indirect") addr8:$addr)> {
+      let InOperandList = (ins Ac:$l, Imag16:$addr);
     }
 
     def IndirIdx :
@@ -351,6 +366,9 @@ def CMPImag8 : MOSCMP { dag InOperandList = (ins GPR:$l, Imag8:$r); }
 let mayLoad = true in {
   def CMPAbs : MOSCMP { dag InOperandList = (ins GPR:$l, addr16:$addr); }
   def CMPAbsIdx : MOSCMP { dag InOperandList = (ins Ac:$l, addr16:$addr, XY:$idx); }
+  def CMPIndir : MOSCMP, PseudoInstExpansion<(CMP_Indirect addr8:$addr)> {
+    dag InOperandList = (ins Ac:$l, Imag16:$addr);
+  }
   def CMPIndirIdx : MOSCMP, PseudoInstExpansion<(CMP_IndirectIndexed addr8:$addr)> {
     dag InOperandList = (ins Ac:$l, Imag16:$addr, Yc:$idx);
   }
@@ -495,6 +513,12 @@ def LDXAbsIdx : MOSLoadIndexed<Xc, Yc>;
 // LDY abs,x
 def LDYAbsIdx : MOSLoadIndexed<Yc, Xc>;
 
+// LDA (zp)
+def LDIndir : MOSLoad, PseudoInstExpansion<(LDA_Indirect addr8:$addr)> {
+  dag OutOperandList = (outs Ac:$dst);
+  dag InOperandList = (ins Imag16:$addr);
+}
+
 // LDA (zp),y
 def LDIndirIdx : MOSLoad, PseudoInstExpansion<(LDA_IndirectIndexed addr8:$addr)> {
   dag OutOperandList = (outs Ac:$dst);
@@ -512,6 +536,12 @@ def STAbs : MOSStore {
 def STAbsIdx : MOSStore {
   dag InOperandList = (ins Ac:$src, addr16:$addr, XY:$idx);
 }
+
+// STA (zp)
+def STIndir : MOSStore, PseudoInstExpansion<(STA_Indirect addr8:$addr)> {
+  dag InOperandList = (ins Ac:$src, Imag16:$addr);
+}
+
 // STA (zp),y
 def STIndirIdx : MOSStore, PseudoInstExpansion<(STA_IndirectIndexed addr8:$addr)> {
   dag InOperandList = (ins Ac:$src, Imag16:$addr, Yc:$offset);

--- a/llvm/lib/Target/MOS/MOSInstrPseudos.td
+++ b/llvm/lib/Target/MOS/MOSInstrPseudos.td
@@ -265,6 +265,7 @@ let mayLoad = true in {
     dag InOperandList = (ins Ac:$l, i16imm:$addr, XY:$idx);
   }
   def CMPTermIndir : MOSCMPTerm {
+    let Predicates = [Has65C02];
     dag InOperandList = (ins Ac:$l, Imag16:$addr);
   }
   def CMPTermIndirIdx : MOSCMPTerm {

--- a/llvm/lib/Target/MOS/MOSInstrPseudos.td
+++ b/llvm/lib/Target/MOS/MOSInstrPseudos.td
@@ -265,6 +265,9 @@ let mayLoad = true in {
     dag InOperandList = (ins Ac:$l, i16imm:$addr, XY:$idx);
   }
   def CMPTermIndir : MOSCMPTerm {
+    dag InOperandList = (ins Ac:$l, Imag16:$addr);
+  }
+  def CMPTermIndirIdx : MOSCMPTerm {
     dag InOperandList = (ins Ac:$l, Imag16:$addr, Yc:$idx);
   }
 }

--- a/llvm/lib/Target/MOS/MOSLegalizerInfo.h
+++ b/llvm/lib/Target/MOS/MOSLegalizerInfo.h
@@ -85,14 +85,14 @@ private:
   bool tryAbsoluteIndexedAddressing(LegalizerHelper &Helper,
                                     MachineRegisterInfo &MRI,
                                     MachineInstr &MI) const;
-  bool selectIndirectIndexedAddressing(LegalizerHelper &Helper,
-                                       MachineRegisterInfo &MRI,
-                                       MachineInstr &MI) const;
+  bool selectIndirectAddressing(LegalizerHelper &Helper,
+                                MachineRegisterInfo &MRI,
+                                MachineInstr &MI) const;
   bool legalizeMemOp(LegalizerHelper &Helper, MachineRegisterInfo &MRI,
                      MachineInstr &MI) const;
   bool tryHuCBlockCopy(LegalizerHelper &Helper, MachineRegisterInfo &MRI,
                        MachineInstr &MI) const;
-                       
+
   // Control Flow
   bool legalizeBrCond(LegalizerHelper &Helper, MachineRegisterInfo &MRI,
                       MachineInstr &MI) const;

--- a/llvm/test/CodeGen/MOS/char-stats-norecurse.ll
+++ b/llvm/test/CodeGen/MOS/char-stats-norecurse.ll
@@ -103,7 +103,6 @@ define void @char_stats() local_unnamed_addr #0 {
 ; CMOS-NEXT:    asl
 ; CMOS-NEXT:    sta __rc2
 ; CMOS-NEXT:    lda #0
-; CMOS-NEXT:    tay
 ; CMOS-NEXT:    rol
 ; CMOS-NEXT:    sta __rc3
 ; CMOS-NEXT:    lda #mos16lo(.Lchar_stats_sstk)
@@ -113,9 +112,9 @@ define void @char_stats() local_unnamed_addr #0 {
 ; CMOS-NEXT:    lda #mos16hi(.Lchar_stats_sstk)
 ; CMOS-NEXT:    adc __rc3
 ; CMOS-NEXT:    sta __rc3
-; CMOS-NEXT:    lda (__rc2),y
+; CMOS-NEXT:    lda (__rc2)
 ; CMOS-NEXT:    sta __rc4
-; CMOS-NEXT:    iny
+; CMOS-NEXT:    ldy #1
 ; CMOS-NEXT:    lda (__rc2),y
 ; CMOS-NEXT:    tax
 ; CMOS-NEXT:    lda __rc4
@@ -126,10 +125,8 @@ define void @char_stats() local_unnamed_addr #0 {
 ; CMOS-NEXT:    inx
 ; CMOS-NEXT:  .LBB0_4: ; %while.body
 ; CMOS-NEXT:    ; in Loop: Header=BB0_1 Depth=1
-; CMOS-NEXT:    ldy #0
-; CMOS-NEXT:    sta (__rc2),y
+; CMOS-NEXT:    sta (__rc2)
 ; CMOS-NEXT:    txa
-; CMOS-NEXT:    iny
 ; CMOS-NEXT:    sta (__rc2),y
 ; CMOS-NEXT:    bra .LBB0_1
 ; CMOS-NEXT:  .LBB0_5: ; %while.end

--- a/llvm/test/CodeGen/MOS/char-stats.ll
+++ b/llvm/test/CodeGen/MOS/char-stats.ll
@@ -115,10 +115,8 @@ define void @char_stats() local_unnamed_addr #0 {
 ; CMOS-NEXT:    bra .LBB0_2
 ; CMOS-NEXT:  .LBB0_1: ; %while.body
 ; CMOS-NEXT:    ; in Loop: Header=BB0_2 Depth=1
-; CMOS-NEXT:    ldy #0
-; CMOS-NEXT:    sta (__rc2),y
+; CMOS-NEXT:    sta (__rc2)
 ; CMOS-NEXT:    txa
-; CMOS-NEXT:    iny
 ; CMOS-NEXT:    sta (__rc2),y
 ; CMOS-NEXT:  .LBB0_2: ; %while.body
 ; CMOS-NEXT:    ; =>This Inner Loop Header: Depth=1
@@ -130,7 +128,6 @@ define void @char_stats() local_unnamed_addr #0 {
 ; CMOS-NEXT:    asl
 ; CMOS-NEXT:    sta __rc2
 ; CMOS-NEXT:    stz __rc3
-; CMOS-NEXT:    ldy #0
 ; CMOS-NEXT:    rol __rc3
 ; CMOS-NEXT:    clc
 ; CMOS-NEXT:    lda __rc0
@@ -141,9 +138,9 @@ define void @char_stats() local_unnamed_addr #0 {
 ; CMOS-NEXT:    txa
 ; CMOS-NEXT:    adc __rc3
 ; CMOS-NEXT:    sta __rc3
-; CMOS-NEXT:    lda (__rc2),y
+; CMOS-NEXT:    lda (__rc2)
 ; CMOS-NEXT:    sta __rc4
-; CMOS-NEXT:    iny
+; CMOS-NEXT:    ldy #1
 ; CMOS-NEXT:    lda (__rc2),y
 ; CMOS-NEXT:    tax
 ; CMOS-NEXT:    lda __rc4

--- a/llvm/test/CodeGen/MOS/instruction-selector.mir
+++ b/llvm/test/CodeGen/MOS/instruction-selector.mir
@@ -222,10 +222,34 @@ body: |
     ; 6502: [[COPY:%[0-9]+]]:imag16 = COPY $rs1
     ; 6502-NEXT: [[COPY1:%[0-9]+]]:ac = COPY $x
     ; 6502-NEXT: [[LDCImm:%[0-9]+]]:cc = LDCImm 0
+    ; 6502-NEXT: [[ADCIndir:%[0-9]+]]:ac, [[ADCIndir1:%[0-9]+]]:cc, [[ADCIndir2:%[0-9]+]]:vc = ADCIndir [[COPY1]], [[COPY]], [[LDCImm]] :: (load (s8))
+    ; 6502-NEXT: RTS implicit [[ADCIndir]]
+    ; 65C02-LABEL: name: add_y_indir
+    ; 65C02: [[COPY:%[0-9]+]]:imag16 = COPY $rs1
+    ; 65C02-NEXT: [[COPY1:%[0-9]+]]:ac = COPY $x
+    ; 65C02-NEXT: [[LDCImm:%[0-9]+]]:cc = LDCImm 0
+    ; 65C02-NEXT: [[ADCIndir:%[0-9]+]]:ac, [[ADCIndir1:%[0-9]+]]:cc, [[ADCIndir2:%[0-9]+]]:vc = ADCIndir [[COPY1]], [[COPY]], [[LDCImm]] :: (load (s8))
+    ; 65C02-NEXT: RTS implicit [[ADCIndir]]
+    %0:any(s16) = COPY $rs1
+    %1:any(s8) = COPY $x
+    %2:any(s8) = G_LOAD_INDIR %0 :: (load (s8))
+    %3:any(s8) = G_ADD %1, %2
+    RTS implicit %3
+...
+---
+name: add_y_indir_idx
+legalized: true
+regBankSelected: true
+body: |
+  bb.0.entry:
+    ; 6502-LABEL: name: add_y_indir_idx
+    ; 6502: [[COPY:%[0-9]+]]:imag16 = COPY $rs1
+    ; 6502-NEXT: [[COPY1:%[0-9]+]]:ac = COPY $x
+    ; 6502-NEXT: [[LDCImm:%[0-9]+]]:cc = LDCImm 0
     ; 6502-NEXT: [[COPY2:%[0-9]+]]:yc = COPY [[COPY1]]
     ; 6502-NEXT: [[ADCIndirIdx:%[0-9]+]]:ac, [[ADCIndirIdx1:%[0-9]+]]:cc, [[ADCIndirIdx2:%[0-9]+]]:vc = ADCIndirIdx [[COPY1]], [[COPY]], [[COPY2]], [[LDCImm]] :: (load (s8))
     ; 6502-NEXT: RTS implicit [[ADCIndirIdx]]
-    ; 65C02-LABEL: name: add_y_indir
+    ; 65C02-LABEL: name: add_y_indir_idx
     ; 65C02: [[COPY:%[0-9]+]]:imag16 = COPY $rs1
     ; 65C02-NEXT: [[COPY1:%[0-9]+]]:ac = COPY $x
     ; 65C02-NEXT: [[LDCImm:%[0-9]+]]:cc = LDCImm 0
@@ -287,10 +311,32 @@ body: |
     ; 6502-LABEL: name: and_y_indir
     ; 6502: [[COPY:%[0-9]+]]:imag16 = COPY $rs1
     ; 6502-NEXT: [[COPY1:%[0-9]+]]:ac = COPY $x
+    ; 6502-NEXT: [[ANDIndir:%[0-9]+]]:ac = ANDIndir [[COPY1]], [[COPY]] :: (load (s8))
+    ; 6502-NEXT: RTS implicit [[ANDIndir]]
+    ; 65C02-LABEL: name: and_y_indir
+    ; 65C02: [[COPY:%[0-9]+]]:imag16 = COPY $rs1
+    ; 65C02-NEXT: [[COPY1:%[0-9]+]]:ac = COPY $x
+    ; 65C02-NEXT: [[ANDIndir:%[0-9]+]]:ac = ANDIndir [[COPY1]], [[COPY]] :: (load (s8))
+    ; 65C02-NEXT: RTS implicit [[ANDIndir]]
+    %0:any(s16) = COPY $rs1
+    %1:any(s8) = COPY $x
+    %2:any(s8) = G_LOAD_INDIR %0 :: (load (s8))
+    %3:any(s8) = G_AND %1, %2
+    RTS implicit %3
+...
+---
+name: and_y_indir_idx
+legalized: true
+regBankSelected: true
+body: |
+  bb.0.entry:
+    ; 6502-LABEL: name: and_y_indir_idx
+    ; 6502: [[COPY:%[0-9]+]]:imag16 = COPY $rs1
+    ; 6502-NEXT: [[COPY1:%[0-9]+]]:ac = COPY $x
     ; 6502-NEXT: [[COPY2:%[0-9]+]]:yc = COPY [[COPY1]]
     ; 6502-NEXT: [[ANDIndirIdx:%[0-9]+]]:ac = ANDIndirIdx [[COPY1]], [[COPY]], [[COPY2]] :: (load (s8))
     ; 6502-NEXT: RTS implicit [[ANDIndirIdx]]
-    ; 65C02-LABEL: name: and_y_indir
+    ; 65C02-LABEL: name: and_y_indir_idx
     ; 65C02: [[COPY:%[0-9]+]]:imag16 = COPY $rs1
     ; 65C02-NEXT: [[COPY1:%[0-9]+]]:ac = COPY $x
     ; 65C02-NEXT: [[COPY2:%[0-9]+]]:yc = COPY [[COPY1]]
@@ -351,10 +397,32 @@ body: |
     ; 6502-LABEL: name: eor_y_indir
     ; 6502: [[COPY:%[0-9]+]]:imag16 = COPY $rs1
     ; 6502-NEXT: [[COPY1:%[0-9]+]]:ac = COPY $x
+    ; 6502-NEXT: [[EORIndir:%[0-9]+]]:ac = EORIndir [[COPY1]], [[COPY]] :: (load (s8))
+    ; 6502-NEXT: RTS implicit [[EORIndir]]
+    ; 65C02-LABEL: name: eor_y_indir
+    ; 65C02: [[COPY:%[0-9]+]]:imag16 = COPY $rs1
+    ; 65C02-NEXT: [[COPY1:%[0-9]+]]:ac = COPY $x
+    ; 65C02-NEXT: [[EORIndir:%[0-9]+]]:ac = EORIndir [[COPY1]], [[COPY]] :: (load (s8))
+    ; 65C02-NEXT: RTS implicit [[EORIndir]]
+    %0:any(s16) = COPY $rs1
+    %1:any(s8) = COPY $x
+    %2:any(s8) = G_LOAD_INDIR %0 :: (load (s8))
+    %3:any(s8) = G_XOR %1, %2
+    RTS implicit %3
+...
+---
+name: eor_y_indir_idx
+legalized: true
+regBankSelected: true
+body: |
+  bb.0.entry:
+    ; 6502-LABEL: name: eor_y_indir_idx
+    ; 6502: [[COPY:%[0-9]+]]:imag16 = COPY $rs1
+    ; 6502-NEXT: [[COPY1:%[0-9]+]]:ac = COPY $x
     ; 6502-NEXT: [[COPY2:%[0-9]+]]:yc = COPY [[COPY1]]
     ; 6502-NEXT: [[EORIndirIdx:%[0-9]+]]:ac = EORIndirIdx [[COPY1]], [[COPY]], [[COPY2]] :: (load (s8))
     ; 6502-NEXT: RTS implicit [[EORIndirIdx]]
-    ; 65C02-LABEL: name: eor_y_indir
+    ; 65C02-LABEL: name: eor_y_indir_idx
     ; 65C02: [[COPY:%[0-9]+]]:imag16 = COPY $rs1
     ; 65C02-NEXT: [[COPY1:%[0-9]+]]:ac = COPY $x
     ; 65C02-NEXT: [[COPY2:%[0-9]+]]:yc = COPY [[COPY1]]
@@ -415,10 +483,32 @@ body: |
     ; 6502-LABEL: name: ora_y_indir
     ; 6502: [[COPY:%[0-9]+]]:imag16 = COPY $rs1
     ; 6502-NEXT: [[COPY1:%[0-9]+]]:ac = COPY $x
+    ; 6502-NEXT: [[ORAIndir:%[0-9]+]]:ac = ORAIndir [[COPY1]], [[COPY]] :: (load (s8))
+    ; 6502-NEXT: RTS implicit [[ORAIndir]]
+    ; 65C02-LABEL: name: ora_y_indir
+    ; 65C02: [[COPY:%[0-9]+]]:imag16 = COPY $rs1
+    ; 65C02-NEXT: [[COPY1:%[0-9]+]]:ac = COPY $x
+    ; 65C02-NEXT: [[ORAIndir:%[0-9]+]]:ac = ORAIndir [[COPY1]], [[COPY]] :: (load (s8))
+    ; 65C02-NEXT: RTS implicit [[ORAIndir]]
+    %0:any(s16) = COPY $rs1
+    %1:any(s8) = COPY $x
+    %2:any(s8) = G_LOAD_INDIR %0 :: (load (s8))
+    %3:any(s8) = G_OR %1, %2
+    RTS implicit %3
+...
+---
+name: ora_y_indir_idx
+legalized: true
+regBankSelected: true
+body: |
+  bb.0.entry:
+    ; 6502-LABEL: name: ora_y_indir_idx
+    ; 6502: [[COPY:%[0-9]+]]:imag16 = COPY $rs1
+    ; 6502-NEXT: [[COPY1:%[0-9]+]]:ac = COPY $x
     ; 6502-NEXT: [[COPY2:%[0-9]+]]:yc = COPY [[COPY1]]
     ; 6502-NEXT: [[ORAIndirIdx:%[0-9]+]]:ac = ORAIndirIdx [[COPY1]], [[COPY]], [[COPY2]] :: (load (s8))
     ; 6502-NEXT: RTS implicit [[ORAIndirIdx]]
-    ; 65C02-LABEL: name: ora_y_indir
+    ; 65C02-LABEL: name: ora_y_indir_idx
     ; 65C02: [[COPY:%[0-9]+]]:imag16 = COPY $rs1
     ; 65C02-NEXT: [[COPY1:%[0-9]+]]:ac = COPY $x
     ; 65C02-NEXT: [[COPY2:%[0-9]+]]:yc = COPY [[COPY1]]
@@ -884,6 +974,30 @@ body: |
     %0:any(s8) = COPY $x
     %1:any(s8) = COPY $a
     %2:any(s8) = G_LOAD_ABS_IDX i16 1234, %1 :: (load (s8))
+    %3:any(s8) = G_SUB %0, %2
+    RTS implicit %3
+...
+---
+name: sub_indir
+legalized: true
+regBankSelected: true
+body: |
+  bb.0.entry:
+    ; 6502-LABEL: name: sub_indir
+    ; 6502: [[COPY:%[0-9]+]]:ac = COPY $x
+    ; 6502-NEXT: [[COPY1:%[0-9]+]]:imag16 = COPY $rs1
+    ; 6502-NEXT: [[LDCImm:%[0-9]+]]:cc = LDCImm -1
+    ; 6502-NEXT: [[SBCIndir:%[0-9]+]]:ac, [[SBCIndir1:%[0-9]+]]:cc, [[SBCIndir2:%[0-9]+]]:vc = SBCIndir [[COPY]], [[COPY1]], [[LDCImm]] :: (load (s8))
+    ; 6502-NEXT: RTS implicit [[SBCIndir]]
+    ; 65C02-LABEL: name: sub_indir
+    ; 65C02: [[COPY:%[0-9]+]]:ac = COPY $x
+    ; 65C02-NEXT: [[COPY1:%[0-9]+]]:imag16 = COPY $rs1
+    ; 65C02-NEXT: [[LDCImm:%[0-9]+]]:cc = LDCImm -1
+    ; 65C02-NEXT: [[SBCIndir:%[0-9]+]]:ac, [[SBCIndir1:%[0-9]+]]:cc, [[SBCIndir2:%[0-9]+]]:vc = SBCIndir [[COPY]], [[COPY1]], [[LDCImm]] :: (load (s8))
+    ; 65C02-NEXT: RTS implicit [[SBCIndir]]
+    %0:any(s8) = COPY $x
+    %1:any(s16) = COPY $rs1
+    %2:any(s8) = G_LOAD_INDIR %1 :: (load (s8))
     %3:any(s8) = G_SUB %0, %2
     RTS implicit %3
 ...
@@ -1443,6 +1557,96 @@ body: |
     RTS
 ...
 ---
+name: cmpindir_brc
+legalized: true
+regBankSelected: true
+body: |
+  bb.0.entry:
+    ; 6502-LABEL: name: cmpindir_brc
+    ; 6502: successors: %bb.0(0x80000000)
+    ; 6502-NEXT: {{  $}}
+    ; 6502-NEXT: [[COPY:%[0-9]+]]:ac = COPY $a
+    ; 6502-NEXT: [[COPY1:%[0-9]+]]:imag16 = COPY $rs1
+    ; 6502-NEXT: [[CMPIndir:%[0-9]+]]:cc = CMPIndir [[COPY]], [[COPY1]] :: (load (s8))
+    ; 6502-NEXT: GBR %bb.0, [[CMPIndir]], 1, implicit-def $c
+    ; 6502-NEXT: RTS
+    ; 65C02-LABEL: name: cmpindir_brc
+    ; 65C02: successors: %bb.0(0x80000000)
+    ; 65C02-NEXT: {{  $}}
+    ; 65C02-NEXT: [[COPY:%[0-9]+]]:ac = COPY $a
+    ; 65C02-NEXT: [[COPY1:%[0-9]+]]:imag16 = COPY $rs1
+    ; 65C02-NEXT: [[CMPIndir:%[0-9]+]]:cc = CMPIndir [[COPY]], [[COPY1]] :: (load (s8))
+    ; 65C02-NEXT: GBR %bb.0, [[CMPIndir]], 1, implicit-def $c
+    ; 65C02-NEXT: RTS
+    %0:any(s8) = COPY $a
+    %1:any(s16) = COPY $rs1
+    %2:any(s8) = G_LOAD_INDIR %1 :: (load (s8))
+    %3:any(s1) = G_CONSTANT i1 -1
+    %4:any(s8), %5:any(s1), %6:any(s1), %7:any(s1), %8:any(s1) = G_SBC %0, %2, %3
+    G_BRCOND_IMM %5, %bb.0, 1
+    RTS
+...
+---
+name: cmpindir_brn
+legalized: true
+regBankSelected: true
+body: |
+  bb.0.entry:
+    ; 6502-LABEL: name: cmpindir_brn
+    ; 6502: successors: %bb.0(0x80000000)
+    ; 6502-NEXT: {{  $}}
+    ; 6502-NEXT: [[COPY:%[0-9]+]]:ac = COPY $a
+    ; 6502-NEXT: [[COPY1:%[0-9]+]]:imag16 = COPY $rs1
+    ; 6502-NEXT: [[CMPTermIndir:%[0-9]+]]:cc = CMPTermIndir [[COPY]], [[COPY1]], implicit-def $nz :: (load (s8))
+    ; 6502-NEXT: BR %bb.0, $n, 1
+    ; 6502-NEXT: RTS
+    ; 65C02-LABEL: name: cmpindir_brn
+    ; 65C02: successors: %bb.0(0x80000000)
+    ; 65C02-NEXT: {{  $}}
+    ; 65C02-NEXT: [[COPY:%[0-9]+]]:ac = COPY $a
+    ; 65C02-NEXT: [[COPY1:%[0-9]+]]:imag16 = COPY $rs1
+    ; 65C02-NEXT: [[CMPTermIndir:%[0-9]+]]:cc = CMPTermIndir [[COPY]], [[COPY1]], implicit-def $nz :: (load (s8))
+    ; 65C02-NEXT: BR %bb.0, $n, 1
+    ; 65C02-NEXT: RTS
+    %0:any(s8) = COPY $a
+    %1:any(s16) = COPY $rs1
+    %2:any(s8) = G_LOAD_INDIR %1 :: (load (s8))
+    %3:any(s1) = G_CONSTANT i1 -1
+    %4:any(s8), %5:any(s1), %6:any(s1), %7:any(s1), %8:any(s1) = G_SBC %0, %2, %3
+    G_BRCOND_IMM %6, %bb.0, 1
+    RTS
+...
+---
+name: cmpindir_brz
+legalized: true
+regBankSelected: true
+body: |
+  bb.0.entry:
+    ; 6502-LABEL: name: cmpindir_brz
+    ; 6502: successors: %bb.0(0x80000000)
+    ; 6502-NEXT: {{  $}}
+    ; 6502-NEXT: [[COPY:%[0-9]+]]:ac = COPY $a
+    ; 6502-NEXT: [[COPY1:%[0-9]+]]:imag16 = COPY $rs1
+    ; 6502-NEXT: [[CMPTermIndir:%[0-9]+]]:cc = CMPTermIndir [[COPY]], [[COPY1]], implicit-def $nz :: (load (s8))
+    ; 6502-NEXT: BR %bb.0, $z, 1
+    ; 6502-NEXT: RTS
+    ; 65C02-LABEL: name: cmpindir_brz
+    ; 65C02: successors: %bb.0(0x80000000)
+    ; 65C02-NEXT: {{  $}}
+    ; 65C02-NEXT: [[COPY:%[0-9]+]]:ac = COPY $a
+    ; 65C02-NEXT: [[COPY1:%[0-9]+]]:imag16 = COPY $rs1
+    ; 65C02-NEXT: [[CMPTermIndir:%[0-9]+]]:cc = CMPTermIndir [[COPY]], [[COPY1]], implicit-def $nz :: (load (s8))
+    ; 65C02-NEXT: BR %bb.0, $z, 1
+    ; 65C02-NEXT: RTS
+    %0:any(s8) = COPY $a
+    %1:any(s16) = COPY $rs1
+    %2:any(s8) = G_LOAD_INDIR %1 :: (load (s8))
+    %3:any(s1) = G_CONSTANT i1 -1
+    %4:any(s8), %5:any(s1), %6:any(s1), %7:any(s1), %8:any(s1) = G_SBC %0, %2, %3
+    G_BRCOND_IMM %8, %bb.0, 1
+    RTS
+...
+---
 name: cmpindiridx_brc
 legalized: true
 regBankSelected: true
@@ -1487,7 +1691,7 @@ body: |
     ; 6502-NEXT: [[COPY:%[0-9]+]]:ac = COPY $a
     ; 6502-NEXT: [[COPY1:%[0-9]+]]:imag16 = COPY $rs1
     ; 6502-NEXT: [[COPY2:%[0-9]+]]:yc = COPY $y
-    ; 6502-NEXT: [[CMPTermIndir:%[0-9]+]]:cc = CMPTermIndir [[COPY]], [[COPY1]], [[COPY2]], implicit-def $nz :: (load (s8))
+    ; 6502-NEXT: [[CMPTermIndirIdx:%[0-9]+]]:cc = CMPTermIndirIdx [[COPY]], [[COPY1]], [[COPY2]], implicit-def $nz :: (load (s8))
     ; 6502-NEXT: BR %bb.0, $n, 1
     ; 6502-NEXT: RTS
     ; 65C02-LABEL: name: cmpindiridx_brn
@@ -1496,7 +1700,7 @@ body: |
     ; 65C02-NEXT: [[COPY:%[0-9]+]]:ac = COPY $a
     ; 65C02-NEXT: [[COPY1:%[0-9]+]]:imag16 = COPY $rs1
     ; 65C02-NEXT: [[COPY2:%[0-9]+]]:yc = COPY $y
-    ; 65C02-NEXT: [[CMPTermIndir:%[0-9]+]]:cc = CMPTermIndir [[COPY]], [[COPY1]], [[COPY2]], implicit-def $nz :: (load (s8))
+    ; 65C02-NEXT: [[CMPTermIndirIdx:%[0-9]+]]:cc = CMPTermIndirIdx [[COPY]], [[COPY1]], [[COPY2]], implicit-def $nz :: (load (s8))
     ; 65C02-NEXT: BR %bb.0, $n, 1
     ; 65C02-NEXT: RTS
     %0:any(s8) = COPY $a
@@ -1520,7 +1724,7 @@ body: |
     ; 6502-NEXT: [[COPY:%[0-9]+]]:ac = COPY $a
     ; 6502-NEXT: [[COPY1:%[0-9]+]]:imag16 = COPY $rs1
     ; 6502-NEXT: [[COPY2:%[0-9]+]]:yc = COPY $y
-    ; 6502-NEXT: [[CMPTermIndir:%[0-9]+]]:cc = CMPTermIndir [[COPY]], [[COPY1]], [[COPY2]], implicit-def $nz :: (load (s8))
+    ; 6502-NEXT: [[CMPTermIndirIdx:%[0-9]+]]:cc = CMPTermIndirIdx [[COPY]], [[COPY1]], [[COPY2]], implicit-def $nz :: (load (s8))
     ; 6502-NEXT: BR %bb.0, $z, 1
     ; 6502-NEXT: RTS
     ; 65C02-LABEL: name: cmpindiridx_brz
@@ -1529,7 +1733,7 @@ body: |
     ; 65C02-NEXT: [[COPY:%[0-9]+]]:ac = COPY $a
     ; 65C02-NEXT: [[COPY1:%[0-9]+]]:imag16 = COPY $rs1
     ; 65C02-NEXT: [[COPY2:%[0-9]+]]:yc = COPY $y
-    ; 65C02-NEXT: [[CMPTermIndir:%[0-9]+]]:cc = CMPTermIndir [[COPY]], [[COPY1]], [[COPY2]], implicit-def $nz :: (load (s8))
+    ; 65C02-NEXT: [[CMPTermIndirIdx:%[0-9]+]]:cc = CMPTermIndirIdx [[COPY]], [[COPY1]], [[COPY2]], implicit-def $nz :: (load (s8))
     ; 65C02-NEXT: BR %bb.0, $z, 1
     ; 65C02-NEXT: RTS
     %0:any(s8) = COPY $a

--- a/llvm/test/CodeGen/MOS/postrapseudos.mir
+++ b/llvm/test/CodeGen/MOS/postrapseudos.mir
@@ -100,8 +100,16 @@ name: cmptermindir
 body: |
   bb.0.entry:
     ; CHECK-LABEL: name: cmptermindir
+    ; CHECK: $c = CMPIndir $a, $rs1, implicit-def $nz
+    $c = CMPTermIndir $a, $rs1, implicit-def $nz
+...
+---
+name: cmptermindiridx
+body: |
+  bb.0.entry:
+    ; CHECK-LABEL: name: cmptermindiridx
     ; CHECK: $c = CMPIndirIdx $a, $rs1, $y, implicit-def $nz
-    $c = CMPTermIndir $a, $rs1, $y, implicit-def $nz
+    $c = CMPTermIndirIdx $a, $rs1, $y, implicit-def $nz
 ...
 ---
 name: br_c

--- a/llvm/test/CodeGen/MOS/print-int.ll
+++ b/llvm/test/CodeGen/MOS/print-int.ll
@@ -96,8 +96,7 @@ define void @print_int(i8 zeroext %x) local_unnamed_addr #0 {
 ; CMOS-NEXT:    sty __rc3
 ; CMOS-NEXT:    jsr __udivmodqi4
 ; CMOS-NEXT:    tax
-; CMOS-NEXT:    ldy #0
-; CMOS-NEXT:    lda (__rc20),y
+; CMOS-NEXT:    lda (__rc20)
 ; CMOS-NEXT:    sta __rc20
 ; CMOS-NEXT:    txa
 ; CMOS-NEXT:    jsr print_int


### PR DESCRIPTION
Largely a copy-adjust-paste job, admittedly. The tests display the (slight) resulting improvements to code generation.