### PR TITLE
MOS: Zero page pointers, pass 2.

### DIFF
--- a/llvm/lib/Target/MOS/MOSIndexIV.cpp
+++ b/llvm/lib/Target/MOS/MOSIndexIV.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "MOSIndexIV.h"
+#include "MOSInstrInfo.h"
 
 #include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/Transforms/Scalar/LoopPassManager.h"
@@ -61,6 +62,9 @@ PreservedAnalyses MOSIndexIV::run(Loop &L, LoopAnalysisManager &AM,
       // Base+Index.
       const auto *R = dyn_cast<SCEVAddRecExpr>(SE.getSCEV(GEP));
       if (!R || R->getLoop() != &L)
+        continue;
+      // Only 16-bit pointer values are currently supported by this pass.
+      if (R->getType()->getPointerAddressSpace() != MOS::AS_Memory)
         continue;
       LLVM_DEBUG(dbgs() << "SCEV: " << *R << "\n");
 

--- a/llvm/lib/Target/MOS/MOSInstructionSelector.cpp
+++ b/llvm/lib/Target/MOS/MOSInstructionSelector.cpp
@@ -1919,6 +1919,9 @@ bool MOSInstructionSelector::selectGeneric(MachineInstr &MI) {
   case MOS::G_PHI:
     Opcode = MOS::PHI;
     break;
+  case MOS::G_STORE_ZP_IDX:
+    Opcode = MOS::STZpIdx;
+    break;
   case MOS::G_STORE_ABS:
     Opcode = MOS::STAbs;
     break;

--- a/llvm/lib/Target/MOS/MOSMCInstLower.cpp
+++ b/llvm/lib/Target/MOS/MOSMCInstLower.cpp
@@ -765,7 +765,7 @@ bool MOSMCInstLower::lowerOperand(const MachineOperand &MO, MCOperand &MCOp) {
     // locate the symbol completely within the zero-page.
     const auto *GVar = dyn_cast<GlobalVariable>(GV->getAliaseeObject());
     if (MOS::isZeroPageSectionName(GV->getSection()) ||
-        (GVar && GVar->getAddressSpace() == 1)) {
+        (GVar && GVar->getAddressSpace() == MOS::AS_ZeroPage)) {
       const MOSMCExpr *Expr =
           MOSMCExpr::create(MOSMCExpr::VK_MOS_ADDR8, MCOp.getExpr(),
                             /*isNegated=*/false, Ctx);
@@ -851,7 +851,7 @@ MCOperand MOSMCInstLower::lowerSymbolOperand(const MachineOperand &MO,
   } else if (MO.isGlobal()) {
     const auto *GV =
         dyn_cast<GlobalVariable>(MO.getGlobal()->getAliaseeObject());
-    ZP = GV && GV->getAddressSpace() == 1;
+    ZP = GV && GV->getAddressSpace() == MOS::AS_ZeroPage;
   } else {
     ZP = false;
   }
@@ -864,6 +864,7 @@ MCOperand MOSMCInstLower::lowerSymbolOperand(const MachineOperand &MO,
   default:
     llvm_unreachable("Invalid target operand flags.");
   case MOS::MO_NO_FLAGS:
+  case MOS::MO_ZEROPAGE:
     break;
   case MOS::MO_LO:
     if (!ZP) {

--- a/llvm/lib/Target/MOS/MOSTargetMachine.cpp
+++ b/llvm/lib/Target/MOS/MOSTargetMachine.cpp
@@ -158,7 +158,7 @@ void MOSTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
 }
 
 StringRef MOSTargetMachine::getSectionPrefix(const GlobalObject *GO) const {
-  return GO->getAddressSpace() == 1 ? ".zp" : "";
+  return GO->getAddressSpace() == MOS::AS_ZeroPage ? ".zp" : "";
 }
 
 MachineFunctionInfo *MOSTargetMachine::createMachineFunctionInfo(

--- a/llvm/lib/Target/MOS/MOSTargetTransformInfo.h
+++ b/llvm/lib/Target/MOS/MOSTargetTransformInfo.h
@@ -56,6 +56,10 @@ public:
   BranchProbability getPredictableBranchThreshold() const {
     return BranchProbability(0, 1);
   }
+
+  bool isValidAddrSpaceCast(unsigned FromAS, unsigned ToAS) const {
+    return true;
+  }
 };
 
 } // end namespace llvm


### PR DESCRIPTION
* Fix crash in MOSIndexIV when receiving a zero page address space pointer.
* Fix crash in MOSInstructionSelector when trying to lower a G_STORE_ZP_IDX.
* Fix crash in MOSMCInstLower when receiving a MO_ZEROPAGE operand.
* Fix isLegalAddressingMode() to cover the zero page address space.
* Use MOS::AS_ZeroPage to consistently refer to the zero page address space.

Fixes https://github.com/llvm-mos/llvm-mos/issues/366 and https://github.com/llvm-mos/llvm-mos/issues/363