### PR TITLE
[Breaking] Rename xo65 segment escape from `_XX` to `_xXX`

### DIFF
--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1976,15 +1976,15 @@ static bool isKnownCC65SegmentName(StringRef name) {
 // in xo65 segment names.
 //
 // Escape sequences:
-// __   -> _             (underscore)
-// _d   -> $             (dollar)
-// _h   -> -             (hyphen)
-// _p   -> .             (period)
-// _xXX -> Byte          (encoded by hex XX)
-// _tn  -> SHT_NOBITS    (@nobits)
-// _tp  -> SHT_NOBITS    (@progbits)
-// _fw  -> SHF_WRITE     (w)
-// _fx  -> SHF_EXECINSTR (x)
+//   __   -> _             (underscore)
+//   _d   -> $             (dollar)
+//   _h   -> -             (hyphen)
+//   _p   -> .             (period)
+//   _xXX -> Byte          (encoded by hex XX)
+//   _tn  -> SHT_NOBITS    (@nobits)
+//   _tp  -> SHT_NOBITS    (@progbits)
+//   _fw  -> SHF_WRITE     (w)
+//   _fx  -> SHF_EXECINSTR (x)
 void XO65File::parseSegmentName(XO65Segment &segment) {
   if (isKnownCC65SegmentName(segment.name)) {
     segment.sectionName = segment.name;

--- a/lld/test/ELF/mos-ld65-segment-name.s
+++ b/lld/test/ELF/mos-ld65-segment-name.s
@@ -24,7 +24,7 @@
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/unfinished-type-escape.o
 ; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/unfinished-type-escape.o 2>&1 | FileCheck --check-prefix=UNFINISHED-TYPE-ESCAPE %s
 ; UNFINISHED-TYPE-ESCAPE: unfinished-type-escape.o: unfinished underscore type escape: _t
-l
+
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/unknown-type-escape.o
 ; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/unknown-type-escape.o 2>&1 | FileCheck --check-prefix=UNKNOWN-TYPE-ESCAPE %s
 ; UNKNOWN-TYPE-ESCAPE: unknown-type-escape.o: unknown underscore type escape: _ta

--- a/lld/test/ELF/mos-ld65-segment-name.s
+++ b/lld/test/ELF/mos-ld65-segment-name.s
@@ -13,10 +13,18 @@
 ; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/unknown-escape.o 2>&1 | FileCheck --check-prefix=UNKNOWN-ESCAPE %s
 ; UNKNOWN-ESCAPE: unknown-escape.o: unknown underscore escape: _g
 
+; RUN: cp %p/Inputs/ca65-dummy.o %t/unfinished-hex-escape.o
+; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/unfinished-hex-escape.o 2>&1 | FileCheck --check-prefix=UNFINISHED-HEX-ESCAPE %s
+; UNFINISHED-HEX-ESCAPE: unfinished-hex-escape.o: unfinished underscore hex escape: _xa
+
+; RUN: cp %p/Inputs/ca65-dummy.o %t/invalid-hex-escape.o
+; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/invalid-hex-escape.o 2>&1 | FileCheck --check-prefix=INVALID-HEX-ESCAPE %s
+; INVALID-HEX-ESCAPE: invalid-hex-escape.o: invalid underscore hex escape: _xgg
+
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/unfinished-type-escape.o
 ; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/unfinished-type-escape.o 2>&1 | FileCheck --check-prefix=UNFINISHED-TYPE-ESCAPE %s
 ; UNFINISHED-TYPE-ESCAPE: unfinished-type-escape.o: unfinished underscore type escape: _t
-
+l
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/unknown-type-escape.o
 ; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/unknown-type-escape.o 2>&1 | FileCheck --check-prefix=UNKNOWN-TYPE-ESCAPE %s
 ; UNKNOWN-TYPE-ESCAPE: unknown-type-escape.o: unknown underscore type escape: _ta
@@ -70,9 +78,9 @@
     Index:
       Name: "_p"
     Index:
-      Name: "_2c"
+      Name: "_x2c"
     Index:
-      Name: "_2F"
+      Name: "_x2F"
     Index:
       Name: "__"
     Index:
@@ -119,6 +127,16 @@
     Count: 0
     Index:
       Name: "_g"
+;--- unfinished-hex-escape.od65
+  Segments:
+    Count: 0
+    Index:
+     Name: "_xa"
+;--- invalid-hex-escape.od65
+  Segments:
+    Count: 0
+    Index:
+      Name: "_xgg"
 ;--- unfinished-type-escape.od65
   Segments:
     Count: 0


### PR DESCRIPTION
The previous had a conflict with the `_d` escape.
Fixes #396