### PR TITLE
[WIP] Initial PreserveMost Calling Convention implementation

### DIFF
--- a/clang/lib/Basic/Targets/MOS.cpp
+++ b/clang/lib/Basic/Targets/MOS.cpp
@@ -14,6 +14,7 @@
 #include "clang/Basic/MacroBuilder.h"
 #include "clang/Basic/TargetInfo.h"
 
+using namespace clang;
 using namespace clang::targets;
 
 MOSTargetInfo::MOSTargetInfo(const llvm::Triple &Triple, const TargetOptions &)
@@ -261,4 +262,15 @@ void MOSTargetInfo::getTargetDefines(const LangOptions &Opts,
 
   Builder.defineMacro("__zp", "__attribute__((__address_space__(1)))");
   Builder.defineMacro("__zeropage", "__attribute__((__address_space__(1)))");
+}
+
+TargetInfo::CallingConvCheckResult
+MOSTargetInfo::checkCallingConvention(CallingConv CC) const {
+  switch (CC) {
+  case CC_C:
+  case CC_PreserveMost:
+    return CCCR_OK;
+  default:
+    return CCCR_Warning;
+  }
 }

--- a/clang/lib/Basic/Targets/MOS.h
+++ b/clang/lib/Basic/Targets/MOS.h
@@ -64,6 +64,8 @@ public:
   bool setCPU(const std::string &Name) override;
 
   bool hasBitIntType() const override { return true; }
+
+  CallingConvCheckResult checkCallingConvention(CallingConv CC) const override;
 };
 
 } // namespace targets

--- a/llvm/lib/Target/MOS/MOSCallLowering.cpp
+++ b/llvm/lib/Target/MOS/MOSCallLowering.cpp
@@ -50,8 +50,8 @@ struct MOSValueAssigner : CallLowering::ValueAssigner {
   BitVector Reserved;
 
   MOSValueAssigner(bool IsIncoming, MachineRegisterInfo &MRI,
-                   const MachineFunction &MF)
-      : CallLowering::ValueAssigner(IsIncoming, CC_MOS, CC_MOS_VarArgs) {
+                   const MachineFunction &MF, CCAssignFn AF, CCAssignFn AFVa)
+      : CallLowering::ValueAssigner(IsIncoming, AF, AFVa) {
     Reserved = MRI.getTargetRegisterInfo()->getReservedRegs(MF);
   }
 
@@ -306,7 +306,9 @@ bool MOSCallLowering::lowerReturn(MachineIRBuilder &MIRBuilder,
     // Invoke TableGen compatibility layer. This will generate copies and stores
     // from the return value virtual register to physical and stack locations.
     MOSOutgoingReturnHandler Handler(MIRBuilder, Return, MRI);
-    MOSValueAssigner Assigner(/*IsIncoming=*/false, MRI, MF);
+    auto CCFn = MOSTargetLowering::CCAssignFnForCall(F.getCallingConv(), false);
+    auto CCVaFn = MOSTargetLowering::CCAssignFnForCall(F.getCallingConv(), true);
+    MOSValueAssigner Assigner(/*IsIncoming=*/false, MRI, MF, CCFn, CCVaFn);
     if (!determineAndHandleAssignments(Handler, Assigner, Args, MIRBuilder,
                                        F.getCallingConv(), F.isVarArg()))
       return false;
@@ -345,7 +347,9 @@ bool MOSCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
   }
 
   MOSIncomingArgsHandler Handler(MIRBuilder, MRI);
-  MOSValueAssigner Assigner(/*IsIncoming=*/true, MRI, MF);
+  auto CCFn = MOSTargetLowering::CCAssignFnForCall(F.getCallingConv(), false);
+  auto CCVaFn = MOSTargetLowering::CCAssignFnForCall(F.getCallingConv(), true);
+  MOSValueAssigner Assigner(/*IsIncoming=*/true, MRI, MF, CCFn, CCVaFn);
   // Invoke TableGen compatibility layer to create loads and copies from the
   // formal argument physical and stack locations to virtual registers.
   if (!determineAndHandleAssignments(Handler, Assigner, SplitArgs, MIRBuilder,
@@ -429,7 +433,9 @@ bool MOSCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
 
   // Copy arguments from virtual registers to their real physical locations.
   MOSOutgoingArgsHandler ArgsHandler(MIRBuilder, Call, MRI);
-  MOSValueAssigner ArgsAssigner(/*IsIncoming=*/false, MRI, MF);
+  auto CCFn = MOSTargetLowering::CCAssignFnForCall(Info.CallConv, false);
+  auto CCVaFn = MOSTargetLowering::CCAssignFnForCall(Info.CallConv, true);
+  MOSValueAssigner ArgsAssigner(/*IsIncoming=*/false, MRI, MF, CCFn, CCVaFn);
   if (!determineAndHandleAssignments(ArgsHandler, ArgsAssigner, OutArgs,
                                      MIRBuilder, Info.CallConv, Info.IsVarArg))
     return false;
@@ -442,7 +448,9 @@ bool MOSCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
   if (!Info.OrigRet.Ty->isVoidTy()) {
     // Copy the return value from its physical location into a virtual register.
     MOSIncomingReturnHandler RetHandler(MIRBuilder, MRI, Call);
-    MOSValueAssigner RetAssigner(/*IsIncoming=*/true, MRI, MF);
+    auto RetCCFn = MOSTargetLowering::CCAssignFnForReturn(Info.CallConv);
+    auto RetCCVaFn = MOSTargetLowering::CCAssignFnForReturn(Info.CallConv);
+    MOSValueAssigner RetAssigner(/*IsIncoming=*/true, MRI, MF, RetCCFn, RetCCVaFn);
     if (!determineAndHandleAssignments(RetHandler, RetAssigner, InArgs,
                                        MIRBuilder, Info.CallConv,
                                        Info.IsVarArg))

--- a/llvm/lib/Target/MOS/MOSCallingConv.h
+++ b/llvm/lib/Target/MOS/MOSCallingConv.h
@@ -30,6 +30,13 @@ bool CC_MOS_VarArgs(unsigned ValNo, MVT ValVT, MVT LocVT,
                     CCValAssign::LocInfo LocInfo, ISD::ArgFlagsTy ArgFlags,
                     Type *OrigTy, CCState &State);
 
+/// Calling convention intended for usecases like interrupts where the main 6502
+/// registers A/X/Y can remain caller saved, but the ZP registers need to be
+/// callee saved.
+bool CC_MOS_PreserveMost(unsigned ValNo, MVT ValVT, MVT LocVT,
+                        CCValAssign::LocInfo LocInfo, ISD::ArgFlagsTy ArgFlags,
+                        CCState &State);
+
 } // namespace llvm
 
 #endif // not LLVM_LIB_TARGET_MOS_MOSCALLINGCONV_H

--- a/llvm/lib/Target/MOS/MOSCallingConv.td
+++ b/llvm/lib/Target/MOS/MOSCallingConv.td
@@ -76,6 +76,26 @@ def CC_MOS : CallingConv<[
 
 // Calling convention for the variable section of a variadic function call.
 // Named arguments in such functions still use the above calling convention.
+def CC_MOS_PreserveMost : CallingConv<[
+  CCIfType<[i1], CCPromoteToType<i8>>,
+
+  // 8-bit values are assigned to A, then X, then Y.
+  CCIfType<[i8], CCAssignToReg<[
+    A, X, Y, RC2, RC3, RC4, RC5, RC6, RC7, RC8, RC9, RC10, RC11, RC12, RC13, RC14,
+    RC15, RC16, RC17, RC18, RC19, RC20, RC21, RC22, RC23, RC24, RC25, RC26, RC27, RC28,
+    RC29, RC30, RC31
+  ]>>,
+
+  // All other values are passed directly on the stack.
+  CCAssignToStack<0, 1>,
+
+  //CCAssignToRegAndStack<[
+  //  RC0, RC1, RC2, RC3, RC4, RC5, RC6, RC7, RC8, RC9, RC10, RC11, RC12, RC13, RC14,
+  //  RC15], 0, 1>,
+]>;
+
+// Calling convention for the variable section of a variadic function call.
+// Named arguments in such functions still use the above calling convention.
 def CC_MOS_VarArgs : CallingConv<[
   CCIfType<[i1], CCPromoteToType<i8>>,
 
@@ -93,3 +113,9 @@ def MOS_CSR : CalleeSavedRegs<(sequence "RC%u", 20, 31)>;
 // interrupt).
 def MOS_Interrupt_CSR :
   CalleeSavedRegs<(add A, X, Y, (sequence "RC%u", 2, 31))>;
+
+// Interrupts save all registers except the stack pointers (which are restored
+// upon return by any function) and the flags (which are implicitly saved by the
+// interrupt).
+def MOS_PreserveMost_CSR :
+  CalleeSavedRegs<(sequence "RC%u", 2, 31)>;

--- a/llvm/lib/Target/MOS/MOSCallingConv.td
+++ b/llvm/lib/Target/MOS/MOSCallingConv.td
@@ -81,9 +81,7 @@ def CC_MOS_PreserveMost : CallingConv<[
 
   // 8-bit values are assigned to A, then X, then Y.
   CCIfType<[i8], CCAssignToReg<[
-    A, X, Y, RC2, RC3, RC4, RC5, RC6, RC7, RC8, RC9, RC10, RC11, RC12, RC13, RC14,
-    RC15, RC16, RC17, RC18, RC19, RC20, RC21, RC22, RC23, RC24, RC25, RC26, RC27, RC28,
-    RC29, RC30, RC31
+    A, X
   ]>>,
 
   // All other values are passed directly on the stack.

--- a/llvm/lib/Target/MOS/MOSFrameLowering.cpp
+++ b/llvm/lib/Target/MOS/MOSFrameLowering.cpp
@@ -32,6 +32,7 @@
 #include "llvm/CodeGen/TargetFrameLowering.h"
 #include "llvm/CodeGen/TargetInstrInfo.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
+#include "llvm/IR/CallingConv.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 
@@ -405,4 +406,10 @@ bool MOSFrameLowering::isISR(const MachineFunction &MF) const {
     return false;
   return F.hasFnAttribute("interrupt") ||
          F.hasFnAttribute("interrupt-norecurse");
+}
+ 
+bool MOSFrameLowering::isProfitableForNoCSROpt(const Function &F) const {
+  // The no-CSR optimisation is bad for code size on ARM, because we can save
+  // many registers with a single PUSH/POP pair.
+  return F.getCallingConv() == CallingConv::PreserveMost ? false : true;
 }

--- a/llvm/lib/Target/MOS/MOSFrameLowering.h
+++ b/llvm/lib/Target/MOS/MOSFrameLowering.h
@@ -31,6 +31,8 @@ public:
 
   bool enableShrinkWrapping(const MachineFunction &MF) const override;
 
+  bool isProfitableForNoCSROpt(const Function &F) const override;
+
   bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
                                  MachineBasicBlock::iterator MI,
                                  ArrayRef<CalleeSavedInfo> CSI,

--- a/llvm/lib/Target/MOS/MOSISelLowering.cpp
+++ b/llvm/lib/Target/MOS/MOSISelLowering.cpp
@@ -23,11 +23,13 @@
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/CodeGen/SelectionDAG.h"
 #include "llvm/CodeGen/TargetLoweringObjectFileImpl.h"
+#include "llvm/IR/CallingConv.h"
 #include "llvm/IR/Function.h"
 #include "llvm/Support/ErrorHandling.h"
 
 #include "MCTargetDesc/MOSMCTargetDesc.h"
 #include "MOS.h"
+#include "MOSCallingConv.h"
 #include "MOSInstrBuilder.h"
 #include "MOSInstrInfo.h"
 #include "MOSRegisterInfo.h"
@@ -714,4 +716,21 @@ static MachineBasicBlock *emitCmpBrZeroMultiByte(MachineInstr &MI,
   recomputeLiveIns(*MBB);
 
   return MaybeZero;
+}
+
+/// Selects the correct CCAssignFn for a given CallingConvention value.
+CCAssignFn *MOSTargetLowering::CCAssignFnForCall(CallingConv::ID CC,
+                                                 bool IsVarArg) {
+  switch (CC) {
+  default:
+    report_fatal_error("Unsupported calling convention.");
+  case CallingConv::C:
+    return IsVarArg ? CC_MOS_VarArgs : CC_MOS;
+  case CallingConv::PreserveMost:
+    return CC_MOS_PreserveMost;
+  }
+}
+
+CCAssignFn *MOSTargetLowering::CCAssignFnForReturn(CallingConv::ID CC) {
+  return CC_MOS;
 }

--- a/llvm/lib/Target/MOS/MOSISelLowering.h
+++ b/llvm/lib/Target/MOS/MOSISelLowering.h
@@ -15,6 +15,7 @@
 #define LLVM_LIB_TARGET_MOS_MOSISELLOWERING_H
 
 #include "llvm/CodeGen/TargetLowering.h"
+#include "llvm/CodeGen/GlobalISel/CallLowering.h"
 
 #include "llvm/Target/TargetMachine.h"
 
@@ -94,6 +95,9 @@ public:
   MachineBasicBlock *
   EmitInstrWithCustomInserter(MachineInstr &MI,
                               MachineBasicBlock *MBB) const override;
+                              
+  static CCAssignFn *CCAssignFnForCall(CallingConv::ID CC, bool IsVarArg);
+  static CCAssignFn *CCAssignFnForReturn(CallingConv::ID CC);
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/MOS/MOSRegisterInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSRegisterInfo.cpp
@@ -76,7 +76,19 @@ MOSRegisterInfo::MOSRegisterInfo()
 const MCPhysReg *
 MOSRegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
   const MOSFrameLowering &TFI = *getFrameLowering(*MF);
-  return TFI.isISR(*MF) ? MOS_Interrupt_CSR_SaveList : MOS_CSR_SaveList;
+  const MCPhysReg * RegList;
+  if (TFI.isISR(*MF)) {
+    RegList = MOS_Interrupt_CSR_SaveList;
+  } else {
+    const Function &F = MF->getFunction();
+    const CallingConv::ID CC = F.getCallingConv();
+    if (CC == CallingConv::PreserveMost) {
+      RegList = MOS_PreserveMost_CSR_SaveList;
+    } else {
+      RegList = MOS_CSR_SaveList;
+    }
+  }
+  return RegList;
 }
 
 const uint32_t *


### PR DESCRIPTION
A WIP branch to try and make an interrupt compatible calling convention where the imaginary registers need to be saved when used, but the A/X/Y registers are readily available to be scratched. This would be useful as a middle ground for writing interrupt routines that can call other functions without affecting the registers on the current thread of execution. See https://github.com/llvm-mos/llvm-mos/issues/229