### PR TITLE
MOS Interrupts: Add the wedge attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1869,6 +1869,13 @@ def MOSNoISR : InheritableAttr, TargetSpecificAttr<TargetMOS> {
   let Documentation = [Undocumented];
 }
 
+def MOSWedge : InheritableAttr, TargetSpecificAttr<TargetMOS> {
+  let Spellings = [GCC<"wedge">];
+  let Args = [UnsignedArgument<"ChainISR">];
+  let Subjects = SubjectList<[HasFunctionProto]>;
+  let Documentation = [Undocumented];
+}
+
 def Reentrant : InheritableAttr {
   let Spellings = [GCC<"reentrant">];
   let Subjects = SubjectList<[Function]>;

--- a/clang/lib/CodeGen/Targets/MOS.cpp
+++ b/clang/lib/CodeGen/Targets/MOS.cpp
@@ -54,6 +54,10 @@ public:
       Fn->addFnAttr("interrupt");
     if (FD->getAttr<MOSInterruptNorecurseAttr>())
       Fn->addFnAttr("interrupt-norecurse");
+    if (FD->getAttr<MOSWedgeAttr>()) {
+      auto mosattr = D->getAttr<MOSWedgeAttr>();
+      Fn->addFnAttr("wedge", llvm::utostr(mosattr->getChainISR()));
+    }
     if (FD->getAttr<MOSNoISRAttr>())
       Fn->addFnAttr("no-isr");
   }

--- a/clang/test/CodeGen/mos-interrupt.c
+++ b/clang/test/CodeGen/mos-interrupt.c
@@ -8,11 +8,16 @@ __attribute__((interrupt)) void interrupt(void) {
 __attribute__((interrupt_norecurse)) void interrupt_norecurse(void) {
 }
 
+// CHECK-LABEL: define dso_local void @interrupt_wedge local_unnamed_addr #1 {
+__attribute__((wedge((void*)(0x0)))) void wedge(void) {
+}
+
 // CHECK-LABEL: define dso_local void @no_isr() local_unnamed_addr #2 {
 __attribute__((interrupt, no_isr)) void no_isr(void) {
 }
 
 // CHECK: attributes #0 = { {{.*}} "interrupt" {{.*}} }
 // CHECK: attributes #1 = { {{.*}} "interrupt-norecurse" {{.*}} }
-// CHECK: attributes #2 = { {{.*}} "interrupt"{{.*}}"no-isr" {{.*}} }
+// CHECK: attributes #2 = { {{.*}} "interrupt"{{.*}}"wedge" {{.*}} }
+// CHECK: attributes #3 = { {{.*}} "interrupt"{{.*}}"no-isr" {{.*}} }
 

--- a/llvm/lib/Target/MOS/MOSFrameLowering.cpp
+++ b/llvm/lib/Target/MOS/MOSFrameLowering.cpp
@@ -421,5 +421,11 @@ bool MOSFrameLowering::isISR(const MachineFunction &MF) const {
   if (F.hasFnAttribute("no-isr"))
     return false;
   return F.hasFnAttribute("interrupt") ||
-         F.hasFnAttribute("interrupt-norecurse");
+         F.hasFnAttribute("interrupt-norecurse") ||
+         F.hasFnAttribute("interrupt-wedge");
+}
+
+bool MOSFrameLowering::isWedgeISR(const MachineFunction &MF) const {
+  const Function &F = MF.getFunction();
+  return F.hasFnAttribute("wedge");
 }

--- a/llvm/lib/Target/MOS/MOSFrameLowering.h
+++ b/llvm/lib/Target/MOS/MOSFrameLowering.h
@@ -64,6 +64,9 @@ public:
   // Return whether or not the function is a direct ISR.
   bool isISR(const MachineFunction& MF) const;
 
+  // Return whether or not the function is a wedge ISR.
+  bool isWedgeISR(const MachineFunction& MF) const;
+
 private:
   void offsetSP(MachineIRBuilder &Builder, int64_t Offset) const;
 };

--- a/llvm/lib/Target/MOS/MOSNonReentrant.cpp
+++ b/llvm/lib/Target/MOS/MOSNonReentrant.cpp
@@ -83,7 +83,7 @@ bool MOSNonReentrantImpl::run(Module &M) {
 
   // Mark all functions reachable from an interrupt function as non-reentrant.
   for (Function &F : M.functions()) {
-    if (F.hasFnAttribute("interrupt")) {
+    if (F.hasFnAttribute("interrupt") || F.hasFnAttribute("interrupt-wedge")) {
       HasInterrupts = true;
       markReentrant(*CG[&F]);
     }

--- a/llvm/test/CodeGen/MOS/zp-alloc.ll
+++ b/llvm/test/CodeGen/MOS/zp-alloc.ll
@@ -248,6 +248,117 @@ entry:
   ret void
 }
 
+define void @inr() wedge "interrupt-wedge" {
+; CHECK-LABEL: inr:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    cld
+; CHECK-NEXT:    pha
+; CHECK-NEXT:    clc
+; CHECK-NEXT:    lda __rc1
+; CHECK-NEXT:    adc #255
+; CHECK-NEXT:    sta __rc1
+; CHECK-NEXT:    pla
+; CHECK-NEXT:    pha
+; CHECK-NEXT:    txa
+; CHECK-NEXT:    pha
+; CHECK-NEXT:    tya
+; CHECK-NEXT:    pha
+; CHECK-NEXT:    lda __rc2
+; CHECK-NEXT:    pha
+; CHECK-NEXT:    ldx __rc3
+; CHECK-NEXT:    stx .Linr_sstk ; 1-byte Folded Spill
+; CHECK-NEXT:    ldx __rc4
+; CHECK-NEXT:    stx .Linr_sstk+1 ; 1-byte Folded Spill
+; CHECK-NEXT:    ldx __rc5
+; CHECK-NEXT:    stx .Linr_sstk+2 ; 1-byte Folded Spill
+; CHECK-NEXT:    ldx __rc6
+; CHECK-NEXT:    stx .Linr_sstk+3 ; 1-byte Folded Spill
+; CHECK-NEXT:    ldx __rc7
+; CHECK-NEXT:    stx .Linr_sstk+4 ; 1-byte Folded Spill
+; CHECK-NEXT:    ldx __rc8
+; CHECK-NEXT:    stx .Linr_sstk+5 ; 1-byte Folded Spill
+; CHECK-NEXT:    ldx __rc9
+; CHECK-NEXT:    stx .Linr_sstk+6 ; 1-byte Folded Spill
+; CHECK-NEXT:    ldx __rc10
+; CHECK-NEXT:    stx .Linr_sstk+7 ; 1-byte Folded Spill
+; CHECK-NEXT:    ldx __rc11
+; CHECK-NEXT:    stx .Linr_sstk+8 ; 1-byte Folded Spill
+; CHECK-NEXT:    ldx __rc12
+; CHECK-NEXT:    stx .Linr_sstk+9 ; 1-byte Folded Spill
+; CHECK-NEXT:    ldx __rc13
+; CHECK-NEXT:    stx .Linr_sstk+10 ; 1-byte Folded Spill
+; CHECK-NEXT:    ldx __rc14
+; CHECK-NEXT:    stx .Linr_sstk+11 ; 1-byte Folded Spill
+; CHECK-NEXT:    ldx __rc15
+; CHECK-NEXT:    stx .Linr_sstk+12 ; 1-byte Folded Spill
+; CHECK-NEXT:    ldx __rc16
+; CHECK-NEXT:    stx .Linr_sstk+13 ; 1-byte Folded Spill
+; CHECK-NEXT:    ldx __rc17
+; CHECK-NEXT:    stx .Linr_sstk+14 ; 1-byte Folded Spill
+; CHECK-NEXT:    ldx __rc18
+; CHECK-NEXT:    stx .Linr_sstk+15 ; 1-byte Folded Spill
+; CHECK-NEXT:    ldx __rc19
+; CHECK-NEXT:    stx .Linr_sstk+16 ; 1-byte Folded Spill
+; CHECK-NEXT:    ldx global
+; CHECK-NEXT:    stx mos8(.Linr_zp_stk) ; 1-byte Folded Spill
+; CHECK-NEXT:    jsr inr_callee
+; CHECK-NEXT:    ldx mos8(.Linr_zp_stk) ; 1-byte Folded Reload
+; CHECK-NEXT:    stx mos8(vol)
+; CHECK-NEXT:    ldx .Linr_sstk+16 ; 1-byte Folded Reload
+; CHECK-NEXT:    stx __rc19
+; CHECK-NEXT:    ldx .Linr_sstk+15 ; 1-byte Folded Reload
+; CHECK-NEXT:    stx __rc18
+; CHECK-NEXT:    ldx .Linr_sstk+14 ; 1-byte Folded Reload
+; CHECK-NEXT:    stx __rc17
+; CHECK-NEXT:    ldx .Linr_sstk+13 ; 1-byte Folded Reload
+; CHECK-NEXT:    stx __rc16
+; CHECK-NEXT:    ldx .Linr_sstk+12 ; 1-byte Folded Reload
+; CHECK-NEXT:    stx __rc15
+; CHECK-NEXT:    ldx .Linr_sstk+11 ; 1-byte Folded Reload
+; CHECK-NEXT:    stx __rc14
+; CHECK-NEXT:    ldx .Linr_sstk+10 ; 1-byte Folded Reload
+; CHECK-NEXT:    stx __rc13
+; CHECK-NEXT:    ldx .Linr_sstk+9 ; 1-byte Folded Reload
+; CHECK-NEXT:    stx __rc12
+; CHECK-NEXT:    ldx .Linr_sstk+8 ; 1-byte Folded Reload
+; CHECK-NEXT:    stx __rc11
+; CHECK-NEXT:    ldx .Linr_sstk+7 ; 1-byte Folded Reload
+; CHECK-NEXT:    stx __rc10
+; CHECK-NEXT:    ldx .Linr_sstk+6 ; 1-byte Folded Reload
+; CHECK-NEXT:    stx __rc9
+; CHECK-NEXT:    ldx .Linr_sstk+5 ; 1-byte Folded Reload
+; CHECK-NEXT:    stx __rc8
+; CHECK-NEXT:    ldx .Linr_sstk+4 ; 1-byte Folded Reload
+; CHECK-NEXT:    stx __rc7
+; CHECK-NEXT:    ldx .Linr_sstk+3 ; 1-byte Folded Reload
+; CHECK-NEXT:    stx __rc6
+; CHECK-NEXT:    ldx .Linr_sstk+2 ; 1-byte Folded Reload
+; CHECK-NEXT:    stx __rc5
+; CHECK-NEXT:    ldx .Linr_sstk+1 ; 1-byte Folded Reload
+; CHECK-NEXT:    stx __rc4
+; CHECK-NEXT:    ldx .Linr_sstk ; 1-byte Folded Reload
+; CHECK-NEXT:    stx __rc3
+; CHECK-NEXT:    pla
+; CHECK-NEXT:    sta __rc2
+; CHECK-NEXT:    pla
+; CHECK-NEXT:    tay
+; CHECK-NEXT:    pla
+; CHECK-NEXT:    tax
+; CHECK-NEXT:    pla
+; CHECK-NEXT:    pha
+; CHECK-NEXT:    clc
+; CHECK-NEXT:    lda __rc1
+; CHECK-NEXT:    adc #1
+; CHECK-NEXT:    sta __rc1
+; CHECK-NEXT:    pla
+; CHECK-NEXT:    jmp $0000
+entry:
+  %0 = load i8, ptr @global, align 1
+  call void @inr_callee();
+  store volatile i8 %0, ptr @vol, align 1
+  ret void
+}
+
 define void @inr_callee() norecurse noinline {
 ; CHECK-LABEL: inr_callee:
 ; CHECK:       ; %bb.0: ; %entry


### PR DESCRIPTION
This allows us to end ISRs with a TailJMP instruction instead of the usual RTI or RTS. This allows for ISRs that are partially defined in the platform's ROM to be continued using a "wedge" style interrupt mechanism, like what is typically required for Commodore machines.

`wedge` takes an argument that is the vector to jump back to, which is the immediate argument to the TailJMP instruction emitted in the call lowering. `wedge` is expected to be used with the normal `interrupt` or `interrupt_norecurse` attributes.