### PR TITLE
MOS legalizer for floating-point operations

### DIFF
--- a/llvm/lib/Target/MOS/MOSLegalizerInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSLegalizerInfo.cpp
@@ -237,15 +237,34 @@ MOSLegalizerInfo::MOSLegalizerInfo(const MOSSubtarget &STI) {
 
   // Floating Point Operations
 
-  // TODO: G_FNEG and G_FABS?
-
-  getActionDefinitionsBuilder({G_FADD,       G_FSUB,
-                               G_FMUL,       G_FDIV,
-                               G_FMA,        G_FREM,
-                               G_FCEIL,      G_FFLOOR,
-                               G_FSQRT,      G_FRINT,
-                               G_FNEARBYINT, G_INTRINSIC_ROUNDEVEN,
-                               G_FPEXT,      G_FPTRUNC})
+  getActionDefinitionsBuilder({G_FADD,
+                               G_FSUB,
+                               G_FMUL,
+                               G_FDIV,
+                               G_FMA,
+                               G_FREM,
+                               G_FPEXT,
+                               G_FPTRUNC,
+                               G_FPOW,
+                               G_FEXP,
+                               G_FEXP2,
+                               G_FLOG,
+                               G_FLOG2,
+                               G_FABS,
+                               G_FMINNUM,
+                               G_FMAXNUM,
+                               G_FCEIL,
+                               G_FCOS,
+                               G_FSIN,
+                               G_FSQRT,
+                               G_FFLOOR,
+                               G_FRINT,
+                               G_FNEARBYINT,
+                               G_INTRINSIC_ROUND,
+                               G_INTRINSIC_TRUNC,
+                               G_FMINIMUM,
+                               G_FMAXIMUM,
+                               G_INTRINSIC_ROUNDEVEN})
       .libcallFor({S32, S64});
 
   getActionDefinitionsBuilder(G_FCONSTANT)
@@ -263,13 +282,6 @@ MOSLegalizerInfo::MOSLegalizerInfo(const MOSSubtarget &STI) {
   getActionDefinitionsBuilder({G_SITOFP, G_UITOFP})
       .libcallForCartesianProduct({S32, S64}, {S32, S64})
       .minScalar(1, S32);
-
-  getActionDefinitionsBuilder({G_FPOW,       G_FCOS,
-                               G_FSIN,       G_FLOG10,
-                               G_FLOG,       G_FLOG2,
-                               G_FEXP,       G_FEXP2,
-                               G_FMINNUM,    G_FMAXNUM})
-      .unsupported();
 
   // Memory Operations
 


### PR DESCRIPTION
Here is a first pass at adding floating-point support to LLVM-MOS.  Most of it was cut-and-pasted from the ARM legalizer.

Some intrinsics aren't working yet like G_INTRINSIC_ROUNDEVEN, so this is still a work in progress.  I'm putting it up for early review.

"float" has been confirmed working with my Mandelbrot example - I have some issues with the "double" version of Mandelbrot so I may have made a mistake somewhere.  I am investigating.

It is necessary to compile and install https://github.com/rweather/berkeley-softfloat-3-6502 into your LLVM-MOS-SDK install directory to get the softfloat code.  See that repo's README for instructions.  Then build a program with:

```
mos-sim-clang -Os -o program program.c -lbsoftfloat
```

If the `-lbsoftfloat` is omitted, then a lot of linker errors will occur for the missing intrinsics.  And there is no -lm or printf support yet, so only basic arithmetic is possible.