### PR TITLE
Report no size for function Mesen labels

### DIFF
--- a/llvm/test/tools/llvm-mlb/mlb-nes.test
+++ b/llvm/test/tools/llvm-mlb/mlb-nes.test
@@ -28,6 +28,12 @@ Symbols:
     Index: SHN_ABS
     Value: 0x1235
     Size:  2
+# CHECK: R:1235:two_byte_fn
+  - Name:  two_byte_fn
+    Index: SHN_ABS
+    Value: 0x1235
+    Size:  2
+    Type:  STT_FUNC
 # CHECK: R:34:__rc5
   - Name:  __rc5
     Index: SHN_ABS

--- a/llvm/tools/llvm-mlb/llvm-mlb.cpp
+++ b/llvm/tools/llvm-mlb/llvm-mlb.cpp
@@ -169,6 +169,10 @@ int main(int argc, char **argv) {
         if (Type == SymbolRef::ST_Unknown)
           if (Name.startswith("__") && !Name.startswith("__rc"))
             continue;
+
+        // Mesen 2 incorrectly displays executable symbols with a size attached.
+        if (Type == SymbolRef::ST_Function)
+          Size = 1;
         
         const auto TryPRGRom = [&]() {
           if ((Address & 0xffff) < 0x8000)


### PR DESCRIPTION
Mesen2 produces an incorrect and noisy disassembly for function labels with sizes. Arguably mesen should be changed, but in the mean time, this considerably improves the debugging experience.

Fixes #403