### PR TITLE
Revert "MOS: Fix addresses in instructions using the zero page non-indexed ad…"

### DIFF
--- a/llvm/lib/Target/MOS/MOSLegalizerInfo.h
+++ b/llvm/lib/Target/MOS/MOSLegalizerInfo.h
@@ -87,7 +87,7 @@ private:
   std::optional<MachineOperand>
   matchAbsoluteAddressing(MachineRegisterInfo &MRI, Register Addr) const;
   bool tryAbsoluteAddressing(LegalizerHelper &Helper, MachineRegisterInfo &MRI,
-                             GLoadStore &MI, bool ZP) const;
+                             GLoadStore &MI) const;
   bool tryAbsoluteIndexedAddressing(LegalizerHelper &Helper,
                                     MachineRegisterInfo &MRI,
                                     GLoadStore &MI, bool ZP) const;

--- a/llvm/test/CodeGen/MOS/legalizer-huc6280.mir
+++ b/llvm/test/CodeGen/MOS/legalizer-huc6280.mir
@@ -18,10 +18,6 @@
     ret i16 1
   }
 
-  define i16 @load_constant_zp_addr_negative() #0 {
-    ret i16 1
-  }
-
   define i16 @load_zp_ptr() #0 {
     ret i16 1
   }
@@ -116,18 +112,6 @@ body: |
     %4:_(s16) = G_CONSTANT i16 0
     G_MEMSET %0:_(p0), %2:_(s8), %3:_(s16), 1 :: (store (s8) into `ptr inttoptr (i16 8960 to ptr)`, align 256); example.c:11:3
     RTS implicit %4
-...
----
-name: load_constant_zp_addr_negative
-body: |
-  bb.1 (%ir-block.0):
-    ; CHECK-LABEL: name: load_constant_zp_addr_negative
-    ; CHECK: [[LOAD_ABS:%[0-9]+]]:_(s8) = G_LOAD_ABS target-flags(zeropage) 8384 :: (load (s8))
-    ; CHECK-NEXT: RTS implicit [[LOAD_ABS]](s8)
-    %0:_(s8) = G_CONSTANT i8 -64
-    %1:_(p1) = G_INTTOPTR %0
-    %2:_(s8) = G_LOAD %1 :: (load (s8))
-    RTS implicit %2
 ...
 ---
 name: load_zp_ptr

--- a/llvm/test/CodeGen/MOS/legalizer-ir.mir
+++ b/llvm/test/CodeGen/MOS/legalizer-ir.mir
@@ -172,7 +172,7 @@ name: load_zp_global
 body: |
   bb.0.entry:
     ; CHECK-LABEL: name: load_zp_global
-    ; CHECK: [[LOAD_ABS:%[0-9]+]]:_(s8) = G_LOAD_ABS target-flags(zeropage) @.str :: (load (s8))
+    ; CHECK: [[LOAD_ABS:%[0-9]+]]:_(s8) = G_LOAD_ABS @.str :: (load (s8))
     ; CHECK-NEXT: RTS implicit [[LOAD_ABS]](s8)
     %0:_(p1) = G_GLOBAL_VALUE @.str
     %1:_(s8) = G_LOAD %0 :: (load (s8))
@@ -183,7 +183,7 @@ name: load_ptradd_zp_global_offset
 body: |
   bb.0.entry:
     ; CHECK-LABEL: name: load_ptradd_zp_global_offset
-    ; CHECK: [[LOAD_ABS:%[0-9]+]]:_(s8) = G_LOAD_ABS target-flags(zeropage) @.str + 154 :: (load (s8))
+    ; CHECK: [[LOAD_ABS:%[0-9]+]]:_(s8) = G_LOAD_ABS @.str + 154 :: (load (s8))
     ; CHECK-NEXT: RTS implicit [[LOAD_ABS]](s8)
     %0:_(p1) = G_GLOBAL_VALUE @.str + 120
     %1:_(s8) = G_CONSTANT i8 34

--- a/llvm/test/CodeGen/MOS/legalizer.mir
+++ b/llvm/test/CodeGen/MOS/legalizer.mir
@@ -2360,18 +2360,6 @@ body: |
     RTS implicit %2
 ...
 ---
-name: load_constant_zp_addr_negative
-body: |
-  bb.0.entry:
-    ; CHECK-LABEL: name: load_constant_zp_addr_negative
-    ; CHECK: [[LOAD_ABS:%[0-9]+]]:_(s8) = G_LOAD_ABS target-flags(zeropage) 192 :: (load (s8))
-    ; CHECK-NEXT: RTS implicit [[LOAD_ABS]](s8)
-    %0:_(s8) = G_CONSTANT i8 -64
-    %1:_(p1) = G_INTTOPTR %0
-    %2:_(s8) = G_LOAD %1 :: (load (s8))
-    RTS implicit %2
-...
----
 name: load_constant_ptradd_zext_8
 body: |
   bb.0.entry:
@@ -2454,7 +2442,7 @@ name: load_zp_constant_addr
 body: |
   bb.0.entry:
     ; CHECK-LABEL: name: load_zp_constant_addr
-    ; CHECK: [[LOAD_ABS:%[0-9]+]]:_(s8) = G_LOAD_ABS target-flags(zeropage) 123 :: (load (s8))
+    ; CHECK: [[LOAD_ABS:%[0-9]+]]:_(s8) = G_LOAD_ABS 123 :: (load (s8))
     ; CHECK-NEXT: RTS implicit [[LOAD_ABS]](s8)
     %0:_(s8) = G_CONSTANT i8 123
     %1:_(p1) = G_INTTOPTR %0


### PR DESCRIPTION
Reverts llvm-mos/llvm-mos#371

This broke verify for O0:
https://github.com/llvm-mos/llvm-test-suite/actions/runs/6368346280/job/17287716350

Reverting to unblock release.