### PR TITLE
MOS: Use upstream Motorola-style integer support in AsmLexer.

### DIFF
--- a/llvm/include/llvm/MC/MCAsmInfo.h
+++ b/llvm/include/llvm/MC/MCAsmInfo.h
@@ -126,10 +126,6 @@ protected:
   /// HLASM dialect.
   bool StarIsPC = false;
 
-  /// The '$' token, when followed immediately by hex characters, refers to
-  /// a hex constant.  Defaults to false.
-  bool DollarIsHexPrefix = false;
-
   /// This string, if specified, is used to separate instructions from each
   /// other when on the same line.  Defaults to ';'
   const char *SeparatorString;
@@ -650,7 +646,6 @@ public:
   bool getDollarIsPC() const { return DollarIsPC; }
   bool getDotIsPC() const { return DotIsPC; }
   bool getStarIsPC() const { return StarIsPC; }
-  bool getDollarIsHexPrefix() const { return DollarIsHexPrefix; }
   const char *getSeparatorString() const { return SeparatorString; }
 
   /// This indicates the column (zero-based) at which asm comments should be

--- a/llvm/include/llvm/MC/MCParser/AsmLexer.h
+++ b/llvm/include/llvm/MC/MCParser/AsmLexer.h
@@ -62,12 +62,10 @@ private:
   AsmToken LexIdentifier();
   AsmToken LexSlash();
   AsmToken LexLineComment();
-  AsmToken LexDollarAsHexPrefix();
   AsmToken LexDigit();
   AsmToken LexSingleQuote();
   AsmToken LexQuote();
   AsmToken LexFloatLiteral();
-  AsmToken LexDollar();
   AsmToken LexHexFloatLiteral(bool NoIntDigits);
 
   StringRef LexUntilEndOfLine();

--- a/llvm/lib/MC/MCParser/AsmLexer.cpp
+++ b/llvm/lib/MC/MCParser/AsmLexer.cpp
@@ -316,20 +316,6 @@ static std::string radixName(unsigned Radix) {
   }
 }
 
-AsmToken AsmLexer::LexDollarAsHexPrefix() {
-  if (!isHexDigit(*CurPtr)) {
-    return AsmToken(AsmToken::Dollar, StringRef(TokStart, 1));
-  }
-  while (isHexDigit(*(++CurPtr)))
-    ;
-  APInt Value(64, 0);
-  StringRef Result(TokStart+1, CurPtr - TokStart - 1);
-  if (Result.getAsInteger(16, Value)) {
-    return ReturnError(TokStart, "invalid hexdecimal number");
-  }
-  return intToken(Result, Value);
-}
-
 /// LexDigit: First character is [0-9].
 ///   Local Label: [0-9][:]
 ///   Forward/Backward Label: [0-9][fb]
@@ -841,8 +827,6 @@ AsmToken AsmLexer::LexToken() {
   case '*': return AsmToken(AsmToken::Star, StringRef(TokStart, 1));
   case ',': return AsmToken(AsmToken::Comma, StringRef(TokStart, 1));
   case '$': {
-    if (MAI.getDollarIsHexPrefix())
-      return LexDollarAsHexPrefix();
     if (LexMotorolaIntegers && isHexDigit(*CurPtr))
       return LexDigit();
     if (MAI.doesAllowDollarAtStartOfIdentifier())

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCAsmInfo.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCAsmInfo.cpp
@@ -23,7 +23,7 @@ MOSMCAsmInfo::MOSMCAsmInfo(const Triple &TT, const MCTargetOptions &Options) {
   CalleeSaveStackSlotSize = 0;
   SeparatorString = "\n";
   CommentString = ";";
-  DollarIsHexPrefix = true;
+  UseMotorolaIntegers = true;
   // Maximum instruction length across all supported subtargets.
   MaxInstLength = 7;
   SupportsDebugInformation = true;

--- a/llvm/test/MC/MOS/addr-asciz.s
+++ b/llvm/test/MC/MOS/addr-asciz.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -triple mos --filetype=obj -o=%t.obj %s
+; RUN: llvm-mc -triple mos -motorola-integers --filetype=obj -o=%t.obj %s
 ; RUN: llvm-readelf --relocs -x .header %t.obj | FileCheck %s
 
 .section .header,"a",@progbits

--- a/llvm/test/MC/MOS/align-nop.s
+++ b/llvm/test/MC/MOS/align-nop.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -triple mos --filetype=obj -I %S/Inputs -o=%t.obj %s
+; RUN: llvm-mc -triple mos -motorola-integers --filetype=obj -I %S/Inputs -o=%t.obj %s
 ; RUN: llvm-objdump -d %t.obj | FileCheck %s
 
 .text

--- a/llvm/test/MC/MOS/all-4510-opcodes.s
+++ b/llvm/test/MC/MOS/all-4510-opcodes.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos --mcpu=mos4510 < %s | FileCheck %s
+; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos -motorola-integers --mcpu=mos4510 < %s | FileCheck %s
 
 	map                             ; CHECK: encoding: [0x5c]
 	eom                             ; CHECK: encoding: [0xea]

--- a/llvm/test/MC/MOS/all-45gs02-opcodes.s
+++ b/llvm/test/MC/MOS/all-45gs02-opcodes.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos --mcpu=mos45gs02 < %s | FileCheck %s
+; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos -motorola-integers --mcpu=mos45gs02 < %s | FileCheck %s
 	adc [$ab], z				; CHECK: encoding: [0xea,0x72,0xab]
 
 	adcq ($ab)					; CHECK: encoding: [0x42,0x42,0x72,0xab]

--- a/llvm/test/MC/MOS/all-6502-opcodes.s
+++ b/llvm/test/MC/MOS/all-6502-opcodes.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos < %s | FileCheck %s
+; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos -motorola-integers < %s | FileCheck %s
 
  	brk                         ; CHECK: encoding: [0x00]
  	ora	($ea,x)                 ; CHECK: encoding: [0x01,0xea]

--- a/llvm/test/MC/MOS/all-6502x-opcodes.s
+++ b/llvm/test/MC/MOS/all-6502x-opcodes.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos --mcpu=mos6502x < %s | FileCheck %s
+; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos -motorola-integers --mcpu=mos6502x < %s | FileCheck %s
 
 	slo ($ea, x)                ; CHECK: encoding: [0x03,0xea]
 	nop $ea                     ; CHECK: encoding: [0x04,0xea]

--- a/llvm/test/MC/MOS/all-65816-opcodes.s
+++ b/llvm/test/MC/MOS/all-65816-opcodes.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos --mcpu=mosw65816 < %s | FileCheck %s
+; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos -motorola-integers --mcpu=mosw65816 < %s | FileCheck %s
 
  	ora	$eaeaea                 ; CHECK: encoding: [0x0f,0xea,0xea,0xea]
  	ora	$eaeaea,x               ; CHECK: encoding: [0x1f,0xea,0xea,0xea]

--- a/llvm/test/MC/MOS/all-65c02-opcodes.s
+++ b/llvm/test/MC/MOS/all-65c02-opcodes.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos --mcpu=mos65c02 < %s | FileCheck %s
+; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos -motorola-integers --mcpu=mos65c02 < %s | FileCheck %s
 
  	tsb	$ea                 ; CHECK: encoding: [0x04,0xea]
  	tsb	$eaea               ; CHECK: encoding: [0x0c,0xea,0xea]

--- a/llvm/test/MC/MOS/all-65ce02-opcodes.s
+++ b/llvm/test/MC/MOS/all-65ce02-opcodes.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos --mcpu=mos65ce02 < %s | FileCheck %s
+; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos -motorola-integers --mcpu=mos65ce02 < %s | FileCheck %s
 
 	cle                         ; CHECK: encoding: [0x02]
 	see                         ; CHECK: encoding: [0x03]

--- a/llvm/test/MC/MOS/all-65dtv02-opcodes.s
+++ b/llvm/test/MC/MOS/all-65dtv02-opcodes.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos --mcpu=mos65dtv02 < %s | FileCheck %s
+; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos -motorola-integers --mcpu=mos65dtv02 < %s | FileCheck %s
 
 	slo ($ea, x)                ; CHECK: encoding: [0x03,0xea]
 	slo $ea                     ; CHECK: encoding: [0x07,0xea]

--- a/llvm/test/MC/MOS/all-65el02-opcodes.s
+++ b/llvm/test/MC/MOS/all-65el02-opcodes.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos --mcpu=mos65el02 < %s | FileCheck %s
+; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos -motorola-integers --mcpu=mos65el02 < %s | FileCheck %s
 
  	ora	$ea,sp                  ; CHECK: encoding: [0x03,0xea]
  	ora	($ea,sp),y              ; CHECK: encoding: [0x13,0xea]

--- a/llvm/test/MC/MOS/all-huc6280-opcodes.s
+++ b/llvm/test/MC/MOS/all-huc6280-opcodes.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos --mcpu=moshuc6280 < %s | FileCheck %s
+; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos -motorola-integers --mcpu=moshuc6280 < %s | FileCheck %s
 
 	sxy                         ; CHECK: encoding: [0x02]
 	st0 #$ea                    ; CHECK: encoding: [0x03,0xea]

--- a/llvm/test/MC/MOS/all-r65c02-opcodes.s
+++ b/llvm/test/MC/MOS/all-r65c02-opcodes.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos --mcpu=mosr65c02 < %s | FileCheck %s
+; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos -motorola-integers --mcpu=mosr65c02 < %s | FileCheck %s
 
 	rmb0    $ea                 ; CHECK: encoding: [0x07,0xea]
 	bbr0    $ea, $ea            ; CHECK: encoding: [0x0f,0xea,0xea]

--- a/llvm/test/MC/MOS/all-w65c02-opcodes.s
+++ b/llvm/test/MC/MOS/all-w65c02-opcodes.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos --mcpu=mosw65c02 < %s | FileCheck %s
+; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos -motorola-integers --mcpu=mosw65c02 < %s | FileCheck %s
 
 	wai                         ; CHECK: encoding: [0xcb]
 	stp                         ; CHECK: encoding: [0xdb]

--- a/llvm/test/MC/MOS/do-copy-data.s
+++ b/llvm/test/MC/MOS/do-copy-data.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -triple mos < %s | FileCheck %s
+; RUN: llvm-mc -triple mos -motorola-integers < %s | FileCheck %s
 .data
 .fill 1
 

--- a/llvm/test/MC/MOS/do-fini-array.s
+++ b/llvm/test/MC/MOS/do-fini-array.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -triple mos < %s | FileCheck %s
+; RUN: llvm-mc -triple mos -motorola-integers < %s | FileCheck %s
 .section .fini_array.10
 ; CHECK: Declaring this symbol
 ; CHECK: __do_fini_array

--- a/llvm/test/MC/MOS/do-init-array.s
+++ b/llvm/test/MC/MOS/do-init-array.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -triple mos < %s | FileCheck %s
+; RUN: llvm-mc -triple mos -motorola-integers < %s | FileCheck %s
 .section .init_array.10
 ; CHECK: Declaring this symbol
 ; CHECK: __do_init_array

--- a/llvm/test/MC/MOS/do-init-stack.s
+++ b/llvm/test/MC/MOS/do-init-stack.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -triple mos < %s | FileCheck %s
+; RUN: llvm-mc -triple mos -motorola-integers < %s | FileCheck %s
 lda mos8(__rc0)
 ; CHECK: Declaring this symbol
 ; CHECK: __do_init_stack

--- a/llvm/test/MC/MOS/do-zero-bss.s
+++ b/llvm/test/MC/MOS/do-zero-bss.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -triple mos < %s | FileCheck %s
+; RUN: llvm-mc -triple mos -motorola-integers < %s | FileCheck %s
 .section .bss.foo
   .fill 1
 ; CHECK: Declaring this symbol

--- a/llvm/test/MC/MOS/eflags.s
+++ b/llvm/test/MC/MOS/eflags.s
@@ -1,15 +1,15 @@
-# RUN: llvm-mc -filetype=obj -triple=mos %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,6502
-# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mos6502x %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,6502X
-# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mos65c02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,65C02
-# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mosr65c02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,R65C02
-# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mosw65c02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,W65C02
-# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mosw65816 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,W65816
-# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mos65el02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,65EL02
-# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mos65ce02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,65CE02
-# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=moshuc6280 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,HUC6280
-# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mos65dtv02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,65DTV02
-# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mos4510 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,4510
-# RUN: llvm-mc -filetype=obj -triple=mos -mcpu=mos45gs02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,45GS02
+# RUN: llvm-mc -filetype=obj -triple=mos -motorola-integers %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,6502
+# RUN: llvm-mc -filetype=obj -triple=mos -motorola-integers -mcpu=mos6502x %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,6502X
+# RUN: llvm-mc -filetype=obj -triple=mos -motorola-integers -mcpu=mos65c02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,65C02
+# RUN: llvm-mc -filetype=obj -triple=mos -motorola-integers -mcpu=mosr65c02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,R65C02
+# RUN: llvm-mc -filetype=obj -triple=mos -motorola-integers -mcpu=mosw65c02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,W65C02
+# RUN: llvm-mc -filetype=obj -triple=mos -motorola-integers -mcpu=mosw65816 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,W65816
+# RUN: llvm-mc -filetype=obj -triple=mos -motorola-integers -mcpu=mos65el02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,65EL02
+# RUN: llvm-mc -filetype=obj -triple=mos -motorola-integers -mcpu=mos65ce02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,65CE02
+# RUN: llvm-mc -filetype=obj -triple=mos -motorola-integers -mcpu=moshuc6280 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,HUC6280
+# RUN: llvm-mc -filetype=obj -triple=mos -motorola-integers -mcpu=mos65dtv02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,65DTV02
+# RUN: llvm-mc -filetype=obj -triple=mos -motorola-integers -mcpu=mos4510 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,4510
+# RUN: llvm-mc -filetype=obj -triple=mos -motorola-integers -mcpu=mos45gs02 %s | llvm-readobj --file-headers - | FileCheck %s -check-prefixes=CHECK,45GS02
 
 # returns with 42 in accumulator
 .globl _start

--- a/llvm/test/MC/MOS/inst-lda.s
+++ b/llvm/test/MC/MOS/inst-lda.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -triple mos -show-encoding < %s | FileCheck %s
+; RUN: llvm-mc -triple mos -motorola-integers -show-encoding < %s | FileCheck %s
 
 foo:
 ;	lda foo,y

--- a/llvm/test/MC/MOS/modifiers.s
+++ b/llvm/test/MC/MOS/modifiers.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -triple mos --filetype=obj -o=%t.obj %s
+; RUN: llvm-mc -triple mos -motorola-integers --filetype=obj -o=%t.obj %s
 ; RUN: llvm-objdump --all-headers --print-imm-hex -D %t.obj | FileCheck %s
 
 ; Test all the modifiers for the MOS assembler.

--- a/llvm/test/MC/MOS/ophis-hello-world.s
+++ b/llvm/test/MC/MOS/ophis-hello-world.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -triple mos -show-encoding < %s | FileCheck %s
+; RUN: llvm-mc -triple mos -motorola-integers -show-encoding < %s | FileCheck %s
 ; source: https://michaelcmartin.github.io/Ophis/book/x162.html
 
 	ldx	#$0                     ; CHECK: encoding: [0xa2,0x00]

--- a/llvm/test/MC/MOS/pc-rel-reloc.s
+++ b/llvm/test/MC/MOS/pc-rel-reloc.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -triple mos --filetype=obj -o=%t.o %s
+; RUN: llvm-mc -triple mos -motorola-integers --filetype=obj -o=%t.o %s
 ; RUN: llvm-objdump -r %t.o | FileCheck %s
 
 ; CHECK: R_MOS_PCREL_8 sym

--- a/llvm/test/MC/MOS/trivial.s
+++ b/llvm/test/MC/MOS/trivial.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -triple mos < %s | FileCheck %s
+; RUN: llvm-mc -triple mos -motorola-integers < %s | FileCheck %s
 ; CHECK-NOT: __do_init_stack
 ; CHECK-NOT: __do_zero_bss
 ; CHECK-NOT: __do_zero_zp_bss

--- a/llvm/test/MC/MOS/uppercase-registers.s
+++ b/llvm/test/MC/MOS/uppercase-registers.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos < %s | FileCheck %s
+; RUN: llvm-mc -assemble --print-imm-hex --show-encoding -triple mos -motorola-integers < %s | FileCheck %s
 
  	ora	($ea,X)                 ; CHECK: encoding: [0x01,0xea]
  	asl	A                       ; CHECK: encoding: [0x0a]

--- a/llvm/test/MC/MOS/zeropage.s
+++ b/llvm/test/MC/MOS/zeropage.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -triple mos --filetype=obj -I %S/Inputs -o=%t.obj %s
+; RUN: llvm-mc -triple mos -motorola-integers --filetype=obj -I %S/Inputs -o=%t.obj %s
 ; RUN: llvm-objdump --all-headers --print-imm-hex -D %t.obj | FileCheck %s
 
 ; An 8-bit immediate value to be used as an address

--- a/llvm/test/MC/MOS/zp-regression.s
+++ b/llvm/test/MC/MOS/zp-regression.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -triple mos --filetype=obj -o=%t %s
+; RUN: llvm-mc -triple mos -motorola-integers --filetype=obj -o=%t %s
 ; RUN: llvm-objdump --all-headers --print-imm-hex -D %t | FileCheck %s
 
 


### PR DESCRIPTION
With the addition of the M68K target, upstream has introduced support for Motorola-style integers, which cover parsing of dollar-prefixed hexademical numbers. This ever-so-slightly reduces our patch surface on top of upstream LLVM.

From an user perspective, this additionally adds support for percent-prefixed binary numbers - "#%10101010", for example. This is supported by ca65, 64tass, and probably other 6502 assemblers.