### PR TITLE
Implement --symbolize-operands on MOS target, fix 65816 BRL handling discrepancies.

### DIFF
--- a/lld/test/ELF/mos-relocs-65816.s
+++ b/lld/test/ELF/mos-relocs-65816.s
@@ -22,8 +22,8 @@ rel16next:
 # RELOCS-NEXT: 00000001 R_MOS_PCREL_16           .R_MOS_PCREL_16+0x6
 # RELOCS-NEXT: 00000004 R_MOS_PCREL_16           .R_MOS_PCREL_16
 # CHECK-LABEL: section .R_MOS_PCREL_16:
-# CHECK: brl $3
-# CHECK: brl $fffa
+# CHECK: brl $100bd
+# CHECK: brl $100b7
 
 .section .R_MOS_ADDR24_BANK,"ax",@progbits
   lda #mos24bank(adr24)

--- a/llvm/lib/Target/MOS/Disassembler/MOSDisassembler.cpp
+++ b/llvm/lib/Target/MOS/Disassembler/MOSDisassembler.cpp
@@ -64,6 +64,26 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeMOSDisassembler() {
                                          createMOSDisassembler);
 }
 
+template <unsigned N>
+static DecodeStatus decodeUImmOperand(MCInst &Inst, uint64_t Imm,
+                                      int64_t Address,
+                                      const MCDisassembler *Decoder) {
+  if (!isUInt<N>(Imm))
+    return MCDisassembler::Fail;
+  Inst.addOperand(MCOperand::createImm(Imm));
+  return MCDisassembler::Success;
+}
+
+template <unsigned N>
+static DecodeStatus decodeSImmOperand(MCInst &Inst, uint64_t Imm,
+                                      int64_t Address,
+                                      const MCDisassembler *Decoder) {
+  if (!isUInt<N>(Imm))
+    return MCDisassembler::Fail;
+  Inst.addOperand(MCOperand::createImm(SignExtend64<N>(Imm)));
+  return MCDisassembler::Success;
+}
+
 #include "MOSGenDisassemblerTables.inc"
 
 std::optional<const uint8_t *> getDecoderTable(size_t Size) {

--- a/llvm/lib/Target/MOS/MCTargetDesc/CMakeLists.txt
+++ b/llvm/lib/Target/MOS/MCTargetDesc/CMakeLists.txt
@@ -7,6 +7,7 @@ add_llvm_component_library(LLVMMOSDesc
   MOSMCCodeEmitter.cpp
   MOSMCELFStreamer.cpp
   MOSMCExpr.cpp
+  MOSMCInstrAnalysis.cpp
   MOSMCTargetDesc.cpp
   MOSTargetStreamer.cpp
 

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSInstPrinter.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSInstPrinter.cpp
@@ -73,7 +73,7 @@ void MOSInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
         return;
       }
     }
-    O << *Op.getExpr();
+    Op.getExpr()->print(O, &MAI);
   }
 }
 

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCInstrAnalysis.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCInstrAnalysis.cpp
@@ -12,6 +12,8 @@
 
 #include "MOSMCInstrAnalysis.h"
 #include "MOSMCTargetDesc.h"
+#include "llvm/MC/MCInstrDesc.h"
+#include "llvm/MC/MCSubtargetInfo.h"
 
 namespace llvm {
 
@@ -19,13 +21,61 @@ bool MOSMCInstrAnalysis::evaluateBranch(const MCInst &Inst,
                                         uint64_t Addr,
                                         uint64_t Size,
                                         uint64_t &Target) const {
-  unsigned NumOps = Inst.getNumOperands();
-  if (NumOps == 0 ||
-    Info->get(Inst.getOpcode()).operands()[NumOps - 1].OperandType !=
-      MCOI::OPERAND_PCREL)
+  if ((!isBranch(Inst) && !isCall(Inst)) || isIndirectBranch(Inst))
     return false;
-  Target = Addr + Size + Inst.getOperand(NumOps - 1).getImm();
-  return true;
+  unsigned NumOps = Inst.getNumOperands();
+  if (NumOps == 0)
+    return false;
+  const auto &Op = Info->get(Inst.getOpcode()).operands()[NumOps - 1];
+  switch (Op.OperandType) {
+    case MOSOp::OPERAND_ADDR16: {
+      Target = (Addr & 0xFFFF0000)
+               | (Inst.getOperand(NumOps - 1).getImm() & 0xFFFF);
+      return true;
+    }
+    case MOSOp::OPERAND_ADDR24: {
+      Target = (Addr & 0xFF000000)
+               | (Inst.getOperand(NumOps - 1).getImm() & 0xFFFFFF);
+      return true;
+    }
+    case MCOI::OPERAND_PCREL: {
+      Target = Addr + Size + Inst.getOperand(NumOps - 1).getImm();
+      return true;
+    }
+  }
+  return false;
+}
+
+std::optional<uint64_t>
+MOSMCInstrAnalysis::evaluateMemoryOperandAddress(const MCInst &Inst,
+                                                 const MCSubtargetInfo *STI,
+                                                 uint64_t Addr,
+                                                 uint64_t Size) const {
+  uint64_t ZpAddrOffset = STI->hasFeature(MOS::FeatureHUC6280)
+                          ? 0x2000 : 0;
+  uint64_t AbsAddrMask = STI->hasFeature(MOS::FeatureW65816)
+                         ? 0xFFFFFF : 0xFFFF;
+
+  unsigned NumOps = Inst.getNumOperands();
+  // Assumption: Every opcode has only one memory operand.
+  for (unsigned OpIdx = 0; OpIdx < NumOps; OpIdx++) {
+    const auto &Op = Info->get(Inst.getOpcode()).operands()[OpIdx];
+    switch (Op.OperandType) {
+      case MOSOp::OPERAND_ADDR8: {
+        return (Addr & ~AbsAddrMask) | ZpAddrOffset
+               | (Inst.getOperand(OpIdx).getImm() & 0xFF);
+      }
+      case MOSOp::OPERAND_ADDR16: {
+        return (Addr & ~AbsAddrMask)
+               | (Inst.getOperand(OpIdx).getImm() & 0xFFFF);
+      }
+      case MOSOp::OPERAND_ADDR24: {
+        return (Addr & ~AbsAddrMask)
+               | (Inst.getOperand(OpIdx).getImm() & 0xFFFFFF);
+      }
+    }
+  }
+  return std::nullopt;
 }
 
 } //  namespace llvm

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCInstrAnalysis.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCInstrAnalysis.cpp
@@ -1,0 +1,31 @@
+//===-- MOSMCInstrAnalysis.cpp - MOS instruction analysis -----------------===//
+//
+// Part of LLVM-MOS, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains the declarations of the MOSMCAsmInfo properties.
+//
+//===----------------------------------------------------------------------===//
+
+#include "MOSMCInstrAnalysis.h"
+#include "MOSMCTargetDesc.h"
+
+namespace llvm {
+
+bool MOSMCInstrAnalysis::evaluateBranch(const MCInst &Inst,
+                                        uint64_t Addr,
+                                        uint64_t Size,
+                                        uint64_t &Target) const {
+  unsigned NumOps = Inst.getNumOperands();
+  if (NumOps == 0 ||
+    Info->get(Inst.getOpcode()).operands()[NumOps - 1].OperandType !=
+      MCOI::OPERAND_PCREL)
+    return false;
+  Target = Addr + Size + Inst.getOperand(NumOps - 1).getImm();
+  return true;
+}
+
+} //  namespace llvm

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCInstrAnalysis.h
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCInstrAnalysis.h
@@ -26,6 +26,10 @@ public:
 
   bool evaluateBranch(const MCInst &Inst, uint64_t Addr, uint64_t Size,
                       uint64_t &Target) const override;
+
+  std::optional<uint64_t>
+  evaluateMemoryOperandAddress(const MCInst &Inst, const MCSubtargetInfo *STI,
+                               uint64_t Addr, uint64_t Size) const override;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCInstrAnalysis.h
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCInstrAnalysis.h
@@ -1,0 +1,33 @@
+//===-- MOSMCInstrAnalysis.h - MOS instruction analysis ---------*- C++ -*-===//
+//
+// Part of LLVM-MOS, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains the declaration of the MOSMCAsmInfo class.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_MOS_MC_INSTR_ANALYSIS_H
+#define LLVM_MOS_MC_INSTR_ANALYSIS_H
+
+#include "llvm/MC/MCInstrAnalysis.h"
+
+namespace llvm {
+
+class Triple;
+
+class MOSMCInstrAnalysis : public MCInstrAnalysis {
+public:
+  explicit MOSMCInstrAnalysis(const MCInstrInfo *Info)
+      : MCInstrAnalysis(Info) {}
+
+  bool evaluateBranch(const MCInst &Inst, uint64_t Addr, uint64_t Size,
+                      uint64_t &Target) const override;
+};
+
+} // end namespace llvm
+
+#endif // LLVM_MOS_MC_INSTR_ANALYSIS_H

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCTargetDesc.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCTargetDesc.cpp
@@ -14,12 +14,15 @@
 #include "MOSInstPrinter.h"
 #include "MOSMCAsmInfo.h"
 #include "MOSMCELFStreamer.h"
+#include "MOSMCInstrAnalysis.h"
 #include "MOSTargetStreamer.h"
+#include "TargetInfo/MOSTargetInfo.h"
 
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/MC/MCAsmBackend.h"
 #include "llvm/MC/MCCodeEmitter.h"
 #include "llvm/MC/MCELFStreamer.h"
+#include "llvm/MC/MCInstrAnalysis.h"
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCSubtargetInfo.h"
@@ -129,6 +132,10 @@ static MCTargetStreamer *createMCAsmTargetStreamer(MCStreamer &S,
   return new MOSTargetAsmStreamer(S, OS);
 }
 
+static MCInstrAnalysis *createMOSMCInstrAnalysis(const MCInstrInfo *Info) {
+  return new MOSMCInstrAnalysis(Info);
+}
+
 extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeMOSTargetMC() {
   // Register the MC asm info.
   RegisterMCAsmInfo<MOSMCAsmInfo> X(getTheMOSTarget());
@@ -146,6 +153,10 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeMOSTargetMC() {
   // Register the MCInstPrinter.
   TargetRegistry::RegisterMCInstPrinter(getTheMOSTarget(),
                                         createMOSMCInstPrinter);
+
+  // Register the MC instruction analyzer.
+  TargetRegistry::RegisterMCInstrAnalysis(getTheMOSTarget(),
+                                          createMOSMCInstrAnalysis);
 
   // Register the MC Code Emitter
   TargetRegistry::RegisterMCCodeEmitter(getTheMOSTarget(),

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCTargetDesc.h
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCTargetDesc.h
@@ -78,7 +78,9 @@ enum OperandType : unsigned {
   OPERAND_ADDR8,
   OPERAND_ADDR16,
   OPERAND_IMM16,
-  OPERAND_IMM3
+  OPERAND_IMM3,
+  OPERAND_ADDR24,
+  OPERAND_IMM24
 };
 
 } // namespace MOSOp

--- a/llvm/lib/Target/MOS/MOSInstrFormats.td
+++ b/llvm/lib/Target/MOS/MOSInstrFormats.td
@@ -116,6 +116,25 @@ class Inst<string asmstr> : Instruction {
   let DecoderNamespace = "MOS";
 }
 
+class InstConditionalBranch {
+  bit isBranch = true;
+  bit isTerminator = true;
+}
+
+class InstUnconditionalBranch : InstConditionalBranch {
+  bit isBarrier = true;
+}
+
+class InstCall {
+  bit isCall = true;
+}
+
+class InstReturn {
+  bit isBarrier = true;
+  bit isReturn = true;
+  bit isTerminator = true;
+}
+
 /// Makes sure that immediate mode operands fit into the required bit field
 /// size.  See also *isImm8 functions in MOS code.
 class MOSAsmOperand<string name> : AsmOperandClass {
@@ -142,6 +161,7 @@ class Addr24Operand<string name> : MOSAsmOperand<name>;
 /// This operand will only match a value from 0 to 7 inclusive.
 def imm3 : Operand<i32> {
   let ParserMatchClass = ImmediateAsmOperand<"Imm3">;
+  let DecoderMethod = "decodeUImmOperand<3>";
   let OperandType = "OPERAND_IMM3";
   let OperandNamespace = "MOSOp";
   let Type = i8;
@@ -151,6 +171,7 @@ def imm3 : Operand<i32> {
 class imm8at<int offset> : Operand<i32> {
   let ParserMatchClass = ImmediateAsmOperand<"Imm8">;
   let EncoderMethod = "encodeImm<MOS::Imm8, " # offset # ">";
+  let DecoderMethod = "decodeUImmOperand<8>";
   let OperandType = "OPERAND_IMM8";
   let OperandNamespace = "MOSOp";
   let Type = i8;
@@ -162,6 +183,7 @@ def imm8at2 : imm8at<2>;
 class imm16at<int offset> : Operand<i32> {
   let ParserMatchClass = ImmediateAsmOperand<"Imm16">;
   let EncoderMethod = "encodeImm<MOS::Imm16, " # offset # ">";
+  let DecoderMethod = "decodeUImmOperand<16>";
   let OperandType = "OPERAND_IMM16";
   let OperandNamespace = "MOSOp";
   let Type = i16;
@@ -173,6 +195,7 @@ def imm16at5 : imm16at<5>;
 class pcrel8at<int offset> : Operand<i32> {
   let ParserMatchClass = PCRelativeOperand<"PCRel8">;
   let EncoderMethod = "encodeImm<MOS::PCRel8, " # offset # ">";
+  let DecoderMethod = "decodeSImmOperand<8>";
   let PrintMethod = "printBranchOperand";
   let OperandType = "OPERAND_PCREL";
 }
@@ -183,12 +206,14 @@ def pcrel8at2 : pcrel8at<2>;
 class pcrel16at<int offset> : Operand<i32> {
   let ParserMatchClass = PCRelativeOperand<"PCRel16">;
   let EncoderMethod = "encodeImm<MOS::PCRel16, " # offset # ">";
+  let DecoderMethod = "decodeSImmOperand<16>";
 }
 def pcrel16 : pcrel16at<1>;
 
 class addr8at<int offset> : Operand<i32> {
   let ParserMatchClass = Addr8Operand<"Addr8">;
   let EncoderMethod = "encodeImm<MOS::Addr8, " # offset # ">";
+  let DecoderMethod = "decodeUImmOperand<8>";
   let OperandType = "OPERAND_ADDR8";
   let OperandNamespace = "MOSOp";
   let Type = i8;
@@ -201,6 +226,7 @@ def addr8at4 : addr8at<4>;
 class addr16at<int offset> : Operand<i32> {
   let ParserMatchClass = Addr16Operand<"Addr16">;
   let EncoderMethod = "encodeImm<MOS::Addr16, " # offset # ">";
+  let DecoderMethod = "decodeUImmOperand<16>";
   let OperandType = "OPERAND_ADDR16";
   let OperandNamespace = "MOSOp";
   let Type = i16;
@@ -212,6 +238,7 @@ def addr16at3 : addr16at<3>;
 class addr24at<int offset> : Operand<i32> {
   let ParserMatchClass = Addr24Operand<"Addr24">;
   let EncoderMethod = "encodeImm<MOS::Addr24, " # offset # ">";
+  let DecoderMethod = "decodeUImmOperand<24>";
 }
 def addr24 : addr24at<1>;
 
@@ -219,6 +246,7 @@ def addr24 : addr24at<1>;
 class imm8To16at<int offset> : Operand<i32> {
   let ParserMatchClass = ImmediateAsmOperand<"Imm8To16">;
   let EncoderMethod = "encodeImm<MOS::Addr16, " # offset # ">";
+  let DecoderMethod = "decodeUImmOperand<16>";
 }
 def imm8To16 : imm8To16at<1>;
 
@@ -226,6 +254,7 @@ def imm8To16 : imm8To16at<1>;
 class imm16To24at<int offset> : Operand<i32> {
   let ParserMatchClass = ImmediateAsmOperand<"Imm16To24">;
   let EncoderMethod = "encodeImm<MOS::Addr24, " # offset # ">";
+  let DecoderMethod = "decodeUImmOperand<24>";
 }
 def imm16To24 : imm16To24at<1>;
 
@@ -525,7 +554,7 @@ class InstImmediate32<string opcodestr, Opcode op = DefaultOpcode,
 
 /// A R65C02 bit branch instruction.
 class InstBitBranch<string opcodestr, Opcode op = DefaultOpcode> :
-    Inst<opcodestr> {
+    Inst<opcodestr>, InstConditionalBranch {
   let Size = 3;
   bits<24> Inst;
   bits<3> tbit;
@@ -962,7 +991,7 @@ multiclass CC3_NoImmediate<bits<3> aaa, string OpcodeStr = "nop"> {
 /// 10  30  50  70  90  B0  D0  F0
 
 class ConditionalBranch<string opcodestr, bits<2> flagType, bits<1> value> :
-    Inst16<opcodestr, DefaultOpcode, Relative> {
+    Inst16<opcodestr, DefaultOpcode, Relative>, InstConditionalBranch {
    bits<3> a;
    let a{2-1} = flagType;
    let a{0} = value;

--- a/llvm/lib/Target/MOS/MOSInstrFormats.td
+++ b/llvm/lib/Target/MOS/MOSInstrFormats.td
@@ -207,6 +207,8 @@ class pcrel16at<int offset> : Operand<i32> {
   let ParserMatchClass = PCRelativeOperand<"PCRel16">;
   let EncoderMethod = "encodeImm<MOS::PCRel16, " # offset # ">";
   let DecoderMethod = "decodeSImmOperand<16>";
+  let PrintMethod = "printBranchOperand";
+  let OperandType = "OPERAND_PCREL";
 }
 def pcrel16 : pcrel16at<1>;
 
@@ -239,6 +241,8 @@ class addr24at<int offset> : Operand<i32> {
   let ParserMatchClass = Addr24Operand<"Addr24">;
   let EncoderMethod = "encodeImm<MOS::Addr24, " # offset # ">";
   let DecoderMethod = "decodeUImmOperand<24>";
+  let OperandType = "OPERAND_ADDR24";
+  let OperandNamespace = "MOSOp";
 }
 def addr24 : addr24at<1>;
 
@@ -247,6 +251,8 @@ class imm8To16at<int offset> : Operand<i32> {
   let ParserMatchClass = ImmediateAsmOperand<"Imm8To16">;
   let EncoderMethod = "encodeImm<MOS::Addr16, " # offset # ">";
   let DecoderMethod = "decodeUImmOperand<16>";
+  let OperandType = "OPERAND_IMM16";
+  let OperandNamespace = "MOSOp";
 }
 def imm8To16 : imm8To16at<1>;
 
@@ -255,6 +261,8 @@ class imm16To24at<int offset> : Operand<i32> {
   let ParserMatchClass = ImmediateAsmOperand<"Imm16To24">;
   let EncoderMethod = "encodeImm<MOS::Addr24, " # offset # ">";
   let DecoderMethod = "decodeUImmOperand<24>";
+  let OperandType = "OPERAND_IMM24";
+  let OperandNamespace = "MOSOp";
 }
 def imm16To24 : imm16To24at<1>;
 

--- a/llvm/lib/Target/MOS/MOSInstrInfo.td
+++ b/llvm/lib/Target/MOS/MOSInstrInfo.td
@@ -137,9 +137,12 @@ def BIT_ZeroPage :
 def BIT_Absolute :
 	Inst24<"bit", OpcodeC0<0b001, 0b011>, Absolute>;
 def JMP_Absolute :
-	Inst24<"jmp", OpcodeC0<0b010, 0b011>, Absolute>;
+	Inst24<"jmp", OpcodeC0<0b010, 0b011>, Absolute>, InstUnconditionalBranch;
 def JMP_Indirect16 :
-	Inst24<"jmp", OpcodeC0<0b011, 0b011>, Indirect16>;
+	Inst24<"jmp", OpcodeC0<0b011, 0b011>, Indirect16>,
+	InstUnconditionalBranch {
+  let isIndirectBranch = true;
+}
 def STY_ZeroPage :
 	Inst16<"sty", OpcodeC0<0b100, 0b001>, ZeroPage>;
 def STY_Absolute :
@@ -186,11 +189,11 @@ def BEQ_Relative : ConditionalBranch<"beq", 0b11, 0b1>;
 /// TXA TXS TAX TSX DEX NOP
 /// 8A  9A  AA  BA  CA  EA
 
-def BRK_Implied: InstLow0<"brk", 0b0000>;
+def BRK_Implied: InstLow0<"brk", 0b0000>, InstUnconditionalBranch;
 /// JSR is the only instruction that does not follow the current pattern.
-def JSR_Absolute: Inst24<"jsr", Opcode<0x20>, Absolute>;
-def RTI_Implied: InstLow0<"rti", 0b0100>;
-def RTS_Implied: InstLow0<"rts", 0b0110>;
+def JSR_Absolute: Inst24<"jsr", Opcode<0x20>, Absolute>, InstCall;
+def RTI_Implied: InstLow0<"rti", 0b0100>, InstReturn;
+def RTS_Implied: InstLow0<"rts", 0b0110>, InstReturn;
 
 def PHP_Implied: InstLow8<"php", 0b0000>;
 def PLP_Implied: InstLow8<"plp", 0b0010>;
@@ -287,7 +290,8 @@ let Predicates = [Has65DTV02] in {
 
 let DecoderNamespace = "65dtv02" in {
 
-def BRA_Relative_DTV02 : Inst16<"bra", Opcode<0x12>, Relative>;
+def BRA_Relative_DTV02 : Inst16<"bra", Opcode<0x12>, Relative>,
+  InstConditionalBranch;
 def SAC_Immediate : Inst16<"sac", Opcode<0x32>, Immediate>;
 def SIR_Immediate : Inst16<"sir", Opcode<0x42>, Immediate>;
 
@@ -316,9 +320,13 @@ def PLX_Implied: InstLowA<"plx", 0b1111>; /// Pull X
 /// BRA
 /// 80
 
-def BRA_Relative : Inst16<"bra", OpcodeC0<0b100, 0b000>, Relative>;
+def BRA_Relative : Inst16<"bra", OpcodeC0<0b100, 0b000>, Relative>,
+    InstConditionalBranch;
 
-def JMP_IndexedIndirect : Inst24<"jmp", Opcode<0x7c>, IndexedIndirect16>;
+def JMP_IndexedIndirect : Inst24<"jmp", Opcode<0x7c>, IndexedIndirect16>,
+    InstUnconditionalBranch {
+  let isIndirectBranch = true;
+}
 
 def BIT_ZeroPageX : Inst16<"bit", Opcode<0x34>, ZeroPageX>;
 def BIT_AbsoluteX : Inst24<"bit", Opcode<0x3c>, AbsoluteX>;
@@ -407,21 +415,37 @@ let Predicates = [Has65CE02] in {
 /// Branches and jumps
 
 let DecoderNamespace = "65ce02" in {
-def BPL_Relative16 : Inst24<"bpl", Opcode<0x13>, Relative16>;
-def BMI_Relative16 : Inst24<"bmi", Opcode<0x33>, Relative16>;
-def BVC_Relative16 : Inst24<"bvc", Opcode<0x53>, Relative16>;
-def BSR_Relative16 : Inst24<"bsr", Opcode<0x63>, Relative16>;
-def BVS_Relative16 : Inst24<"bvs", Opcode<0x73>, Relative16>;
-def BRA_Relative16 : Inst24<"bra", Opcode<0x83>, Relative16>; /// BRU
-def BCC_Relative16 : Inst24<"bcc", Opcode<0x93>, Relative16>;
-def BCS_Relative16 : Inst24<"bcs", Opcode<0xb3>, Relative16>;
-def BNE_Relative16 : Inst24<"bne", Opcode<0xd3>, Relative16>;
-def BEQ_Relative16 : Inst24<"beq", Opcode<0xf3>, Relative16>;
+def BPL_Relative16 : Inst24<"bpl", Opcode<0x13>, Relative16>,
+	InstConditionalBranch;
+def BMI_Relative16 : Inst24<"bmi", Opcode<0x33>, Relative16>,
+	InstConditionalBranch;
+def BVC_Relative16 : Inst24<"bvc", Opcode<0x53>, Relative16>,
+	InstConditionalBranch;
+def BSR_Relative16 : Inst24<"bsr", Opcode<0x63>, Relative16>,
+	InstConditionalBranch;
+def BVS_Relative16 : Inst24<"bvs", Opcode<0x73>, Relative16>,
+	InstConditionalBranch;
+def BRA_Relative16 : Inst24<"bra", Opcode<0x83>, Relative16>,
+	InstUnconditionalBranch; /// BRU
+def BCC_Relative16 : Inst24<"bcc", Opcode<0x93>, Relative16>,
+	InstConditionalBranch;
+def BCS_Relative16 : Inst24<"bcs", Opcode<0xb3>, Relative16>,
+	InstConditionalBranch;
+def BNE_Relative16 : Inst24<"bne", Opcode<0xd3>, Relative16>,
+	InstConditionalBranch;
+def BEQ_Relative16 : Inst24<"beq", Opcode<0xf3>, Relative16>,
+	InstConditionalBranch;
 
-def JSR_AbsoluteIndirect: Inst24<"jsr", Opcode<0x22>, Indirect16>;
-def JSR_AbsoluteIndirectX: Inst24<"jsr", Opcode<0x23>, IndexedIndirect16>;
+def JSR_AbsoluteIndirect: Inst24<"jsr", Opcode<0x22>, Indirect16>,
+	InstConditionalBranch {
+  let isIndirectBranch = true;
+}
+def JSR_AbsoluteIndirectX: Inst24<"jsr", Opcode<0x23>, IndexedIndirect16>,
+	InstConditionalBranch {
+  let isIndirectBranch = true;
+}
 
-def RTN_Immediate : Inst16<"rtn", Opcode<0x62>, Immediate>;
+def RTN_Immediate : Inst16<"rtn", Opcode<0x62>, Immediate>, InstReturn;
 
 /// Arithmetic Operations
 
@@ -633,7 +657,7 @@ def TST_ZeroPageX : InstImmediate24<"tst", Opcode<0xA3>, ZeroPageXAt2>; // Test 
 def TST_AbsoluteX : InstImmediate32<"tst", Opcode<0xB3>, AbsoluteXAt2>; // Test Immediate with Absolute, X
 
 /// Relative Branch
-def BSR_Relative : Inst16<"bsr", Opcode<0x44>, Relative>;
+def BSR_Relative : Inst16<"bsr", Opcode<0x44>, Relative>, InstCall;
 
 /// CPU Control
 def CSL_Implied : InstLow4<"csl", 0b0101>; /// Set CPU Clock Low
@@ -665,7 +689,9 @@ def LDX_Immediate16 : Inst24<"ldx", OpcodeC2<0b101, 0b000>, Immediate16> {
 /// FC
 
 def JSR_IndexedIndirect16 :
-  Inst24<"jsr", OpcodeC0<0b111, 0b111>, IndexedIndirect16>;
+    Inst24<"jsr", OpcodeC0<0b111, 0b111>, IndexedIndirect16>, InstCall {
+  let isIndirectBranch = true;
+}
 
 /// Stack manipulation instructions
 /// PEA PEI
@@ -697,25 +723,31 @@ let DecoderNamespace = "w65816" in {
 /// BRL
 /// 82
 
-def BRL_Relative16 : Inst24<"brl", OpcodeC2<0b100, 0b000>, Relative16>;
+def BRL_Relative16 : Inst24<"brl", OpcodeC2<0b100, 0b000>, Relative16>,
+    InstUnconditionalBranch;
 
 /// 24-bit long-jumps
 /// JMP JSL
 /// 5C  22
 
-def JMP_AbsoluteLong : Inst32<"jmp", OpcodeC0<0b010, 0b111>, AbsoluteLong>;
-def JSL_AbsoluteLong : Inst32<"jsl", OpcodeC2<0b001, 0b000>, AbsoluteLong>;
+def JMP_AbsoluteLong : Inst32<"jmp", OpcodeC0<0b010, 0b111>, AbsoluteLong>,
+	InstUnconditionalBranch;
+def JSL_AbsoluteLong : Inst32<"jsl", OpcodeC2<0b001, 0b000>, AbsoluteLong>,
+	InstCall;
 
 /// Return from long-jump subroutine
 /// RTL
 /// 6B
 
-def RTL_Implied : Inst8<"rtl", OpcodeC3<0b011, 0b010>>;
+def RTL_Implied : Inst8<"rtl", OpcodeC3<0b011, 0b010>>, InstReturn;
 
 /// 16-bit indirect long-jump
 /// JML
 /// DC
-def JML_Indirect16 : Inst24<"jml", OpcodeC0<0b110, 0b111>, Indirect16>;
+def JML_Indirect16 : Inst24<"jml", OpcodeC0<0b110, 0b111>, Indirect16>,
+	InstUnconditionalBranch {
+  let isIndirectBranch = true;
+}
 
 /// Memory moves
 /// MVN MVP

--- a/llvm/lib/Target/MOS/MOSMCInstLower.cpp
+++ b/llvm/lib/Target/MOS/MOSMCInstLower.cpp
@@ -750,6 +750,10 @@ bool MOSMCInstLower::lowerOperand(const MachineOperand &MO, MCOperand &MCOp) {
       case MOSOp::OPERAND_ADDR16:
         return 65536;
         break;
+      case MOSOp::OPERAND_IMM24:
+      case MOSOp::OPERAND_ADDR24:
+        return 16777216;
+        break;
       }
     };
     MCOp = MCOperand::createImm(MO.getImm() >= 0 ? MO.getImm()

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -1247,8 +1247,9 @@ static void collectLocalBranchTargets(
     ArrayRef<uint8_t> Bytes, const MCInstrAnalysis *MIA, MCDisassembler *DisAsm,
     MCInstPrinter *IP, const MCSubtargetInfo *STI, uint64_t SectionAddr,
     uint64_t Start, uint64_t End, std::unordered_map<uint64_t, std::string> &Labels) {
-  // So far only supports PowerPC and X86.
-  if (!STI->getTargetTriple().isPPC() && !STI->getTargetTriple().isX86())
+  // So far only supports MOS, PowerPC and X86.
+  if (!STI->getTargetTriple().isMOS() && !STI->getTargetTriple().isPPC()
+      && !STI->getTargetTriple().isX86())
     return;
 
   Labels.clear();


### PR DESCRIPTION
Fixes https://github.com/llvm-mos/llvm-mos/issues/336