### PR TITLE
[MOS][NFC] Rename MOS to MOSToolchain

### DIFF
--- a/clang/lib/Driver/CMakeLists.txt
+++ b/clang/lib/Driver/CMakeLists.txt
@@ -70,7 +70,7 @@ add_clang_library(clangDriver
   ToolChains/Linux.cpp
   ToolChains/MipsLinux.cpp
   ToolChains/MinGW.cpp
-  ToolChains/MOS.cpp
+  ToolChains/MOSToolchain.cpp
   ToolChains/MSP430.cpp
   ToolChains/MSVC.cpp
   ToolChains/NaCl.cpp

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -31,7 +31,7 @@
 #include "ToolChains/Hurd.h"
 #include "ToolChains/Lanai.h"
 #include "ToolChains/Linux.h"
-#include "ToolChains/MOS.h"
+#include "ToolChains/MOSToolchain.h"
 #include "ToolChains/MSP430.h"
 #include "ToolChains/MSVC.h"
 #include "ToolChains/MinGW.h"
@@ -6485,7 +6485,7 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
         TC = std::make_unique<toolchains::SPIRVToolChain>(*this, Target, Args);
         break;
       case llvm::Triple::mos:
-        TC = std::make_unique<toolchains::MOS>(*this, Target, Args);
+        TC = std::make_unique<toolchains::MOSToolChain>(*this, Target, Args);
         break;
       case llvm::Triple::csky:
         TC = std::make_unique<toolchains::CSKYToolChain>(*this, Target, Args);

--- a/clang/lib/Driver/ToolChains/MOSToolchain.cpp
+++ b/clang/lib/Driver/ToolChains/MOSToolchain.cpp
@@ -1,4 +1,4 @@
-//===-- MOS.cpp - MOS ToolChain -------------------------------------------===//
+//===-- MOSToolchain.cpp - MOS ToolChain ----------------------------------===//
 //
 // Part of the LLVM-MOS Project, under Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "MOS.h"
+#include "MOSToolchain.h"
 
 #include "CommonArgs.h"
 
@@ -20,16 +20,16 @@ using namespace clang::driver;
 using namespace clang::driver::tools;
 using namespace clang::driver::toolchains;
 
-MOS::MOS(const Driver &D, const llvm::Triple &Triple,
-         const llvm::opt::ArgList &Args)
+MOSToolChain::MOSToolChain(const Driver &D, const llvm::Triple &Triple,
+                           const llvm::opt::ArgList &Args)
     : ToolChain(D, Triple, Args) {
   getProgramPaths().push_back(getDriver().Dir);
 }
 
-Tool *MOS::buildLinker() const { return new tools::mos::Linker(*this); }
+Tool *MOSToolChain::buildLinker() const { return new tools::mos::Linker(*this); }
 
-void MOS::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
-                                    ArgStringList &CC1Args) const {
+void MOSToolChain::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
+                                             ArgStringList &CC1Args) const {
   if (DriverArgs.hasArg(options::OPT_nostdinc))
     return;
 
@@ -40,7 +40,7 @@ void MOS::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
   }
 }
 
-void MOS::addClangTargetOptions(const ArgList &DriverArgs,
+void MOSToolChain::addClangTargetOptions(const ArgList &DriverArgs,
                                 ArgStringList &CC1Args,
                                 Action::OffloadKind) const {
   CC1Args.push_back("-nostdsysteminc");
@@ -65,7 +65,7 @@ void mos::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                                const char *LinkingOutput) const {
   ArgStringList CmdArgs;
 
-  auto &TC = static_cast<const toolchains::MOS &>(getToolChain());
+  auto &TC = static_cast<const toolchains::MOSToolChain &>(getToolChain());
   auto &D = TC.getDriver();
 
   // Pass defaults before AddLinkerInputs, since that includes -Wl
@@ -132,7 +132,7 @@ void mos::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   }
 }
 
-void mos::Linker::AddLTOOptions(const toolchains::MOS &TC, const ArgList &Args,
+void mos::Linker::AddLTOOptions(const toolchains::MOSToolChain &TC, const ArgList &Args,
                                 const InputInfo &Output,
                                 const InputInfoList &Inputs,
                                 ArgStringList &CmdArgs) const {

--- a/clang/lib/Driver/ToolChains/MOSToolchain.h
+++ b/clang/lib/Driver/ToolChains/MOSToolchain.h
@@ -1,4 +1,4 @@
-//===-- MOS.h - MOS ToolChain -----------------------------------*- C++ -*-===//
+//===-- MOSToolchain.h - MOS ToolChain --------------------------*- C++ -*-===//
 //
 // Part of the LLVM-MOS Project, under Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef CLANG_LIB_DRIVER_TOOLCHAINS_MOS_H_
-#define CLANG_LIB_DRIVER_TOOLCHAINS_MOS_H_
+#ifndef CLANG_LIB_DRIVER_TOOLCHAINS_MOSTOOLCHAIN_H_
+#define CLANG_LIB_DRIVER_TOOLCHAINS_MOSTOOLCHAIN_H_
 
 #include "clang/Driver/Tool.h"
 #include "clang/Driver/ToolChain.h"
@@ -19,9 +19,9 @@ namespace driver {
 
 namespace toolchains {
 
-class LLVM_LIBRARY_VISIBILITY MOS : public ToolChain {
+class LLVM_LIBRARY_VISIBILITY MOSToolChain : public ToolChain {
 public:
-  MOS(const Driver &D, const llvm::Triple &Triple,
+  MOSToolChain(const Driver &D, const llvm::Triple &Triple,
       const llvm::opt::ArgList &Args);
 
 protected:
@@ -69,7 +69,7 @@ public:
                     const char *LinkingOutput) const override;
 
 private:
-  void AddLTOOptions(const toolchains::MOS &TC, const llvm::opt::ArgList &Args,
+  void AddLTOOptions(const toolchains::MOSToolChain &TC, const llvm::opt::ArgList &Args,
                      const InputInfo &Output, const InputInfoList &Inputs,
                      llvm::opt::ArgStringList &CmdArgs) const;
 };
@@ -80,4 +80,4 @@ private:
 } // namespace driver
 } // namespace clang
 
-#endif // not CLANG_LIB_DRIVER_TOOLCHAINS_MOS_H_
+#endif // not CLANG_LIB_DRIVER_TOOLCHAINS_MOSTOOLCHAIN_H_


### PR DESCRIPTION
/Library/Developer/CommandLineTools/usr/bin/libtool: warning duplicate member name 'MOS.cpp.o' from 'tools/clang/lib/Driver/CMakeFiles/obj.clangDriver.dir/ToolChains/MOS.cpp.o(MOS.cpp.o)' and 'tools/clang/lib/Driver/CMakeFiles/obj.clangDriver.dir/ToolChains/Arch/MOS.cpp.o(MOS.cpp.o)'