### PR TITLE
MOS: Reduce 65C02 lowering code complexity by varying DE/IN/PH/PL log…

### DIFF
--- a/llvm/lib/Target/MOS/MOSFrameLowering.cpp
+++ b/llvm/lib/Target/MOS/MOSFrameLowering.cpp
@@ -118,7 +118,7 @@ bool MOSFrameLowering::spillCalleeSavedRegisters(
       continue;
     if (!StackRegClass.contains(Reg))
       Reg = Builder.buildCopy(&StackRegClass, Reg).getReg(0);
-    Builder.buildInstr(STI.hasGPRStackRegs() ? MOS::PH_CMOS : MOS::PH, {}, {Reg});
+    Builder.buildInstr(MOS::PH, {}, {Reg});
   }
 
   // Record that the frame pointer is killed by these instructions.
@@ -191,7 +191,7 @@ bool MOSFrameLowering::restoreCalleeSavedRegisters(
       continue;
     if (!StackRegClass.contains(Reg))
       Reg = Builder.getMRI()->createVirtualRegister(&StackRegClass);
-    Builder.buildInstr(STI.hasGPRStackRegs() ? MOS::PL_CMOS : MOS::PL, {Reg}, {});
+    Builder.buildInstr(MOS::PL, {Reg}, {});
     if (Reg != CI.getReg())
       Builder.buildCopy(CI.getReg(), Reg);
   }

--- a/llvm/lib/Target/MOS/MOSInstrLogical.td
+++ b/llvm/lib/Target/MOS/MOSInstrLogical.td
@@ -395,16 +395,9 @@ let mayLoad = true in {
 
 multiclass MOSIncDec {
   def NAME : MOSLogicalInstr {
-    dag OutOperandList = (outs XY:$dst);
-    dag InOperandList = (ins XY:$src);
+    dag OutOperandList = (outs IncDec:$dst);
+    dag InOperandList = (ins IncDec:$src);
     let Constraints = "$src = $dst";
-  }
-
-  def _CMOS : MOSLogicalInstr {
-    dag OutOperandList = (outs GPR:$dst);
-    dag InOperandList = (ins GPR:$src);
-    let Constraints = "$src = $dst";
-    let Predicates = [HasGPRIncDec];
   }
 
   def CImag8 : MOSLogicalInstr, PseudoInstExpansion<(!cast<Instruction>(NAME # C_ZeroPage) addr8:$dst)> {
@@ -487,32 +480,16 @@ def SWAP : MOSLogicalInstr {
 
 // PHA, PHP
 def PH : MOSLogicalInstr {
-  dag InOperandList = (ins AP:$src);
+  dag InOperandList = (ins PushPop:$src);
 
   let mayStore = true;
 }
 
 // PLA, PLP
 def PL : MOSLogicalInstr {
-  dag OutOperandList = (outs AP:$dst);
+  dag OutOperandList = (outs PushPop:$dst);
 
   let mayLoad = true;
-}
-
-let Predicates = [HasGPRStackRegs] in {
-  // PHA, PHP
-  def PH_CMOS : MOSLogicalInstr {
-    dag InOperandList = (ins AXYP:$src);
-
-    let mayStore = true;
-  }
-
-  // PLA, PLX, PLY, PLP
-  def PL_CMOS : MOSLogicalInstr {
-    dag OutOperandList = (outs AXYP:$dst);
-
-    let mayLoad = true;
-  }
 }
 
 //===---------------------------------------------------------------------===//

--- a/llvm/lib/Target/MOS/MOSLateOptimization.cpp
+++ b/llvm/lib/Target/MOS/MOSLateOptimization.cpp
@@ -63,7 +63,7 @@ bool MOSLateOptimization::runOnMachineFunction(MachineFunction &MF) {
 static bool definesNZ(const MachineInstr &MI, Register Val, const MOSSubtarget &STI) {
   if (MI.getOpcode() == MOS::CL)
     return false;
-  if (STI.hasSPC700() && MI.getOpcode() == MOS::PL_CMOS)
+  if (STI.hasSPC700() && MI.getOpcode() == MOS::PL)
     return false;
   if (MI.getOpcode() == MOS::STImag8)
     return false;
@@ -114,12 +114,10 @@ bool MOSLateOptimization::lowerCMPTermZs(MachineBasicBlock &MBB) const {
         case MOS::LDCImm:
         case MOS::STImag8:
         case MOS::PH:
-        case MOS::PH_CMOS:
         case MOS::SWAP:
           ClobbersNZ = false;
           break;
         case MOS::PL:
-        case MOS::PL_CMOS:
           if (STI.hasSPC700())
             ClobbersNZ = false;
           break;
@@ -322,10 +320,7 @@ bool MOSLateOptimization::combineLdImm(MachineBasicBlock &MBB) const {
       }
 
       if (Load) {
-        if (STI.hasGPRIncDec())
-          MI.setDesc(TII.get(Val > Load->Val ? MOS::IN_CMOS : MOS::DE_CMOS));
-        else
-          MI.setDesc(TII.get(Val > Load->Val ? MOS::IN : MOS::DE));
+        MI.setDesc(TII.get(Val > Load->Val ? MOS::IN : MOS::DE));
         MI.getOperand(1).ChangeToRegister(Dst, /*isDef=*/false, /*isImp=*/false,
                                           /*isKill=*/true);
         MI.tieOperands(0, 1);

--- a/llvm/lib/Target/MOS/MOSMCInstLower.cpp
+++ b/llvm/lib/Target/MOS/MOSMCInstLower.cpp
@@ -498,9 +498,7 @@ void MOSMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI) {
     }
   }
   case MOS::DE:
-  case MOS::DE_CMOS:
   case MOS::IN:
-  case MOS::IN_CMOS:
   case MOS::TA:
     switch (MI->getOperand(0).getReg()) {
     default:
@@ -509,10 +507,10 @@ void MOSMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI) {
       switch (MI->getOpcode()) {
       default:
         llvm_unreachable("Inconsistent opcode.");
-      case MOS::DE_CMOS:
+      case MOS::DE:
         OutMI.setOpcode(MOS::DEC_Accumulator);
         return;
-      case MOS::IN_CMOS:
+      case MOS::IN:
         OutMI.setOpcode(MOS::INC_Accumulator);
         return;
       }
@@ -521,11 +519,9 @@ void MOSMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI) {
       default:
         llvm_unreachable("Inconsistent opcode.");
       case MOS::DE:
-      case MOS::DE_CMOS:
         OutMI.setOpcode(MOS::DEX_Implied);
         return;
       case MOS::IN:
-      case MOS::IN_CMOS:
         OutMI.setOpcode(MOS::INX_Implied);
         return;
       case MOS::TA:
@@ -537,11 +533,9 @@ void MOSMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI) {
       default:
         llvm_unreachable("Inconsistent opcode.");
       case MOS::DE:
-      case MOS::DE_CMOS:
         OutMI.setOpcode(MOS::DEY_Implied);
         return;
       case MOS::IN:
-      case MOS::IN_CMOS:
         OutMI.setOpcode(MOS::INY_Implied);
         return;
       case MOS::TA:
@@ -601,27 +595,21 @@ void MOSMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI) {
       }
     }
   case MOS::PH:
-  case MOS::PH_CMOS:
-  case MOS::PL:
-  case MOS::PL_CMOS: {
-    bool IsPush = MI->getOpcode() == MOS::PH || MI->getOpcode() == MOS::PH_CMOS;
+  case MOS::PL: {
+    bool IsPush = MI->getOpcode() == MOS::PH;
     switch (MI->getOperand(0).getReg()) {
     case MOS::A:
       OutMI.setOpcode(IsPush ? MOS::PHA_Implied : MOS::PLA_Implied);
       return;
+    case MOS::X:
+      OutMI.setOpcode(IsPush ? MOS::PHX_Implied : MOS::PLX_Implied);
+      return;
+    case MOS::Y:
+      OutMI.setOpcode(IsPush ? MOS::PHY_Implied : MOS::PLY_Implied);
+      return;
     case MOS::P:
       OutMI.setOpcode(IsPush ? MOS::PHP_Implied : MOS::PLP_Implied);
       return;
-    }
-    if (MI->getOpcode() == MOS::PH_CMOS || MI->getOpcode() == MOS::PL_CMOS) {
-      switch (MI->getOperand(0).getReg()) {
-      case MOS::X:
-        OutMI.setOpcode(IsPush ? MOS::PHX_Implied : MOS::PLX_Implied);
-        return;
-      case MOS::Y:
-        OutMI.setOpcode(IsPush ? MOS::PHY_Implied : MOS::PLY_Implied);
-        return;
-      }
     }
     llvm_unreachable("Unexpected register.");
   }

--- a/llvm/lib/Target/MOS/MOSRegisterInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSRegisterInfo.cpp
@@ -125,11 +125,9 @@ static bool pushPullBalanced(MachineBasicBlock::iterator Begin,
   for (const MachineInstr &MI : make_range(Begin, End)) {
     switch (MI.getOpcode()) {
     case MOS::PH:
-    case MOS::PH_CMOS:
       ++PushCount;
       break;
     case MOS::PL:
-    case MOS::PL_CMOS:
       if (!PushCount)
         return false;
       --PushCount;
@@ -175,14 +173,14 @@ bool MOSRegisterInfo::saveScavengerRegister(MachineBasicBlock &MBB,
         (Reg == MOS::A || STI.hasGPRStackRegs()) && pushPullBalanced(I, UseMI);
 
     if (UseHardStack)
-      Builder.buildInstr(STI.hasGPRStackRegs() ? MOS::PH_CMOS : MOS::PH, {}, {Reg});
+      Builder.buildInstr(MOS::PH, {}, {Reg});
     else
       Builder.buildInstr(MOS::STImag8, {Save}, {Reg});
 
     Builder.setInsertPt(MBB, UseMI);
 
     if (UseHardStack)
-      Builder.buildInstr(STI.hasGPRStackRegs() ? MOS::PL_CMOS : MOS::PL, {Reg}, {});
+      Builder.buildInstr(MOS::PL, {Reg}, {});
     else
       Builder.buildInstr(MOS::LDImag8, {Reg}, {Save});
     break;

--- a/llvm/lib/Target/MOS/MOSRegisterInfo.td
+++ b/llvm/lib/Target/MOS/MOSRegisterInfo.td
@@ -191,6 +191,22 @@ let isAllocatable = false in {
   def AXYP : MOSReg8Class<(add A, X, Y, P)>;
 }
 
+// Subtarget-and-instruction-specific register classes.
+let isAllocatable = false in {
+  def PushPop : MOSReg8Class<(add AXYP)> {
+    let AltOrders = [(add AP)];
+    let AltOrderSelect = [{
+      return !MF.getSubtarget<MOSSubtarget>().hasGPRStackRegs();
+    }];
+  }
+  def IncDec : MOSReg8Class<(add GPR)> {
+    let AltOrders = [(add XY)];
+    let AltOrderSelect = [{
+      return !MF.getSubtarget<MOSSubtarget>().hasGPRIncDec();
+    }];
+  }
+}
+
 // While not directly used, unless this is present, the TableGen-erated intersection
 // register class between Anyi1 and Flags will not be allocatable.
 def AllocatableFlags : MOSReg1Class<(add Cc, Vc)>;

--- a/llvm/test/CodeGen/MOS/asm-printer-spc700.mir
+++ b/llvm/test/CodeGen/MOS/asm-printer-spc700.mir
@@ -318,7 +318,7 @@ name: dea_implied
 # CHECK-LABEL: dea_implied
 body: |
   bb.0.entry:
-    $a = DE_CMOS $a
+    $a = DE $a
     ; CHECK: dec a{{$}}
     RTS
     ; CHECK-NEXT: ret
@@ -328,7 +328,7 @@ name: ina_implied
 # CHECK-LABEL: ina_implied
 body: |
   bb.0.entry:
-    $a = IN_CMOS $a
+    $a = IN $a
     ; CHECK: inc a{{$}}
     RTS
     ; CHECK-NEXT: ret
@@ -378,7 +378,7 @@ name: phx_implied
 # CHECK-LABEL: phx_implied
 body: |
   bb.0.entry:
-    PH_CMOS $x
+    PH $x
     ; CHECK: push x{{$}}
     RTS
     ; CHECK-NEXT: ret
@@ -388,7 +388,7 @@ name: plx_implied
 # CHECK-LABEL: plx_implied
 body: |
   bb.0.entry:
-    $x = PL_CMOS
+    $x = PL
     ; CHECK: pop x{{$}}
     RTS
     ; CHECK-NEXT: ret
@@ -398,7 +398,7 @@ name: phy_implied
 # CHECK-LABEL: phy_implied
 body: |
   bb.0.entry:
-    PH_CMOS $y
+    PH $y
     ; CHECK: push y{{$}}
     RTS
     ; CHECK-NEXT: ret
@@ -408,7 +408,7 @@ name: ply_implied
 # CHECK-LABEL: ply_implied
 body: |
   bb.0.entry:
-    $y = PL_CMOS
+    $y = PL
     ; CHECK: pop y{{$}}
     RTS
     ; CHECK-NEXT: ret

--- a/llvm/test/CodeGen/MOS/asm-printer.mir
+++ b/llvm/test/CodeGen/MOS/asm-printer.mir
@@ -439,7 +439,7 @@ name: dea_implied
 # CHECK-LABEL: dea_implied
 body: |
   bb.0.entry:
-    $a = DE_CMOS $a
+    $a = DE $a
     ; CHECK: dec{{$}}
     RTS
     ; CHECK-NEXT: rts
@@ -449,7 +449,7 @@ name: ina_implied
 # CHECK-LABEL: ina_implied
 body: |
   bb.0.entry:
-    $a = IN_CMOS $a
+    $a = IN $a
     ; CHECK: inc{{$}}
     RTS
     ; CHECK-NEXT: rts
@@ -499,7 +499,7 @@ name: phx_implied
 # CHECK-LABEL: phx_implied
 body: |
   bb.0.entry:
-    PH_CMOS $x
+    PH $x
     ; CHECK: phx{{$}}
     RTS
     ; CHECK-NEXT: rts
@@ -509,7 +509,7 @@ name: plx_implied
 # CHECK-LABEL: plx_implied
 body: |
   bb.0.entry:
-    $x = PL_CMOS
+    $x = PL
     ; CHECK: plx{{$}}
     RTS
     ; CHECK-NEXT: rts
@@ -519,7 +519,7 @@ name: phy_implied
 # CHECK-LABEL: phy_implied
 body: |
   bb.0.entry:
-    PH_CMOS $y
+    PH $y
     ; CHECK: phy{{$}}
     RTS
     ; CHECK-NEXT: rts
@@ -529,7 +529,7 @@ name: ply_implied
 # CHECK-LABEL: ply_implied
 body: |
   bb.0.entry:
-    $y = PL_CMOS
+    $y = PL
     ; CHECK: ply{{$}}
     RTS
     ; CHECK-NEXT: rts

--- a/llvm/test/CodeGen/MOS/copy-phys-reg-65c02.mir
+++ b/llvm/test/CodeGen/MOS/copy-phys-reg-65c02.mir
@@ -9,8 +9,8 @@ body: |
     ; CHECK-LABEL: name: xlsb_to_v
     ; CHECK: liveins: $xlsb
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: $x = DE_CMOS $x
-    ; CHECK-NEXT: $x = IN_CMOS $x, implicit-def $nz
+    ; CHECK-NEXT: $x = DE $x
+    ; CHECK-NEXT: $x = IN $x, implicit-def $nz
     ; CHECK-NEXT: $v = SelectImm $z, 0, -1
     $v = COPY $xlsb
 ...
@@ -23,8 +23,8 @@ body: |
     ; CHECK-LABEL: name: ylsb_to_v
     ; CHECK: liveins: $ylsb
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: $y = DE_CMOS $y
-    ; CHECK-NEXT: $y = IN_CMOS $y, implicit-def $nz
+    ; CHECK-NEXT: $y = DE $y
+    ; CHECK-NEXT: $y = IN $y, implicit-def $nz
     ; CHECK-NEXT: $v = SelectImm $z, 0, -1
     $v = COPY $ylsb
 ...
@@ -37,7 +37,7 @@ body: |
     ; CHECK-LABEL: name: xy_to_xy
     ; CHECK: liveins: $x
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: PH_CMOS $x
-    ; CHECK-NEXT: $y = PL_CMOS implicit-def $nz
+    ; CHECK-NEXT: PH $x
+    ; CHECK-NEXT: $y = PL implicit-def $nz
     $y = COPY $x
 ...

--- a/llvm/test/CodeGen/MOS/copy-phys-reg-huc6280.mir
+++ b/llvm/test/CodeGen/MOS/copy-phys-reg-huc6280.mir
@@ -21,7 +21,7 @@ body: |
     ; CHECK-LABEL: name: xy_to_xy_src_alive
     ; CHECK: liveins: $x
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: PH_CMOS $x
-    ; CHECK-NEXT: $y = PL_CMOS implicit-def $nz
+    ; CHECK-NEXT: PH $x
+    ; CHECK-NEXT: $y = PL implicit-def $nz
     $y = COPY $x
 ...

--- a/llvm/test/CodeGen/MOS/late-opt-65c02.mir
+++ b/llvm/test/CodeGen/MOS/late-opt-65c02.mir
@@ -7,10 +7,10 @@ body: |
     ; CHECK-LABEL: name: ldayimm_to_inaydeay
     ; CHECK: $a = LDImm 0
     ; CHECK-NEXT: $y = LDImm 5
-    ; CHECK-NEXT: $a = IN_CMOS $a
-    ; CHECK-NEXT: $y = IN_CMOS $y
-    ; CHECK-NEXT: $a = DE_CMOS killed $a
-    ; CHECK-NEXT: $y = DE_CMOS killed $y
+    ; CHECK-NEXT: $a = IN $a
+    ; CHECK-NEXT: $y = IN $y
+    ; CHECK-NEXT: $a = DE killed $a
+    ; CHECK-NEXT: $y = DE killed $y
     ; CHECK-NEXT: RTS implicit $a, implicit $y
     dead $a = LDImm 0
     dead $y = LDImm 5

--- a/llvm/test/CodeGen/MOS/prologepilog-ir.mir
+++ b/llvm/test/CodeGen/MOS/prologepilog-ir.mir
@@ -67,7 +67,7 @@ body:             |
     ; 6502-NEXT: $rc1 = COPY killed $a
     ; 6502-NEXT: RTS
     ; 65C02-LABEL: name: nonreentrant
-    ; 65C02: PH_CMOS $a
+    ; 65C02: PH $a
     ; 65C02-NEXT: $c = LDCImm 0
     ; 65C02-NEXT: $a = COPY $rc0
     ; 65C02-NEXT: $a, $c, $v = ADCImm $a, 254, $c
@@ -75,7 +75,7 @@ body:             |
     ; 65C02-NEXT: $a = COPY $rc1
     ; 65C02-NEXT: $a, $c, $v = ADCImm $a, 255, $c
     ; 65C02-NEXT: $rc1 = COPY killed $a
-    ; 65C02-NEXT: $a = PL_CMOS
+    ; 65C02-NEXT: $a = PL
     ; 65C02-NEXT: STAbs $a, target-index(mos-static-stack) :: (store (s8) into %stack.0)
     ; 65C02-NEXT: $a = LDAbs target-index(mos-static-stack) + 1 :: (load (s8) from %stack.1)
     ; 65C02-NEXT: $c = LDCImm 0
@@ -117,15 +117,15 @@ body: |
     ; 6502-NEXT: RTS implicit $rc30, implicit $rc31
     ; 65C02-LABEL: name: nonreentrant_variable_sized
     ; 65C02: $x = frame-setup COPY $rc30
-    ; 65C02-NEXT: frame-setup PH_CMOS killed $x
+    ; 65C02-NEXT: frame-setup PH killed $x
     ; 65C02-NEXT: $x = frame-setup COPY $rc31
-    ; 65C02-NEXT: frame-setup PH_CMOS killed $x
+    ; 65C02-NEXT: frame-setup PH killed $x
     ; 65C02-NEXT: $rs15 = COPY $rs0
     ; 65C02-NEXT: $a = LDAbs target-index(mos-static-stack) + 2 :: (load (s8) from %stack.2 + 1)
     ; 65C02-NEXT: $rs0 = COPY $rs15
-    ; 65C02-NEXT: $x = frame-destroy PL_CMOS
+    ; 65C02-NEXT: $x = frame-destroy PL
     ; 65C02-NEXT: $rc31 = frame-destroy COPY killed $x
-    ; 65C02-NEXT: $x = frame-destroy PL_CMOS
+    ; 65C02-NEXT: $x = frame-destroy PL
     ; 65C02-NEXT: $rc30 = frame-destroy COPY killed $x
     ; 65C02-NEXT: RTS implicit $rc30, implicit $rc31
     $a = LDAbs %stack.2 + 1 :: (load 1 from %stack.2 + 1)
@@ -185,7 +185,7 @@ body: |
     ; 65C02: liveins: $a, $x, $y
     ; 65C02-NEXT: {{  $}}
     ; 65C02-NEXT: CLD_Implied
-    ; 65C02-NEXT: PH_CMOS $a
+    ; 65C02-NEXT: PH $a
     ; 65C02-NEXT: $c = LDCImm 0
     ; 65C02-NEXT: $a = COPY $rc0
     ; 65C02-NEXT: $a, $c, $v = ADCImm $a, 255, $c
@@ -193,12 +193,12 @@ body: |
     ; 65C02-NEXT: $a = COPY $rc1
     ; 65C02-NEXT: $a, $c, $v = ADCImm $a, 254, $c
     ; 65C02-NEXT: $rc1 = COPY killed $a
-    ; 65C02-NEXT: $a = PL_CMOS
-    ; 65C02-NEXT: frame-setup PH_CMOS $a
-    ; 65C02-NEXT: frame-setup PH_CMOS $x
-    ; 65C02-NEXT: frame-setup PH_CMOS $y
+    ; 65C02-NEXT: $a = PL
+    ; 65C02-NEXT: frame-setup PH $a
+    ; 65C02-NEXT: frame-setup PH $x
+    ; 65C02-NEXT: frame-setup PH $y
     ; 65C02-NEXT: $x = frame-setup COPY $rc16
-    ; 65C02-NEXT: frame-setup PH_CMOS killed $x
+    ; 65C02-NEXT: frame-setup PH killed $x
     ; 65C02-NEXT: $a = COPY $rc17
     ; 65C02-NEXT: $y = LDImm 0
     ; 65C02-NEXT: STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.0)
@@ -208,12 +208,12 @@ body: |
     ; 65C02-NEXT: $y = LDImm 0
     ; 65C02-NEXT: $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.0)
     ; 65C02-NEXT: $rc17 = COPY killed $a
-    ; 65C02-NEXT: $x = frame-destroy PL_CMOS
+    ; 65C02-NEXT: $x = frame-destroy PL
     ; 65C02-NEXT: $rc16 = frame-destroy COPY killed $x
-    ; 65C02-NEXT: $y = frame-destroy PL_CMOS
-    ; 65C02-NEXT: $x = frame-destroy PL_CMOS
-    ; 65C02-NEXT: $a = frame-destroy PL_CMOS
-    ; 65C02-NEXT: PH_CMOS $a
+    ; 65C02-NEXT: $y = frame-destroy PL
+    ; 65C02-NEXT: $x = frame-destroy PL
+    ; 65C02-NEXT: $a = frame-destroy PL
+    ; 65C02-NEXT: PH $a
     ; 65C02-NEXT: $c = LDCImm 0
     ; 65C02-NEXT: $a = COPY $rc0
     ; 65C02-NEXT: $a, $c, $v = ADCImm $a, 1, $c
@@ -221,7 +221,7 @@ body: |
     ; 65C02-NEXT: $a = COPY $rc1
     ; 65C02-NEXT: $a, $c, $v = ADCImm $a, 1, $c
     ; 65C02-NEXT: $rc1 = COPY killed $a
-    ; 65C02-NEXT: $a = PL_CMOS
+    ; 65C02-NEXT: $a = PL
     ; 65C02-NEXT: RTI implicit $a, implicit $x, implicit $y, implicit $rc16, implicit $rc17
     CLD_Implied
     $x = LDImm 42
@@ -287,7 +287,7 @@ body: |
   ; 65C02-NEXT:   liveins: $a, $x, $y
   ; 65C02-NEXT: {{  $}}
   ; 65C02-NEXT:   CLD_Implied
-  ; 65C02-NEXT:   PH_CMOS $a
+  ; 65C02-NEXT:   PH $a
   ; 65C02-NEXT:   $c = LDCImm 0
   ; 65C02-NEXT:   $a = COPY $rc0
   ; 65C02-NEXT:   $a, $c, $v = ADCImm $a, 255, $c
@@ -295,12 +295,12 @@ body: |
   ; 65C02-NEXT:   $a = COPY $rc1
   ; 65C02-NEXT:   $a, $c, $v = ADCImm $a, 254, $c
   ; 65C02-NEXT:   $rc1 = COPY killed $a
-  ; 65C02-NEXT:   $a = PL_CMOS
-  ; 65C02-NEXT:   frame-setup PH_CMOS $a
-  ; 65C02-NEXT:   frame-setup PH_CMOS $x
-  ; 65C02-NEXT:   frame-setup PH_CMOS $y
+  ; 65C02-NEXT:   $a = PL
+  ; 65C02-NEXT:   frame-setup PH $a
+  ; 65C02-NEXT:   frame-setup PH $x
+  ; 65C02-NEXT:   frame-setup PH $y
   ; 65C02-NEXT:   $x = frame-setup COPY $rc16
-  ; 65C02-NEXT:   frame-setup PH_CMOS killed $x
+  ; 65C02-NEXT:   frame-setup PH killed $x
   ; 65C02-NEXT:   $a = COPY $rc17
   ; 65C02-NEXT:   $y = LDImm 0
   ; 65C02-NEXT:   STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.0)
@@ -310,12 +310,12 @@ body: |
   ; 65C02-NEXT:   $y = LDImm 0
   ; 65C02-NEXT:   $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.0)
   ; 65C02-NEXT:   $rc17 = COPY killed $a
-  ; 65C02-NEXT:   $x = frame-destroy PL_CMOS
+  ; 65C02-NEXT:   $x = frame-destroy PL
   ; 65C02-NEXT:   $rc16 = frame-destroy COPY killed $x
-  ; 65C02-NEXT:   $y = frame-destroy PL_CMOS
-  ; 65C02-NEXT:   $x = frame-destroy PL_CMOS
-  ; 65C02-NEXT:   $a = frame-destroy PL_CMOS
-  ; 65C02-NEXT:   PH_CMOS $a
+  ; 65C02-NEXT:   $y = frame-destroy PL
+  ; 65C02-NEXT:   $x = frame-destroy PL
+  ; 65C02-NEXT:   $a = frame-destroy PL
+  ; 65C02-NEXT:   PH $a
   ; 65C02-NEXT:   $c = LDCImm 0
   ; 65C02-NEXT:   $a = COPY $rc0
   ; 65C02-NEXT:   $a, $c, $v = ADCImm $a, 1, $c
@@ -323,7 +323,7 @@ body: |
   ; 65C02-NEXT:   $a = COPY $rc1
   ; 65C02-NEXT:   $a, $c, $v = ADCImm $a, 1, $c
   ; 65C02-NEXT:   $rc1 = COPY killed $a
-  ; 65C02-NEXT:   $a = PL_CMOS
+  ; 65C02-NEXT:   $a = PL
   ; 65C02-NEXT:   RTI implicit $a, implicit $x, implicit $y, implicit $rc16, implicit $rc17
   bb.0.entry:
     CLD_Implied
@@ -395,7 +395,7 @@ body: |
   ; 65C02-NEXT:   liveins: $a, $y, $rc30, $rc31
   ; 65C02-NEXT: {{  $}}
   ; 65C02-NEXT:   CLD_Implied
-  ; 65C02-NEXT:   PH_CMOS $a
+  ; 65C02-NEXT:   PH $a
   ; 65C02-NEXT:   $c = LDCImm 0
   ; 65C02-NEXT:   $a = COPY $rc0
   ; 65C02-NEXT:   $a, $c, $v = ADCImm $a, 254, $c
@@ -403,13 +403,13 @@ body: |
   ; 65C02-NEXT:   $a = COPY $rc1
   ; 65C02-NEXT:   $a, $c, $v = ADCImm $a, 254, $c
   ; 65C02-NEXT:   $rc1 = COPY killed $a
-  ; 65C02-NEXT:   $a = PL_CMOS
-  ; 65C02-NEXT:   frame-setup PH_CMOS $a
-  ; 65C02-NEXT:   frame-setup PH_CMOS $y
+  ; 65C02-NEXT:   $a = PL
+  ; 65C02-NEXT:   frame-setup PH $a
+  ; 65C02-NEXT:   frame-setup PH $y
   ; 65C02-NEXT:   $y = frame-setup COPY $rc16
-  ; 65C02-NEXT:   frame-setup PH_CMOS killed $y
+  ; 65C02-NEXT:   frame-setup PH killed $y
   ; 65C02-NEXT:   $y = frame-setup COPY $rc17
-  ; 65C02-NEXT:   frame-setup PH_CMOS killed $y
+  ; 65C02-NEXT:   frame-setup PH killed $y
   ; 65C02-NEXT:   $a = COPY $rc30
   ; 65C02-NEXT:   $y = LDImm 1
   ; 65C02-NEXT:   STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.0)
@@ -425,13 +425,13 @@ body: |
   ; 65C02-NEXT:   $y = LDImm 1
   ; 65C02-NEXT:   $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.0)
   ; 65C02-NEXT:   $rc30 = COPY killed $a
-  ; 65C02-NEXT:   $y = frame-destroy PL_CMOS
+  ; 65C02-NEXT:   $y = frame-destroy PL
   ; 65C02-NEXT:   $rc17 = frame-destroy COPY killed $y
-  ; 65C02-NEXT:   $y = frame-destroy PL_CMOS
+  ; 65C02-NEXT:   $y = frame-destroy PL
   ; 65C02-NEXT:   $rc16 = frame-destroy COPY killed $y
-  ; 65C02-NEXT:   $y = frame-destroy PL_CMOS
-  ; 65C02-NEXT:   $a = frame-destroy PL_CMOS
-  ; 65C02-NEXT:   PH_CMOS $a
+  ; 65C02-NEXT:   $y = frame-destroy PL
+  ; 65C02-NEXT:   $a = frame-destroy PL
+  ; 65C02-NEXT:   PH $a
   ; 65C02-NEXT:   $c = LDCImm 0
   ; 65C02-NEXT:   $a = COPY $rc0
   ; 65C02-NEXT:   $a, $c, $v = ADCImm $a, 2, $c
@@ -439,7 +439,7 @@ body: |
   ; 65C02-NEXT:   $a = COPY $rc1
   ; 65C02-NEXT:   $a, $c, $v = ADCImm $a, 1, $c
   ; 65C02-NEXT:   $rc1 = COPY killed $a
-  ; 65C02-NEXT:   $a = PL_CMOS
+  ; 65C02-NEXT:   $a = PL
   ; 65C02-NEXT:   RTI implicit $a, implicit $y, implicit $rc16, implicit $rc17, implicit $rc30, implicit $rc31
   bb.0.entry:
     CLD_Implied
@@ -513,7 +513,7 @@ body: |
   ; 65C02-NEXT:   liveins: $a, $y, $rc30, $rc31
   ; 65C02-NEXT: {{  $}}
   ; 65C02-NEXT:   CLD_Implied
-  ; 65C02-NEXT:   PH_CMOS $a
+  ; 65C02-NEXT:   PH $a
   ; 65C02-NEXT:   $c = LDCImm 0
   ; 65C02-NEXT:   $a = COPY $rc0
   ; 65C02-NEXT:   $a, $c, $v = ADCImm $a, 254, $c
@@ -521,13 +521,13 @@ body: |
   ; 65C02-NEXT:   $a = COPY $rc1
   ; 65C02-NEXT:   $a, $c, $v = ADCImm $a, 254, $c
   ; 65C02-NEXT:   $rc1 = COPY killed $a
-  ; 65C02-NEXT:   $a = PL_CMOS
-  ; 65C02-NEXT:   frame-setup PH_CMOS $a
-  ; 65C02-NEXT:   frame-setup PH_CMOS $y
+  ; 65C02-NEXT:   $a = PL
+  ; 65C02-NEXT:   frame-setup PH $a
+  ; 65C02-NEXT:   frame-setup PH $y
   ; 65C02-NEXT:   $y = frame-setup COPY $rc16
-  ; 65C02-NEXT:   frame-setup PH_CMOS killed $y
+  ; 65C02-NEXT:   frame-setup PH killed $y
   ; 65C02-NEXT:   $y = frame-setup COPY $rc17
-  ; 65C02-NEXT:   frame-setup PH_CMOS killed $y
+  ; 65C02-NEXT:   frame-setup PH killed $y
   ; 65C02-NEXT:   $a = COPY $rc30
   ; 65C02-NEXT:   $y = LDImm 1
   ; 65C02-NEXT:   STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.0)
@@ -545,13 +545,13 @@ body: |
   ; 65C02-NEXT:   $y = LDImm 1
   ; 65C02-NEXT:   $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.0)
   ; 65C02-NEXT:   $rc30 = COPY killed $a
-  ; 65C02-NEXT:   $y = frame-destroy PL_CMOS
+  ; 65C02-NEXT:   $y = frame-destroy PL
   ; 65C02-NEXT:   $rc17 = frame-destroy COPY killed $y
-  ; 65C02-NEXT:   $y = frame-destroy PL_CMOS
+  ; 65C02-NEXT:   $y = frame-destroy PL
   ; 65C02-NEXT:   $rc16 = frame-destroy COPY killed $y
-  ; 65C02-NEXT:   $y = frame-destroy PL_CMOS
-  ; 65C02-NEXT:   $a = frame-destroy PL_CMOS
-  ; 65C02-NEXT:   PH_CMOS $a
+  ; 65C02-NEXT:   $y = frame-destroy PL
+  ; 65C02-NEXT:   $a = frame-destroy PL
+  ; 65C02-NEXT:   PH $a
   ; 65C02-NEXT:   $c = LDCImm 0
   ; 65C02-NEXT:   $a = COPY $rc0
   ; 65C02-NEXT:   $a, $c, $v = ADCImm $a, 2, $c
@@ -559,7 +559,7 @@ body: |
   ; 65C02-NEXT:   $a = COPY $rc1
   ; 65C02-NEXT:   $a, $c, $v = ADCImm $a, 1, $c
   ; 65C02-NEXT:   $rc1 = COPY killed $a
-  ; 65C02-NEXT:   $a = PL_CMOS
+  ; 65C02-NEXT:   $a = PL
   ; 65C02-NEXT:   RTI implicit $a, implicit $y, implicit $rc16, implicit $rc17, implicit $rc30, implicit $rc31
   bb.0.entry:
     CLD_Implied
@@ -717,7 +717,7 @@ body: |
     ; 65C02: liveins: $a, $x, $y, $rc2, $rc3, $rc4, $rc5, $rc6, $rc7, $rc8, $rc9, $rc10, $rc11, $rc12, $rc13, $rc14, $rc15, $rc18, $rc19
     ; 65C02-NEXT: {{  $}}
     ; 65C02-NEXT: CLD_Implied
-    ; 65C02-NEXT: PH_CMOS $a
+    ; 65C02-NEXT: PH $a
     ; 65C02-NEXT: $c = LDCImm 0
     ; 65C02-NEXT: $a = COPY $rc0
     ; 65C02-NEXT: $a, $c, $v = ADCImm $a, 239, $c
@@ -725,12 +725,12 @@ body: |
     ; 65C02-NEXT: $a = COPY $rc1
     ; 65C02-NEXT: $a, $c, $v = ADCImm $a, 254, $c
     ; 65C02-NEXT: $rc1 = COPY killed $a
-    ; 65C02-NEXT: $a = PL_CMOS
-    ; 65C02-NEXT: frame-setup PH_CMOS $a
-    ; 65C02-NEXT: frame-setup PH_CMOS $x
-    ; 65C02-NEXT: frame-setup PH_CMOS $y
+    ; 65C02-NEXT: $a = PL
+    ; 65C02-NEXT: frame-setup PH $a
+    ; 65C02-NEXT: frame-setup PH $x
+    ; 65C02-NEXT: frame-setup PH $y
     ; 65C02-NEXT: $x = frame-setup COPY $rc2
-    ; 65C02-NEXT: frame-setup PH_CMOS killed $x
+    ; 65C02-NEXT: frame-setup PH killed $x
     ; 65C02-NEXT: $a = COPY $rc3
     ; 65C02-NEXT: $y = LDImm 16
     ; 65C02-NEXT: STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.0)
@@ -834,12 +834,12 @@ body: |
     ; 65C02-NEXT: $y = LDImm 16
     ; 65C02-NEXT: $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.0)
     ; 65C02-NEXT: $rc3 = COPY killed $a
-    ; 65C02-NEXT: $x = frame-destroy PL_CMOS
+    ; 65C02-NEXT: $x = frame-destroy PL
     ; 65C02-NEXT: $rc2 = frame-destroy COPY killed $x
-    ; 65C02-NEXT: $y = frame-destroy PL_CMOS
-    ; 65C02-NEXT: $x = frame-destroy PL_CMOS
-    ; 65C02-NEXT: $a = frame-destroy PL_CMOS
-    ; 65C02-NEXT: PH_CMOS $a
+    ; 65C02-NEXT: $y = frame-destroy PL
+    ; 65C02-NEXT: $x = frame-destroy PL
+    ; 65C02-NEXT: $a = frame-destroy PL
+    ; 65C02-NEXT: PH $a
     ; 65C02-NEXT: $c = LDCImm 0
     ; 65C02-NEXT: $a = COPY $rc0
     ; 65C02-NEXT: $a, $c, $v = ADCImm $a, 17, $c
@@ -847,7 +847,7 @@ body: |
     ; 65C02-NEXT: $a = COPY $rc1
     ; 65C02-NEXT: $a, $c, $v = ADCImm $a, 1, $c
     ; 65C02-NEXT: $rc1 = COPY killed $a
-    ; 65C02-NEXT: $a = PL_CMOS
+    ; 65C02-NEXT: $a = PL
     ; 65C02-NEXT: RTI implicit $a, implicit $x, implicit $y, implicit $rc2, implicit $rc3, implicit $rc4, implicit $rc5, implicit $rc6, implicit $rc7, implicit $rc8, implicit $rc9, implicit $rc10, implicit $rc11, implicit $rc12, implicit $rc13, implicit $rc14, implicit $rc15, implicit $rc16, implicit $rc17, implicit $rc18, implicit $rc19
     CLD_Implied
     ADJCALLSTACKDOWN 0, 0, implicit $rs0, implicit-def $rs0

--- a/llvm/test/CodeGen/MOS/scavenger-65c02.mir
+++ b/llvm/test/CodeGen/MOS/scavenger-65c02.mir
@@ -8,9 +8,9 @@ body: |
     ; CHECK-LABEL: name: spill_y
     ; CHECK: liveins: $a, $x, $y
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: PH_CMOS $y
+    ; CHECK-NEXT: PH $y
     ; CHECK-NEXT: dead $y = LDImm 42
-    ; CHECK-NEXT: $y = PL_CMOS
+    ; CHECK-NEXT: $y = PL
     ; CHECK-NEXT: RTS implicit $a, implicit $x, implicit $y
     %0:yc = LDImm 42
     RTS implicit $a, implicit $x, implicit $y
@@ -25,11 +25,11 @@ body: |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: $rc17 = STImag8 $y
     ; CHECK-NEXT: $y = LDImm 42
-    ; CHECK-NEXT: PH_CMOS killed $y
+    ; CHECK-NEXT: PH killed $y
     ; CHECK-NEXT: $y = LDImag8 $rc17
     ; CHECK-NEXT: RTS implicit $a, implicit $x, implicit $y
     %0:yc = LDImm 42
-    PH_CMOS %0
+    PH %0
     RTS implicit $a, implicit $x, implicit $y
 ...
 ---
@@ -41,9 +41,9 @@ body: |
     ; CHECK: liveins: $a, $x, $y
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: $rc17 = STImag8 $y
-    ; CHECK-NEXT: dead $y = PL_CMOS
+    ; CHECK-NEXT: dead $y = PL
     ; CHECK-NEXT: $y = LDImag8 $rc17
     ; CHECK-NEXT: RTS implicit $a, implicit $x, implicit $y
-    %0:yc = PL_CMOS
+    %0:yc = PL
     RTS implicit $a, implicit $x, implicit $y
 ...


### PR DESCRIPTION
…ical opcode choice based on register classes.

This strategy appears to be present in LLVM - the X86 target uses it to vary supported register classes between 32-bit and 64-bit mode. One important note from testing and studying other targets' use of AltOrder is that there can be multiple AltOrders, and the "main" order doesn't have to ever be returned, but the "main" order must be a superset of all AltOrders.

This PR uses it to clean up 65C02 logical opcode handling, but I foresee it being of potential greater use for two other subtargets:

* 65C816: according to my current plan for generating native code on 65C816, the X and Y register will be used almost exclusively in an 16-bit form, while the A register will be used in both its 8- and 16-bit form.
* SPC700: this target adds a few new addressing modes to arithmetic, logical, and load/store instructions, which among other things allow bumping the register class for many opcodes from "Ac" to "AImag8".