### PR TITLE
WIP: Fix xo65 integration on Windows

### DIFF
--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -349,6 +349,7 @@ struct Config {
   StringRef packageMetadata;
   StringRef ld65Path;
   StringRef od65Path;
+  StringRef cc65Launcher;
 
   // The following config options do not directly correspond to any
   // particular command line options.

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -1245,6 +1245,7 @@ static void readConfigs(opt::InputArgList &args) {
   config->noinhibitExec = args.hasArg(OPT_noinhibit_exec);
   config->nostdlib = args.hasArg(OPT_nostdlib);
   config->od65Path = args.getLastArgValue(OPT_od65_path);
+  config->cc65Launcher = args.getLastArgValue(OPT_cc65_launcher);
   config->oFormatBinary = isOutputFormatBinary(args);
   config->omagic = args.hasFlag(OPT_omagic, OPT_no_omagic, false);
   config->optRemarksFilename = args.getLastArgValue(OPT_opt_remarks_filename);

--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1803,7 +1803,8 @@ XO65TempFile::~XO65TempFile() {
 
 void XO65TempFile::close() {
   buffer.reset();
-  if (std::error_code ec = closeFile(fd))
+  file_t f = convertFDToNativeFile(fd);
+  if (std::error_code ec = closeFile(f))
     fatal(ctx + ": could not close " + description + ": " + ec.message());
   fd = -1;
 }
@@ -1875,7 +1876,7 @@ void XO65File::postParse() {
 void XO65File::postWrite() { outputFile.reset(); }
 
 void XO65File::parseOD65Output(StringRef od65Output) {
-  const auto od65Lines = llvm::split(od65Output, "\n");
+  const auto od65Lines = llvm::split(od65Output, od65Output.detectEOL());
   od65Line = od65Lines.begin();
   od65LinesEnd = od65Lines.end();
   parseOD65Segments();
@@ -2254,7 +2255,8 @@ void XO65Enclave::generateCfgFile(llvm::raw_fd_ostream &os) const {
 }
 
 bool XO65Enclave::updateSymbols() const {
-  const auto range = llvm::split(mapFile->getBuffer().getBuffer(), "\n");
+  StringRef buf = mapFile->getBuffer().getBuffer();
+  const auto range = llvm::split(buf, buf.detectEOL());
   auto i = range.begin();
   for (; i != range.end(); ++i) {
     if (*i == "Exports list by name:")

--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1822,9 +1822,16 @@ void XO65File::parse() {
 
   outputFile.emplace("od65", "out", toString(this), "od65 output file");
 
+  SmallVector<StringRef> args = {config->od65Path, "--dump-all", getName()};
+  StringRef executable = args.front();
+  if (!config->cc65Launcher.empty()) {
+    args.insert(args.begin(), config->cc65Launcher);
+    executable = config->cc65Launcher;
+  }
+
   std::string errMsg;
   int resultCode = sys::ExecuteAndWait(
-      config->od65Path, {config->od65Path, "--dump-all", getName()},
+      executable, args,
       /*Env=*/std::nullopt, {"", outputFile->getPath(), std::nullopt},
       /*SecondsToWait=*/0, /*MemoryLimit=*/0, &errMsg);
 
@@ -2153,12 +2160,17 @@ bool XO65Enclave::link() {
                                  "-vm",
                                  "-m",
                                  mapFile->getPath()};
+  StringRef executable = args.front();
+  if (!config->cc65Launcher.empty()) {
+    args.insert(args.begin(), config->cc65Launcher);
+    executable = config->cc65Launcher;
+  }
   for (XO65File *f : files)
     args.push_back(f->getName());
 
   std::string errMsg;
   int resultCode =
-      sys::ExecuteAndWait(config->ld65Path, args,
+      sys::ExecuteAndWait(executable, args,
                           /*Env=*/std::nullopt, {"", "", std::nullopt},
                           /*SecondsToWait=*/0, /*MemoryLimit=*/0, &errMsg);
   if (resultCode)

--- a/lld/ELF/InputFiles.h
+++ b/lld/ELF/InputFiles.h
@@ -402,6 +402,8 @@ public:
   StringRef getPath() const { return path; }
   int getFD() const { return fd; }
   MemoryBufferRef getBuffer() const { return *buffer; }
+  void close();
+  void open();
 
   void read();
 };

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -320,6 +320,7 @@ def o: JoinedOrSeparate<["-"], "o">, MetaVarName<"<path>">,
   HelpText<"Path to file to write output">;
 
 defm od65_path: Eq<"od65-path", "Path to od65 object file dump utility">, MetaVarName<"<path>">;
+defm cc65_launcher: Eq<"cc65-launcher", "Test-only launcher for cc65 utilities">, Flags<[HelpHidden]>;
 
 defm oformat: EEq<"oformat", "Specify the binary format for the output object file">,
   MetaVarName<"[elf,binary]">;

--- a/lld/test/ELF/mos-ld65-bad-path.s
+++ b/lld/test/ELF/mos-ld65-bad-path.s
@@ -16,4 +16,3 @@
 Exports list by name:
 ---------------------
 ;--- ld65.hex
-

--- a/lld/test/ELF/mos-ld65-cfg.s
+++ b/lld/test/ELF/mos-ld65-cfg.s
@@ -1,9 +1,8 @@
-; REQUIRES: system-linux
 ; RUN: split-file %s %t
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/ca65.o
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/other-ca65.o
 ; RUN: llvm-mc -filetype=obj -triple=mos -o %t/main.o %t/main.s
-; RUN: ld.lld --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py -o %t/a.out -T%t/link.ld %t/main.o %t/ca65.o %t/other-ca65.o
+; RUN: ld.lld --cc65-launcher=%python --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py -o %t/a.out -T%t/link.ld %t/main.o %t/ca65.o %t/other-ca65.o
 ; RUN: FileCheck --input-file=%t/ld65.cfg %s
 
 ; CHECK:      MEMORY {

--- a/lld/test/ELF/mos-ld65-contents.s
+++ b/lld/test/ELF/mos-ld65-contents.s
@@ -1,7 +1,6 @@
-; REQUIRES: system-linux
 ; RUN: split-file %s %t
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/ca65.o
-; RUN: ld.lld -m moself --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py -o %t/a.out %t/ca65.o
+; RUN: ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py -o %t/a.out %t/ca65.o
 ; RUN: llvm-readelf -x two_bytes %t/a.out | FileCheck --check-prefix=TWO-BYTES %s
 ; RUN: llvm-readelf -x one_byte %t/a.out | FileCheck --check-prefix=ONE-BYTE %s
 ; TWO-BYTES: 12ab

--- a/lld/test/ELF/mos-ld65-gc.s
+++ b/lld/test/ELF/mos-ld65-gc.s
@@ -1,8 +1,7 @@
-; REQUIRES: system-linux
 ; RUN: split-file %s %t
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/ca65.o
 ; RUN: llvm-mc -filetype=obj -triple=mos -o %t/main.o %t/main.s
-; RUN: ld.lld --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py --gc-sections -o %t/a.out %t/main.o %t/ca65.o
+; RUN: ld.lld --cc65-launcher=%python --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py --gc-sections -o %t/a.out %t/main.o %t/ca65.o
 ; RUN: llvm-readelf -x .referenced_by_ca65 %t/a.out | FileCheck %s
 ; CHECK: .referenced_by_ca65
 

--- a/lld/test/ELF/mos-ld65-map.s
+++ b/lld/test/ELF/mos-ld65-map.s
@@ -1,27 +1,26 @@
-; REQUIRES: system-linux
 ; RUN: split-file %s %t
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/ca65.o
 ; RUN: llvm-mc -filetype=obj -triple=mos -o %t/main.o %t/main.s
 
-; RUN: ld.lld --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py -o %t/a.out %t/main.o %t/ca65.o
+; RUN: ld.lld --cc65-launcher=%python --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py -o %t/a.out %t/main.o %t/ca65.o
 ; RUN: llvm-nm %t/a.out | FileCheck %s
 ; CHECK: 1234 A abs_sym
 ; CHECK: abcd A ca65_sym
 
 ; RUN: cp %t/no-exports-list.map %t/ld65.map
-; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py -o %t/a.out %t/ca65.o 2>&1 | FileCheck --check-prefix=NO-EXPORTS-LIST %s
+; RUN: not ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py -o %t/a.out %t/ca65.o 2>&1 | FileCheck --check-prefix=NO-EXPORTS-LIST %s
 ; NO-EXPORTS-LIST: error: ld65 map file: expected "Exports list by name:"
 
 ; RUN: cp %t/bad-symbol-line.map %t/ld65.map
-; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py -o %t/a.out %t/ca65.o 2>&1 | FileCheck --check-prefix=BAD-SYMBOL-LINE %s
+; RUN: not ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py -o %t/a.out %t/ca65.o 2>&1 | FileCheck --check-prefix=BAD-SYMBOL-LINE %s
 ; BAD-SYMBOL-LINE: error: ld65 map file: expected symbol values line; found
 
 ; RUN: cp %t/bad-address.map %t/ld65.map
-; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py -o %t/a.out %t/ca65.o 2>&1 | FileCheck --check-prefix=BAD-ADDRESS %s
+; RUN: not ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py -o %t/a.out %t/ca65.o 2>&1 | FileCheck --check-prefix=BAD-ADDRESS %s
 ; BAD-ADDRESS: error: ld65 map file: expected hex integer; found: 9999999999999999999999999
 
 ; RUN: cp %t/unknown-symbol.map %t/ld65.map
-; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py -o %t/a.out %t/ca65.o 2>&1 | FileCheck --check-prefix=UNKNOWN-SYMBOL %s
+; RUN: not ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py -o %t/a.out %t/ca65.o 2>&1 | FileCheck --check-prefix=UNKNOWN-SYMBOL %s
 ; UNKNOWN-SYMBOL: error: ld65 map file: could not find symbol definition: unknown
 
 

--- a/lld/test/ELF/mos-ld65-od65-parse-error.s
+++ b/lld/test/ELF/mos-ld65-od65-parse-error.s
@@ -1,25 +1,24 @@
-; REQUIRES: system-linux
 ; RUN: split-file %s %t
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/ca65.o
 
 ; RUN: cp %t/no-segments.od65 %t/ca65.od65
-; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/ca65.o 2>&1 | FileCheck --check-prefix=NO-SEGMENTS %s
+; RUN: not ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py %t/ca65.o 2>&1 | FileCheck --check-prefix=NO-SEGMENTS %s
 ; NO-SEGMENTS: ca65.o: could not parse od65 output: expected "  Segments:"
 
 ; RUN: cp %t/no-segment-count.od65 %t/ca65.od65
-; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/ca65.o 2>&1 | FileCheck --check-prefix=NO-SEGMENT-COUNT %s
+; RUN: not ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py %t/ca65.o 2>&1 | FileCheck --check-prefix=NO-SEGMENT-COUNT %s
 ; NO-SEGMENT-COUNT: ca65.o: could not parse od65 output: expected prefix " Count:"
 
 ; RUN: cp %t/bad-quotes.od65 %t/ca65.od65
-; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/ca65.o 2>&1 | FileCheck --check-prefix=BAD-QUOTES %s
+; RUN: not ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py %t/ca65.o 2>&1 | FileCheck --check-prefix=BAD-QUOTES %s
 ; BAD-QUOTES: ca65.o: could not parse quoted string Name: Bad
 
 ; RUN: cp %t/bad-kv.od65 %t/ca65.od65
-; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/ca65.o 2>&1 | FileCheck --check-prefix=BAD-KV %s
+; RUN: not ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py %t/ca65.o 2>&1 | FileCheck --check-prefix=BAD-KV %s
 ; BAD-KV: ca65.o: could not parse key-value pair: Size
 
 ; RUN: cp %t/bad-int.od65 %t/ca65.od65
-; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/ca65.o 2>&1 | FileCheck --check-prefix=BAD-INT %s
+; RUN: not ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py %t/ca65.o 2>&1 | FileCheck --check-prefix=BAD-INT %s
 ; BAD-INT: ca65.o: could not parse int Size: Bad
 
 ;--- no-segments.od65

--- a/lld/test/ELF/mos-ld65-segment-name.s
+++ b/lld/test/ELF/mos-ld65-segment-name.s
@@ -1,40 +1,39 @@
-; REQUIRES: system-linux
 ; RUN: split-file %s %t
 
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/ca65.o
-; RUN: ld.lld -m moself --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py -o %t/a.out %t/ca65.o
+; RUN: ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py -o %t/a.out %t/ca65.o
 ; RUN: llvm-readelf --sections %t/a.out | FileCheck %s
 
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/unfinished-escape.o
-; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/unfinished-escape.o 2>&1 | FileCheck --check-prefix=UNFINISHED-ESCAPE %s
+; RUN: not ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py %t/unfinished-escape.o 2>&1 | FileCheck --check-prefix=UNFINISHED-ESCAPE %s
 ; UNFINISHED-ESCAPE: unfinished-escape.o: unfinished underscore escape: _
 
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/unknown-escape.o
-; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/unknown-escape.o 2>&1 | FileCheck --check-prefix=UNKNOWN-ESCAPE %s
+; RUN: not ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py %t/unknown-escape.o 2>&1 | FileCheck --check-prefix=UNKNOWN-ESCAPE %s
 ; UNKNOWN-ESCAPE: unknown-escape.o: unknown underscore escape: _g
 
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/unfinished-hex-escape.o
-; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/unfinished-hex-escape.o 2>&1 | FileCheck --check-prefix=UNFINISHED-HEX-ESCAPE %s
+; RUN: not ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py %t/unfinished-hex-escape.o 2>&1 | FileCheck --check-prefix=UNFINISHED-HEX-ESCAPE %s
 ; UNFINISHED-HEX-ESCAPE: unfinished-hex-escape.o: unfinished underscore hex escape: _xa
 
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/invalid-hex-escape.o
-; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/invalid-hex-escape.o 2>&1 | FileCheck --check-prefix=INVALID-HEX-ESCAPE %s
+; RUN: not ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py %t/invalid-hex-escape.o 2>&1 | FileCheck --check-prefix=INVALID-HEX-ESCAPE %s
 ; INVALID-HEX-ESCAPE: invalid-hex-escape.o: invalid underscore hex escape: _xgg
 
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/unfinished-type-escape.o
-; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/unfinished-type-escape.o 2>&1 | FileCheck --check-prefix=UNFINISHED-TYPE-ESCAPE %s
+; RUN: not ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py %t/unfinished-type-escape.o 2>&1 | FileCheck --check-prefix=UNFINISHED-TYPE-ESCAPE %s
 ; UNFINISHED-TYPE-ESCAPE: unfinished-type-escape.o: unfinished underscore type escape: _t
 
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/unknown-type-escape.o
-; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/unknown-type-escape.o 2>&1 | FileCheck --check-prefix=UNKNOWN-TYPE-ESCAPE %s
+; RUN: not ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py %t/unknown-type-escape.o 2>&1 | FileCheck --check-prefix=UNKNOWN-TYPE-ESCAPE %s
 ; UNKNOWN-TYPE-ESCAPE: unknown-type-escape.o: unknown underscore type escape: _ta
 
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/unfinished-flag-escape.o
-; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/unfinished-flag-escape.o 2>&1 | FileCheck --check-prefix=UNFINISHED-FLAG-ESCAPE %s
+; RUN: not ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py %t/unfinished-flag-escape.o 2>&1 | FileCheck --check-prefix=UNFINISHED-FLAG-ESCAPE %s
 ; UNFINISHED-FLAG-ESCAPE: unfinished-flag-escape.o: unfinished underscore flag escape: _f
 
 ; RUN: cp %p/Inputs/ca65-dummy.o %t/unknown-flag-escape.o
-; RUN: not ld.lld -m moself --od65-path=%p/Inputs/od65.py %t/unknown-flag-escape.o 2>&1 | FileCheck --check-prefix=UNKNOWN-FLAG-ESCAPE %s
+; RUN: not ld.lld -m moself --cc65-launcher=%python --od65-path=%p/Inputs/od65.py %t/unknown-flag-escape.o 2>&1 | FileCheck --check-prefix=UNKNOWN-FLAG-ESCAPE %s
 ; UNKNOWN-FLAG-ESCAPE: unknown-flag-escape.o: unknown underscore flag escape: _fa
 
 ; CHECK: nobits NOBITS


### PR DESCRIPTION
A file sharing issue on Windows completely breaks xo65 integration. This PR finds a circuitous way to run the tests for xo65 on Windows and repairs the feature.