### PR TITLE
Make LLVM compile on Apple Silicon again

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -14,7 +14,7 @@ on:
         required: false
       os_list:
         required: false
-        default: '["ubuntu-latest", "windows-2019", "macOS-13"]'
+        default: '["ubuntu-latest", "windows-2019", "macOS-13", "macos-14"]'
       python_version:
         required: false
         type: string

--- a/clang/cmake/caches/MOS.cmake
+++ b/clang/cmake/caches/MOS.cmake
@@ -18,6 +18,7 @@ set(BUILTINS_mos-unknown-unknown_COMPILER_RT_BAREMETAL_BUILD ON CACHE BOOL "")
 set(BUILTINS_mos-unknown-unknown_COMPILER_RT_BUILTINS_ENABLE_PIC OFF CACHE BOOL "")
 set(BUILTINS_mos-unknown-unknown_CMAKE_BUILD_TYPE MinSizeRel CACHE BOOL "")
 set(BUILTINS_mos-unknown-unknown_CMAKE_SYSTEM_NAME Generic CACHE STRING "")
+set(RUNTIMES_mos-unknown-unknown_CMAKE_SYSTEM_NAME Generic CACHE STRING "")
 
 set(LLVM_DEFAULT_TARGET_TRIPLE "mos-unknown-unknown" CACHE STRING "")
 


### PR DESCRIPTION
Fixes #443. It appears that LLVM no longer ignores `RUNTIMES_mos-unknown-unknown_CMAKE_SYSTEM_NAME`.

Also related to #444. LLVM project tests will also run tests on Apple Silicon with this PR.