### PR TITLE
Internalize libcalls and GC

### DIFF
--- a/clang/lib/Driver/ToolChains/MOS.cpp
+++ b/clang/lib/Driver/ToolChains/MOS.cpp
@@ -71,12 +71,14 @@ void mos::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   auto &TC = static_cast<const toolchains::MOS &>(getToolChain());
   auto &D = TC.getDriver();
 
+  // Pass defaults before AddLinkerInputs, since that includes -Wl
+  // options, which should override these.
+  CmdArgs.push_back("--gc-sections");
+  CmdArgs.push_back("--sort-section=alignment");
+
   AddLinkerInputs(TC, Inputs, Args, CmdArgs, JA);
 
   AddLTOOptions(TC, Args, Output, Inputs, CmdArgs);
-
-  CmdArgs.push_back("--gc-sections");
-  CmdArgs.push_back("--sort-section=alignment");
 
   if (!D.SysRoot.empty())
     CmdArgs.push_back(Args.MakeArgString("--sysroot=" + D.SysRoot));

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -883,9 +883,8 @@ else ()
         list(APPEND BUILTIN_CFLAGS_${arch} -fforce-enable-int128)
       endif()
 
-      # MOS builtins can be called inside interrupts and are no-LTO.
       if (${arch} STREQUAL "mos")
-        list(APPEND BUILTIN_CFLAGS_${arch} -fno-static-stack)
+        list(APPEND BUILTIN_CFLAGS_${arch} -flto)
       endif()
 
       add_compiler_rt_runtime(clang_rt.builtins

--- a/llvm/include/llvm/LTO/LTO.h
+++ b/llvm/include/llvm/LTO/LTO.h
@@ -156,6 +156,7 @@ public:
     using irsymtab::Symbol::getSectionName;
     using irsymtab::Symbol::isExecutable;
     using irsymtab::Symbol::isUsed;
+    using irsymtab::Symbol::isPreserved;
   };
 
   /// A range over the symbols in this InputFile.
@@ -388,6 +389,8 @@ private:
     /// Any partitioning of the combined LTO object is done internally by the
     /// LTO backend.
     unsigned Partition = Unknown;
+
+    bool Contingent = false;
 
     /// Special partition numbers.
     enum : unsigned {

--- a/llvm/include/llvm/Object/IRSymtab.h
+++ b/llvm/include/llvm/Object/IRSymtab.h
@@ -114,6 +114,7 @@ struct Symbol {
     FB_format_specific,
     FB_unnamed_addr,
     FB_executable,
+    FB_preserved,
   };
 };
 
@@ -210,6 +211,8 @@ struct Symbol {
   bool isFormatSpecific() const { return (Flags >> S::FB_format_specific) & 1; }
   bool isUnnamedAddr() const { return (Flags >> S::FB_unnamed_addr) & 1; }
   bool isExecutable() const { return (Flags >> S::FB_executable) & 1; }
+
+  bool isPreserved() const { return (Flags >> S::FB_preserved) & 1; }
 
   uint64_t getCommonSize() const {
     assert(isCommon());

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -296,7 +296,7 @@ static void
 addUsedSymbolToPreservedGUID(const lto::InputFile &File,
                              DenseSet<GlobalValue::GUID> &PreservedGUID) {
   for (const auto &Sym : File.symbols()) {
-    if (Sym.isUsed())
+    if (Sym.isUsed() || Sym.isPreserved())
       PreservedGUID.insert(GlobalValue::getGUID(Sym.getIRName()));
   }
 }

--- a/llvm/lib/Object/IRSymtab.cpp
+++ b/llvm/lib/Object/IRSymtab.cpp
@@ -291,8 +291,10 @@ Error Builder::addSymbol(const ModuleSymbolTable &Msymtab,
       buildPreservedSymbolsSet();
   bool IsPreservedSymbol = PreservedSymbolsSet.contains(GV->getName());
 
-  if (Used.count(GV) || IsPreservedSymbol)
+  if (Used.count(GV))
     Sym.Flags |= 1 << storage::Symbol::FB_used;
+  if (IsPreservedSymbol)
+    Sym.Flags |= 1 << storage::Symbol::FB_preserved;
   if (GV->isThreadLocal())
     Sym.Flags |= 1 << storage::Symbol::FB_tls;
   if (GV->hasGlobalUnnamedAddr())

--- a/llvm/lib/Target/MOS/CMakeLists.txt
+++ b/llvm/lib/Target/MOS/CMakeLists.txt
@@ -26,15 +26,16 @@ add_llvm_target(MOSCodeGen
   MOSCallingConv.cpp
   MOSCombiner.cpp
   MOSCopyOpt.cpp
-  MOSInstrCost.cpp
   MOSFrameLowering.cpp
   MOSISelLowering.cpp
+  MOSIncDecPhi.cpp
   MOSIndexIV.cpp
   MOSInlineAsmLowering.cpp
-  MOSIncDecPhi.cpp
   MOSInsertCopies.cpp
+  MOSInstrCost.cpp
   MOSInstrInfo.cpp
   MOSInstructionSelector.cpp
+  MOSInternalize.cpp
   MOSLateOptimization.cpp
   MOSLegalizerInfo.cpp
   MOSLowerSelect.cpp

--- a/llvm/lib/Target/MOS/MOS.h
+++ b/llvm/lib/Target/MOS/MOS.h
@@ -24,6 +24,7 @@ void initializeMOSCopyOptPass(PassRegistry &);
 void initializeMOSIncDecPhiPass(PassRegistry &);
 void initializeMOSIndexIVPass(PassRegistry &);
 void initializeMOSInsertCopiesPass(PassRegistry &);
+void initializeMOSInternalizePass(PassRegistry &);
 void initializeMOSLateOptimizationPass(PassRegistry &);
 void initializeMOSLowerSelectPass(PassRegistry &);
 void initializeMOSNonReentrantPass(PassRegistry &);

--- a/llvm/lib/Target/MOS/MOSCallGraphUtils.h
+++ b/llvm/lib/Target/MOS/MOSCallGraphUtils.h
@@ -17,12 +17,20 @@
 #ifndef LLVM_LIB_TARGET_MOS_MOSCALLGRAPHUTILS_H
 #define LLVM_LIB_TARGET_MOS_MOSCALLGRAPHUTILS_H
 
+#include "llvm/ADT/StringRef.h"
+
 namespace llvm {
 
 class CallGraph;
+class Function;
 class MachineModuleInfo;
+class Module;
 
 namespace mos {
+
+// Returns the function that an symbol reference will ultimately resolve to,
+// looking through aliases and pointer casts.
+Function *getSymbolFunction(Module &M, StringRef Name);
 
 // Collect libcalls and added edges for them to the call graph.
 //

--- a/llvm/lib/Target/MOS/MOSInternalize.cpp
+++ b/llvm/lib/Target/MOS/MOSInternalize.cpp
@@ -1,0 +1,172 @@
+//===-- MOSInternalize.cpp - MOS Libcall Internalization ------------------===//
+//
+// Part of LLVM-MOS, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the MOS library call internalization pass.
+//
+// Since library calls can benefit from static stacks and zero page, it's
+// ideal to include them in the main LTO unit of the program. However, library
+// calls may not exist until legalization occurs, which is far after global
+// interprocedural dead code elimination would typically strip them out.
+//
+// Accordingly, this pass runs after legalization and internalizes any library
+// calls that have liveness contingent on a call being emitted by the legalizer,
+// but where no calls were actually emitted. The pass then runs dead code
+// elimination to strip out such functions and cleans up any data structures
+// that refer to them.
+//
+//===----------------------------------------------------------------------===//
+
+#include "MOSInternalize.h"
+
+#include "MOS.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineInstr.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/MachineOperand.h"
+#include "llvm/IR/GlobalValue.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
+#include "llvm/Transforms/IPO/GlobalDCE.h"
+
+#define DEBUG_TYPE "mos-internalize"
+
+using namespace llvm;
+
+namespace {
+
+class MOSInternalize : public ModulePass {
+  MachineModuleInfo *MMI;
+
+public:
+  static char ID;
+
+  MOSInternalize() : ModulePass(ID) {
+    llvm::initializeMOSInternalizePass(*PassRegistry::getPassRegistry());
+  }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override;
+
+  bool runOnModule(Module &M) override;
+
+  DenseMap<std::pair<Function *, GlobalValue *>, Instruction *>
+  insertDummyIRLibcalls(Module &M) const;
+
+  void eraseDummyIRLibcalls(
+      DenseMap<std::pair<Function *, GlobalValue *>, Instruction *>
+          DummyIRLibcalls,
+      const DenseSet<Function *> &ErasedFunctions) const;
+};
+
+} // namespace
+
+void MOSInternalize::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.addRequired<MachineModuleInfoWrapperPass>();
+  AU.addPreserved<MachineModuleInfoWrapperPass>();
+}
+
+bool MOSInternalize::runOnModule(Module &M) {
+  MMI = &getAnalysis<MachineModuleInfoWrapperPass>().getMMI();
+
+  DenseMap<std::pair<Function *, GlobalValue *>, Instruction *>
+      DummyIRLibcalls = insertDummyIRLibcalls(M);
+  if (DummyIRLibcalls.empty())
+    return false;
+
+  for (GlobalValue &GV : M.global_values()) {
+    if (GV.getPartition() != "contingent")
+      continue;
+    // These may be used in BSS zeroing and data copying, which may not be
+    // discovered until the final LTO assembly is emitted.
+    if (GV.getName() == "__memset" || GV.getName() == "memcpy")
+      continue;
+    GV.setPartition("");
+    GV.setLinkage(llvm::GlobalValue::InternalLinkage);
+  }
+
+  DenseSet<Function *> ErasedFunctions;
+  for (Function &F : M)
+    ErasedFunctions.insert(&F);
+
+  GlobalDCEPass DCE;
+  ModuleAnalysisManager AM;
+  DCE.run(M, AM);
+
+  for (Function &F : M)
+    ErasedFunctions.erase(&F);
+
+  for (Function *F : ErasedFunctions)
+    MMI->deleteMachineFunctionFor(*F);
+
+  eraseDummyIRLibcalls(std::move(DummyIRLibcalls), ErasedFunctions);
+
+  return true;
+}
+
+DenseMap<std::pair<Function *, GlobalValue *>, Instruction *>
+MOSInternalize::insertDummyIRLibcalls(Module &M) const {
+  DenseMap<std::pair<Function *, GlobalValue *>, Instruction *> DummyIRLibcalls;
+
+  for (Function &F : M) {
+    const MachineFunction *MF = MMI->getMachineFunction(F);
+    if (!MF)
+      continue;
+
+    for (const MachineBasicBlock &MBB : *MF) {
+      for (const MachineInstr &MI : MBB) {
+        if (!MI.isCall())
+          continue;
+        for (const MachineOperand &MO : MI.operands()) {
+          if (!MO.isSymbol())
+            continue;
+
+          GlobalValue *Callee = M.getFunction(MO.getSymbolName());
+          if (!Callee)
+            Callee = M.getNamedAlias(MO.getSymbolName());
+          if (!Callee || Callee->getPartition() != "contingent")
+            continue;
+
+          IRBuilder<> Builder(&F.getEntryBlock());
+          std::pair<Function *, GlobalValue *> KV = {&F, Callee};
+          if (DummyIRLibcalls.contains(KV))
+            continue;
+          auto Res = DummyIRLibcalls.try_emplace(
+              KV, Builder.CreateCall(
+                      FunctionType::get(Type::getVoidTy(F.getContext()),
+                                        /*isVarArg=*/false),
+                      Callee));
+          (void)Res;
+          assert(Res.second);
+        }
+      }
+    }
+  }
+
+  return DummyIRLibcalls;
+}
+
+void MOSInternalize::eraseDummyIRLibcalls(
+    DenseMap<std::pair<Function *, GlobalValue *>, Instruction *>
+        DummyIRLibcalls,
+    const DenseSet<Function *> &ErasedFunctions) const {
+  for (const auto &KV : DummyIRLibcalls) {
+    Function *Caller = KV.first.first;
+    Instruction *I = KV.second;
+    if (ErasedFunctions.contains(Caller))
+      continue;
+    I->eraseFromParent();
+  }
+}
+
+char MOSInternalize::ID = 0;
+
+INITIALIZE_PASS(MOSInternalize, DEBUG_TYPE, "MOS internalize libcalls", false,
+                false)
+
+ModulePass *llvm::createMOSInternalizePass() { return new MOSInternalize(); }

--- a/llvm/lib/Target/MOS/MOSInternalize.h
+++ b/llvm/lib/Target/MOS/MOSInternalize.h
@@ -1,0 +1,24 @@
+//===-- MOSInternalize.h - MOS Libcall Internalization ----------*- C++ -*-===//
+//
+// Part of LLVM-MOS, under the Apache License v2.n with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the MOS library call internalization pass.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_MOS_MOSINTERNALIZE_H
+#define LLVM_LIB_TARGET_MOS_MOSINTERNALIZE_H
+
+namespace llvm {
+
+class ModulePass;
+
+ModulePass *createMOSInternalizePass();
+
+} // namespace llvm
+
+#endif // not LLVM_LIB_TARGET_MOS_MOSINTERNALIZE_H

--- a/llvm/lib/Target/MOS/MOSTargetMachine.cpp
+++ b/llvm/lib/Target/MOS/MOSTargetMachine.cpp
@@ -38,6 +38,7 @@
 #include "MOSIncDecPhi.h"
 #include "MOSIndexIV.h"
 #include "MOSInsertCopies.h"
+#include "MOSInternalize.h"
 #include "MOSLateOptimization.h"
 #include "MOSLowerSelect.h"
 #include "MOSMachineFunctionInfo.h"
@@ -62,6 +63,7 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeMOSTarget() {
   initializeMOSCopyOptPass(PR);
   initializeMOSIncDecPhiPass(PR);
   initializeMOSInsertCopiesPass(PR);
+  initializeMOSInternalizePass(PR);
   initializeMOSLateOptimizationPass(PR);
   initializeMOSLowerSelectPass(PR);
   initializeMOSNonReentrantPass(PR);
@@ -249,6 +251,7 @@ void MOSPassConfig::addPreLegalizeMachineIR() {
 
 bool MOSPassConfig::addLegalizeMachineIR() {
   addPass(new Legalizer());
+  addPass(createMOSInternalizePass());
   return false;
 }
 

--- a/llvm/lib/Target/MOS/MOSZeroPageAlloc.cpp
+++ b/llvm/lib/Target/MOS/MOSZeroPageAlloc.cpp
@@ -256,7 +256,7 @@ void MOSZeroPageAlloc::getAnalysisUsage(AnalysisUsage &AU) const {
 }
 
 } // namespace
-  
+
 static float getFreq(const BlockFrequencyInfo &BFI, MachineBasicBlock &MBB);
 
 bool MOSZeroPageAlloc::runOnModule(Module &M) {
@@ -716,7 +716,7 @@ std::vector<EntryGraph> MOSZeroPageAlloc::buildEntryGraphs(Module &M,
               if (MO.isGlobal())
                 Callee = dyn_cast<Function>(MO.getGlobal());
               else if (MO.isSymbol())
-                Callee = M.getFunction(MO.getSymbolName());
+                Callee = mos::getSymbolFunction(M, MO.getSymbolName());
               if (!Callee)
                 continue;
               float Freq = getFreq(BFI, MBB);

--- a/llvm/test/CodeGen/MOS/internalize.mir
+++ b/llvm/test/CodeGen/MOS/internalize.mir
@@ -1,0 +1,76 @@
+# RUN: llc -mtriple=mos -run-pass=mos-internalize -verify-machineinstrs -o - %s | FileCheck %s
+# CHECK: @used_alias = internal alias void (), ptr @used_contingent
+# CHECK-NOT: @unused_contingent()
+# CHECK: define internal void @used_contingent() {
+# CHECK-NOT: define void @used_only_by_unused_contingent() {
+# CHECK: define internal void @used_by_used_contingent() {
+# CHECK-NOT: @alias
+# CHECK: define void @user() {
+--- |
+  define void @unused_contingent() partition "contingent" {
+    entry:
+      ret void
+  }
+
+  define void @used_contingent() partition "contingent" {
+    entry:
+      ret void
+  }
+
+  define void @used_only_by_unused_contingent() partition "contingent" {
+    entry:
+      ret void
+  }
+
+  define void @used_by_used_contingent() partition "contingent" {
+    entry:
+      ret void
+  }
+
+  @unused_alias = alias void (), ptr @unused_contingent, partition "contingent"
+  @used_alias = alias void (), ptr @used_contingent, partition "contingent"
+
+  define void @user() {
+    entry:
+      ret void
+  }
+...
+---
+# CHECK-NOT: name: unused_contingent
+name: unused_contingent
+body: |
+  bb.0.entry:
+    JSR &used_only_by_unused_contingent
+    RTS
+...
+---
+# CHECK: name: used_contingent
+name: used_contingent
+body: |
+  bb.0.entry:
+    JSR &used_by_used_contingent
+    RTS
+...
+---
+# CHECK-NOT: name: used_only_by_unused_contingent
+name: used_only_by_unused_contingent
+body: |
+  bb.0.entry:
+    RTS
+...
+---
+# CHECK: name: used_by_used_contingent
+name: used_by_used_contingent
+body: |
+  bb.0.entry:
+    RTS
+...
+---
+# CHECK: name: user
+name: user
+body: |
+  bb.0.entry:
+    JSR &used_contingent
+    JSR &used_alias
+    RTS
+...


### PR DESCRIPTION
Code generation can emit calls to C functions as part of the lowering of
IR operations. Ideally the implementations of these would be visible to
LTO: that allows them to use static stacks and the zero page. However,
unused libcalls would be kept in the binary until GC-ed away by the
linker. This isn't ideal, since it disrupts the true static stack and
zero page allocation process.

This change records whenever a libcall is only present because it might be
used as a libcall (i.e., no other references exist to it, either inside
or outside LTO). The new MOSInternalize pass then internalizes these
"contingent" libcalls, adds fake IR calls for each observed library
call, then runs Global Dead Code Elimination. Finally, the fake IR calls
are stripped, which pulls out any unused functions from the compile
before anything is allocated for it.

This allows us to move the floating point libcalls (et al) to LTO.
