### PR TITLE
Fix building MOS target on LLVM/Clang 16

### DIFF
--- a/llvm/lib/Target/MOS/AsmParser/MOSAsmParser.cpp
+++ b/llvm/lib/Target/MOS/AsmParser/MOSAsmParser.cpp
@@ -721,7 +721,7 @@ public:
 #define GET_MATCHER_IMPLEMENTATION
 #include "MOSGenAsmMatcher.inc"
 
-extern "C" void LLVM_EXTERNAL_VISIBILITY
+extern "C" LLVM_EXTERNAL_VISIBILITY void
 LLVMInitializeMOSAsmParser() { // NOLINT
   RegisterMCAsmParser<MOSAsmParser> X(getTheMOSTarget());
 }

--- a/llvm/lib/Target/MOS/Disassembler/MOSDisassembler.cpp
+++ b/llvm/lib/Target/MOS/Disassembler/MOSDisassembler.cpp
@@ -58,7 +58,7 @@ MCDisassembler *createMOSDisassembler(const Target &T,
   return new MOSDisassembler(STI, Ctx);
 }
 
-extern "C" void LLVM_EXTERNAL_VISIBILITY LLVMInitializeMOSDisassembler() {
+extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeMOSDisassembler() {
   // Register the disassembler.
   TargetRegistry::RegisterMCDisassembler(getTheMOSTarget(),
                                          createMOSDisassembler);

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCTargetDesc.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCTargetDesc.cpp
@@ -129,7 +129,7 @@ static MCTargetStreamer *createMCAsmTargetStreamer(MCStreamer &S,
   return new MOSTargetAsmStreamer(S, OS);
 }
 
-extern "C" void LLVM_EXTERNAL_VISIBILITY LLVMInitializeMOSTargetMC() {
+extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeMOSTargetMC() {
   // Register the MC asm info.
   RegisterMCAsmInfo<MOSMCAsmInfo> X(getTheMOSTarget());
 

--- a/llvm/lib/Target/MOS/MOSTargetMachine.cpp
+++ b/llvm/lib/Target/MOS/MOSTargetMachine.cpp
@@ -51,7 +51,7 @@
 
 using namespace llvm;
 
-extern "C" void LLVM_EXTERNAL_VISIBILITY LLVMInitializeMOSTarget() {
+extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeMOSTarget() {
   // Register the target.
   RegisterTargetMachine<MOSTargetMachine> X(getTheMOSTarget());
 


### PR DESCRIPTION
Started happening after the upstream update. Fix aligns the usage of `LLVM_EXTERNAL_VISIBILITY` with other Targets.

```
FAILED: lib/Target/MOS/CMakeFiles/LLVMMOSCodeGen.dir/MOSTargetMachine.cpp.o
/usr/bin/clang++ -DGTEST_HAS_RTTI=0 -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GNU_SOURCE -D_LIBCPP_ENABLE_HARDENED_MODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I[...]/llvm-mos/build/lib/Target/MOS -I[...]/llvm-mos/llvm/lib/Target/MOS -I[...]/llvm-mos/build/include -I[...]/llvm-mos/llvm/include -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -g -std=c++17 -fvisibility=hidden  -fno-exceptions -funwind-tables -fno-rtti -MD -MT lib/Target/MOS/CMakeFiles/LLVMMOSCodeGen.dir/MOSTargetMachine.cpp.o -MF lib/Target/MOS/CMakeFiles/LLVMMOSCodeGen.dir/MOSTargetMachine.cpp.o.d -o lib/Target/MOS/CMakeFiles/LLVMMOSCodeGen.dir/MOSTargetMachine.cpp.o -c [...]/llvm-mos/llvm/lib/Target/MOS/MOSTargetMachine.cpp
[...]/llvm-mos/llvm/lib/Target/MOS/MOSTargetMachine.cpp:54:17: error: 'visibility' attribute cannot be applied to types
extern "C" void LLVM_EXTERNAL_VISIBILITY LLVMInitializeMOSTarget() {
                ^
[...]/llvm-mos/llvm/include/llvm/Support/Compiler.h:133:34: note: expanded from macro 'LLVM_EXTERNAL_VISIBILITY'
#define LLVM_EXTERNAL_VISIBILITY LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
                                 ^
[...]/llvm-mos/llvm/include/llvm/Support/Compiler.h:119:45: note: expanded from macro 'LLVM_ATTRIBUTE_VISIBILITY_DEFAULT'
#define LLVM_ATTRIBUTE_VISIBILITY_DEFAULT [[gnu::visibility("default")]]
                                            ^
[...]
[asie@nano llvm-mos]$ clang++ -v
clang version 16.0.6
Target: x86_64-pc-linux-gnu
[...]
```