### PR TITLE
Use Apple Silicon for CI/CD

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -18,7 +18,7 @@ on:
       python_version:
         required: false
         type: string
-        default: '3.11'
+        default: "3.11"
   workflow_call:
     inputs:
       build_target:
@@ -39,12 +39,12 @@ on:
         type: string
         # Use windows-2019 due to:
         # https://developercommunity.visualstudio.com/t/Prev-Issue---with-__assume-isnan-/1597317
-        default: '["ubuntu-latest", "windows-2019", "macOS-13"]'
+        default: '["ubuntu-latest", "windows-2019", "macos-14"]'
 
       python_version:
         required: false
         type: string
-        default: '3.11'
+        default: "3.11"
 
 concurrency:
   # Skip intermediate builds: always.


### PR DESCRIPTION
Fixes #444. According to [GitHub's list of available GitHub-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories), we may use M1 machines for our GitHub Actions simply by specifying `runs-on: macos-14`. This PR does just that. In addition to `llvm-project-tests.yml`, `clang-tests.yml`, `lld-test.yaml`, and `llvm-test.yaml` are effected by this as well.

Note that this will most likely result in a broken MacOS pipeline (cf #443). This translates into the inability to build LLVM for Macs. 