### PR TITLE
Add x86_64 and arm64 build targets for macOS

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -41,6 +41,7 @@ jobs:
           cd build
           cmake \
             -GNinja \
+            -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
             -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/llvm-mos \
             -C../clang/cmake/caches/MOS.cmake \
             ../llvm


### PR DESCRIPTION
Should partially address #274 if fat binaries are acceptable.