### PR TITLE
MOS: Add initial LLDB support.

### DIFF
--- a/lldb/include/lldb/Utility/ArchSpec.h
+++ b/lldb/include/lldb/Utility/ArchSpec.h
@@ -221,6 +221,8 @@ public:
 
     eCore_avr,
 
+    eCore_mos,
+
     eCore_wasm32,
 
     kNumCores,

--- a/lldb/source/Utility/ArchSpec.cpp
+++ b/lldb/source/Utility/ArchSpec.cpp
@@ -238,6 +238,8 @@ static const CoreDefinition g_core_definitions[] = {
 
     {eByteOrderLittle, 2, 2, 4, llvm::Triple::avr, ArchSpec::eCore_avr, "avr"},
 
+    {eByteOrderLittle, 4, 1, 7, llvm::Triple::mos, ArchSpec::eCore_mos, "mos"},
+
     {eByteOrderLittle, 4, 1, 4, llvm::Triple::wasm32, ArchSpec::eCore_wasm32,
      "wasm32"},
 };
@@ -414,6 +416,8 @@ static const ArchDefinitionEntry g_elf_arch_entries[] = {
      0xFFFFFFFFu, 0xFFFFFFFFu}, // ARC
     {ArchSpec::eCore_avr, llvm::ELF::EM_AVR, LLDB_INVALID_CPUTYPE, 0xFFFFFFFFu,
      0xFFFFFFFFu}, // AVR
+    {ArchSpec::eCore_mos, llvm::ELF::EM_MOS, LLDB_INVALID_CPUTYPE, 0xFFFFFFFFu,
+     0xFFFFFFFFu}, // MOS
     {ArchSpec::eCore_riscv32, llvm::ELF::EM_RISCV,
      ArchSpec::eRISCVSubType_riscv32, 0xFFFFFFFFu, 0xFFFFFFFFu}, // riscv32
     {ArchSpec::eCore_riscv64, llvm::ELF::EM_RISCV,
@@ -731,6 +735,7 @@ bool ArchSpec::CharIsSignedByDefault() const {
   case llvm::Triple::systemz:
   case llvm::Triple::xcore:
   case llvm::Triple::arc:
+  case llvm::Triple::mos:
     return false;
   }
 }


### PR DESCRIPTION
This really only adds support for recognizing the "mos" target in LLDB, as well as automatically picking up on LLVM-MOS built ELF files as "mos" files. A surprising amount of things either work automatically (disassembly, for example) or are provided by the GDB server by design (such as register information).

Notably, CPU subtype support is currently entirely missing.