### PR TITLE
Add missing 65C02/HuC6280 MCInstLower tests.

### DIFF
--- a/llvm/test/CodeGen/MOS/asm-printer-huc6280.mir
+++ b/llvm/test/CodeGen/MOS/asm-printer-huc6280.mir
@@ -1,0 +1,52 @@
+# RUN: llc -mtriple=mos -mcpu=moshuc6280 -start-after=machine-opt-remark-emitter -verify-machineinstrs -o - %s | FileCheck %s
+---
+name: tii_memcpy
+# CHECK-LABEL: tii_memcpy
+body: |
+  bb.0.entry:
+    HuCMemcpy 1234, 5678, 90, 0
+    ; CHECK: tii 1234,5678,#90
+    RTS
+    ; CHECK-NEXT: rts
+...
+---
+name: tdd_memcpy
+# CHECK-LABEL: tdd_memcpy
+body: |
+  bb.0.entry:
+    HuCMemcpy 5678, 1234, 45, 1
+    ; CHECK: tdd 5678,1234,#45
+    RTS
+    ; CHECK-NEXT: rts
+...
+---
+name: cly_implied
+# CHECK-LABEL: cly_implied
+body: |
+  bb.0.entry:
+    $y = CL
+    ; CHECK: cly{{$}}
+    RTS
+    ; CHECK-NEXT: rts
+...
+---
+name: sax_implied
+# CHECK-LABEL: sax_implied
+body: |
+  bb.0.entry:
+    $a, $x = SWAP killed $x, killed undef $a
+    ; CHECK: sax{{$}}
+    RTS
+    ; CHECK-NEXT: rts
+...
+---
+name: sax_implied_sxa
+# CHECK-LABEL: sax_implied_sxa
+body: |
+  bb.0.entry:
+    $x, $a = SWAP killed $a, killed undef $x
+    ; CHECK: sax{{$}}
+    RTS
+    ; CHECK-NEXT: rts
+...
+

--- a/llvm/test/CodeGen/MOS/asm-printer.mir
+++ b/llvm/test/CodeGen/MOS/asm-printer.mir
@@ -164,6 +164,17 @@ body: |
     ; CHECK-NEXT: rts
 ...
 ---
+name: bra_relative
+# CHECK-LABEL: bra_relative
+body: |
+  bb.0.entry:
+    BRA %bb.0.entry
+    ; CHECK: [[BLOCK:\.L.*]]: ; %entry
+    ; CHECK: bra [[BLOCK]]
+    RTS
+    ; CHECK-NEXT: rts
+...
+---
 name: cmp_immediate
 # CHECK-LABEL: cmp_immediate
 body: |
@@ -340,6 +351,26 @@ body: |
   bb.0.entry:
     $c = LDCImm -1
     ; CHECK: sec{{$}}
+    RTS
+    ; CHECK-NEXT: rts
+...
+---
+name: dea_implied
+# CHECK-LABEL: dea_implied
+body: |
+  bb.0.entry:
+    $a = DE_CMOS $a
+    ; CHECK: dec{{$}}
+    RTS
+    ; CHECK-NEXT: rts
+...
+---
+name: ina_implied
+# CHECK-LABEL: ina_implied
+body: |
+  bb.0.entry:
+    $a = IN_CMOS $a
+    ; CHECK: inc{{$}}
     RTS
     ; CHECK-NEXT: rts
 ...


### PR DESCRIPTION
Spotted these omissions while adding similar tests to a 65816 PR. Some of these are slightly non-trivial (like HuCMemcpy), so might be good to have tests for them.