### PR TITLE
MOS: Fix DWARF5 code pointer data.

### DIFF
--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCAsmInfo.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCAsmInfo.cpp
@@ -19,7 +19,10 @@
 namespace llvm {
 
 MOSMCAsmInfo::MOSMCAsmInfo(const Triple &TT, const MCTargetOptions &Options) {
-  CodePointerSize = 2;
+  // While the platform uses 2-byte pointers, the ELF files use 4-byte pointers
+  // to convey banking information; this field is used, among others, by the
+  // DWARF debug structures.
+  CodePointerSize = 4;
   CalleeSaveStackSlotSize = 0;
   SeparatorString = "\n";
   CommentString = ";";

--- a/llvm/test/DebugInfo/MOS/dwarf-basics-v5.ll
+++ b/llvm/test/DebugInfo/MOS/dwarf-basics-v5.ll
@@ -21,7 +21,7 @@
 ; CHECK: file format elf32-mos
 
 ; CHECK: .debug_info contents:
-; CHECK: Compile Unit: length = 0x{{.*}}, format = DWARF32, version = 0x0005, unit_type = DW_UT_compile, abbr_offset = 0x0000, addr_size = 0x02 (next unit at 0x{{.*}})
+; CHECK: Compile Unit: length = 0x{{.*}}, format = DWARF32, version = 0x0005, unit_type = DW_UT_compile, abbr_offset = 0x0000, addr_size = 0x04 (next unit at 0x{{.*}})
 
 ; CHECK: DW_TAG_compile_unit
 ; CHECK:   DW_AT_producer    ("clang version 14.0.0 (https://github.com/llvm/llvm-project ...)")
@@ -88,7 +88,7 @@
 ; CHECK:     NULL
 
 ; CHECK:      .debug_addr contents:
-; CHECK-NEXT: Address table header: length = 0x{{.*}}, format = DWARF32, version = 0x0005, addr_size = 0x02, seg_size = 0x00
+; CHECK-NEXT: Address table header: length = 0x{{.*}}, format = DWARF32, version = 0x0005, addr_size = 0x04, seg_size = 0x00
 ; CHECK-NEXT: Addrs: [
 ; CHECK-NEXT: 0x0000
 ; CHECK-NEXT: ]

--- a/llvm/test/DebugInfo/MOS/dwarf-basics.ll
+++ b/llvm/test/DebugInfo/MOS/dwarf-basics.ll
@@ -21,7 +21,7 @@
 ; CHECK: file format elf32-mos
 
 ; CHECK: .debug_info contents:
-; CHECK: Compile Unit: length = 0x{{.*}}, format = DWARF32, version = 0x0003, abbr_offset = 0x0000, addr_size = 0x02 (next unit at 0x{{.*}})
+; CHECK: Compile Unit: length = 0x{{.*}}, format = DWARF32, version = 0x0003, abbr_offset = 0x0000, addr_size = 0x04 (next unit at 0x{{.*}})
 
 ; CHECK: DW_TAG_compile_unit
 ; CHECK:   DW_AT_producer    ("clang version 14.0.0 (https://github.com/llvm/llvm-project ...)")


### PR DESCRIPTION
The ELF file format uses 4-byte pointers to preserve banking information, but DWARF is told to assume 2-byte pointers. This makes the DWARF header disagree with the source line pointers, leading to a crash in LLDB:

> lldb: [...]/llvm-mos/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp:389: Error llvm::DWARFDebugLine::Prologue::parse(DWARFDataExtractor, uint64_t *, function_ref<void (Error)>, const DWARFContext &, const DWARFUnit *): Assertion `(!Cursor || DebugLineData.getAddressSize() == 0 || DebugLineData.getAddressSize() == getAddressSize()) && "Line table header and data extractor disagree"' failed.

LLDB support is not part of this PR, but I thought it'd be good to get this fixed separately.