### PR TITLE
Strict inlining costs

### DIFF
--- a/llvm/include/llvm/Analysis/TargetTransformInfo.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfo.h
@@ -370,6 +370,14 @@ public:
   /// scientific. A target may has no bonus on vector instructions.
   int getInlinerVectorBonusPercent() const;
 
+  /// \returns Whether inlining costs should be boosted or taken as law.
+  ///
+  /// Some targets typically have extreme size constraints; in such cases,
+  /// inlining may be inappropriate even if it provides a great runtime benefit.
+  /// If true, the inlining costs are always compared directly against the
+  /// threshold; boosts for desireable runtime benefits are not applied.
+  bool strictInliningCosts() const;
+
   /// \return the expected cost of a memcpy, which could e.g. depend on the
   /// source/destination type and alignment and the number of bytes copied.
   InstructionCost getMemcpyCost(const Instruction *I) const;
@@ -1746,6 +1754,7 @@ public:
   getInliningCostBenefitAnalysisProfitableMultiplier() const = 0;
   virtual unsigned adjustInliningThreshold(const CallBase *CB) = 0;
   virtual int getInlinerVectorBonusPercent() const = 0;
+  virtual bool strictInliningCosts() const = 0;
   virtual unsigned getCallerAllocaCost(const CallBase *CB,
                                        const AllocaInst *AI) const = 0;
   virtual InstructionCost getMemcpyCost(const Instruction *I) = 0;
@@ -2135,6 +2144,9 @@ public:
   }
   int getInlinerVectorBonusPercent() const override {
     return Impl.getInlinerVectorBonusPercent();
+  }
+  bool strictInliningCosts() const override {
+    return Impl.strictInliningCosts();
   }
   unsigned getCallerAllocaCost(const CallBase *CB,
                                const AllocaInst *AI) const override {

--- a/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
@@ -79,6 +79,7 @@ public:
   };
 
   int getInlinerVectorBonusPercent() const { return 150; }
+  bool strictInliningCosts() const { return false; }
 
   InstructionCost getMemcpyCost(const Instruction *I) const {
     return TTI::TCC_Expensive;

--- a/llvm/include/llvm/CodeGen/BasicTTIImpl.h
+++ b/llvm/include/llvm/CodeGen/BasicTTIImpl.h
@@ -568,6 +568,7 @@ public:
   }
 
   int getInlinerVectorBonusPercent() const { return 150; }
+  bool strictInliningCosts() const { return false; }
 
   void getUnrollingPreferences(Loop *L, ScalarEvolution &SE,
                                TTI::UnrollingPreferences &UP,

--- a/llvm/lib/Analysis/InlineCost.cpp
+++ b/llvm/lib/Analysis/InlineCost.cpp
@@ -680,7 +680,7 @@ class InlineCostCallAnalyzer final : public CallAnalyzer {
     // during devirtualization and so we want to give it a hefty bonus for
     // inlining, but cap that bonus in the event that inlining wouldn't pan out.
     // Pretend to inline the function, with a custom threshold.
-    if (IsIndirectCall && BoostIndirectCalls) {
+    if (IsIndirectCall && BoostIndirectCalls && !TTI.strictInliningCosts()) {
       auto IndirectCallParams = Params;
       IndirectCallParams.DefaultThreshold =
           InlineConstants::IndirectCallThreshold;

--- a/llvm/lib/Analysis/TargetTransformInfo.cpp
+++ b/llvm/lib/Analysis/TargetTransformInfo.cpp
@@ -237,6 +237,10 @@ int TargetTransformInfo::getInlinerVectorBonusPercent() const {
   return TTIImpl->getInlinerVectorBonusPercent();
 }
 
+bool TargetTransformInfo::strictInliningCosts() const {
+  return TTIImpl->strictInliningCosts();
+}
+
 InstructionCost TargetTransformInfo::getGEPCost(
     Type *PointeeType, const Value *Ptr, ArrayRef<const Value *> Operands,
     Type *AccessType, TTI::TargetCostKind CostKind) const {

--- a/llvm/lib/Target/MOS/MOSTargetTransformInfo.h
+++ b/llvm/lib/Target/MOS/MOSTargetTransformInfo.h
@@ -60,6 +60,8 @@ public:
   bool isValidAddrSpaceCast(unsigned FromAS, unsigned ToAS) const {
     return true;
   }
+
+  bool strictInliningCosts() const { return true; }
 };
 
 } // end namespace llvm


### PR DESCRIPTION
The inliner will apply negative boosts to inlining costs if runtime
desirable situations occur. In particular, inlining is strongly
preferred if an indirect call can be folded away as a result.
Unfortunatley, this can blow up sizes on the 6502 arbitrarily, and
worse, it affects our printf implementation.

This change adds a new TTI hook, strictInliningCosts(), that prevents
this boost from altering the true costs. Size is paramount for our
target, so we should disable other boosts using this flag as they cause
problems.
