### PR TITLE
Build compiler-rt builtins

### DIFF
--- a/clang/cmake/caches/MOS.cmake
+++ b/clang/cmake/caches/MOS.cmake
@@ -15,6 +15,8 @@ set(LLVM_ENABLE_RUNTIMES compiler-rt CACHE STRING "")
 set(LLVM_BUILTIN_TARGETS mos-unknown-unknown CACHE STRING "")
 set(LLVM_RUNTIME_TARGETS mos-unknown-unknown CACHE STRING "")
 set(BUILTINS_mos-unknown-unknown_COMPILER_RT_BAREMETAL_BUILD ON CACHE BOOL "")
+set(BUILTINS_mos-unknown-unknown_COMPILER_RT_BUILD_CRT OFF CACHE BOOL "")
+set(BUILTINS_mos-unknown-unknown_CMAKE_BUILD_TYPE MinSizeRel CACHE BOOL "")
 set(RUNTIMES_mos-unknown-unknown_CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY CACHE STRING "")
 
 set(LLVM_DEFAULT_TARGET_TRIPLE "mos-unknown-unknown" CACHE STRING "")

--- a/clang/cmake/caches/MOS.cmake
+++ b/clang/cmake/caches/MOS.cmake
@@ -10,6 +10,13 @@ set(LLVM_ENABLE_LIBXML2 "OFF" CACHE STRING "")
 set(LLVM_ENABLE_ZLIB "OFF" CACHE STRING "")
 set(LLVM_ENABLE_ZSTD "OFF" CACHE STRING "")
 
+set(LLVM_ENABLE_RUNTIMES compiler-rt CACHE STRING "")
+
+set(LLVM_BUILTIN_TARGETS mos-unknown-unknown CACHE STRING "")
+set(LLVM_RUNTIME_TARGETS mos-unknown-unknown CACHE STRING "")
+set(BUILTINS_mos-unknown-unknown_COMPILER_RT_BAREMETAL_BUILD ON CACHE BOOL "")
+set(RUNTIMES_mos-unknown-unknown_CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY CACHE STRING "")
+
 set(LLVM_DEFAULT_TARGET_TRIPLE "mos-unknown-unknown" CACHE STRING "")
 
 # The following option is principally to reduce space on Github action runner

--- a/clang/lib/Basic/Targets/MOS.cpp
+++ b/clang/lib/Basic/Targets/MOS.cpp
@@ -196,6 +196,7 @@ void MOSTargetInfo::getTargetDefines(const LangOptions &Opts,
                                      MacroBuilder &Builder) const {
   Builder.defineMacro("__mos__");
   Builder.defineMacro("__ELF__");
+  Builder.defineMacro("__SOFTFP__");
 
   // Generate instruction feature set macros.
   const auto &CPUDefines = llvm::StringSwitch<std::vector<std::string>>(CPUName)

--- a/compiler-rt/cmake/builtin-config-ix.cmake
+++ b/compiler-rt/cmake/builtin-config-ix.cmake
@@ -54,6 +54,7 @@ set(HEXAGON hexagon)
 set(X86 i386)
 set(X86_64 x86_64)
 set(LOONGARCH64 loongarch64)
+set(MOS mos)
 set(MIPS32 mips mipsel)
 set(MIPS64 mips64 mips64el)
 set(PPC32 powerpc powerpcspe)
@@ -74,7 +75,7 @@ endif()
 
 set(ALL_BUILTIN_SUPPORTED_ARCH
   ${X86} ${X86_64} ${ARM32} ${ARM64} ${AVR}
-  ${HEXAGON} ${MIPS32} ${MIPS64} ${PPC32} ${PPC64}
+  ${HEXAGON} ${MIPS32} ${MIPS64} ${MOS} ${PPC32} ${PPC64}
   ${RISCV32} ${RISCV64} ${SPARC} ${SPARCV9}
   ${WASM32} ${WASM64} ${VE} ${LOONGARCH64})
 

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -678,6 +678,8 @@ set(mips64_SOURCES ${GENERIC_TF_SOURCES}
 set(mips64el_SOURCES ${GENERIC_TF_SOURCES}
                      ${mips_SOURCES})
 
+set(mos_SOURCES ${GENERIC_SOURCES})
+
 set(powerpc_SOURCES ${GENERIC_SOURCES})
 
 set(powerpcspe_SOURCES ${GENERIC_SOURCES})

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -929,6 +929,10 @@ if (COMPILER_RT_BUILD_CRT)
   endif()
 
   foreach(arch ${BUILTIN_SUPPORTED_ARCH})
+    if (arch STREQUAL mos)
+      continue()
+    endif()
+
     add_compiler_rt_runtime(clang_rt.crtbegin
       OBJECT
       ARCHS ${arch}

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -679,6 +679,27 @@ set(mips64el_SOURCES ${GENERIC_TF_SOURCES}
                      ${mips_SOURCES})
 
 set(mos_SOURCES ${GENERIC_SOURCES})
+# MOS SDK integer division is already smaller and faster
+list(REMOVE_ITEM mos_SOURCES
+  divdi3.c
+  divmoddi4.c
+  divmodsi4.c
+  divmodti4.c
+  divsi3.c
+  divti3.c
+  moddi3.c
+  modsi3.c
+  modti3.c
+  udivdi3.c
+  udivmoddi4.c
+  udivmodsi4.c
+  udivmodti4.c
+  udivsi3.c
+  udivti3.c
+  umoddi3.c
+  umodsi3.c
+  umodti3.c
+)
 
 set(powerpc_SOURCES ${GENERIC_SOURCES})
 


### PR DESCRIPTION
This adds a build of compiler-rt's builtins (libclang_rt.a), a libgcc replacement. We disable crt0 and integer division libcalls, since the versions already in the SDK are better tuned for the 6502. We gain mostly encyclopedic coverage of libgcc and a license unencumbered soft float library, albeit one also poorly optimized for the 6502.