### PR TITLE
[LLD][MOS][ld65] Report bank attribute to ld65 and mask addresses

### DIFF
--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -2286,6 +2286,8 @@ void XO65Enclave::postWrite() {
 void XO65Enclave::generateCfgFile(llvm::raw_fd_ostream &os) const {
   size_t size = 0;
   os << "MEMORY {\n";
+  // TODO
+  bool isBanked = true;
   for (const InputSectionBase *baseSec : sections) {
     const auto &sec = *cast<XO65Section>(baseSec);
     os << "  " << sec.getSegmentName() << ": start = " << sec.getVA()
@@ -2313,6 +2315,8 @@ void XO65Enclave::generateCfgFile(llvm::raw_fd_ostream &os) const {
     os << "  " << defSym->getName() << ": ";
 
     uint64_t va = defSym->getVA(ctx);
+    if (isBanked)
+      va &= 0xffff;
     if (va < 0x100)
       os << "addrsize = zp, ";
     os << "type = export, value = " << va << ";\n";

--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1969,6 +1969,8 @@ XO65Segment XO65File::parseOD65Segment() {
       parseInt(k, v, segment.size);
     } else if (k == "Alignment") {
       parseInt(k, v, segment.alignment);
+    } else if (k == "Address size") {
+      parseInt(k, v, segment.addrSize);
     }
   }
   return segment;
@@ -2035,7 +2037,7 @@ void XO65File::expectPrefix(StringRef prefix) {
 }
 
 std::pair<StringRef, StringRef> XO65File::parseKV() {
-  static llvm::Regex kvRegex(" *([^ ]+): *([^ ]+)");
+  static llvm::Regex kvRegex(" *([^ ].*): *([^ ]+)");
   SmallVector<StringRef> matches;
   if (od65Line == od65LinesEnd || !kvRegex.match(*od65Line, &matches))
     fatal(toStr(ctx, this) + ": could not parse key-value pair: " + *od65Line);
@@ -2189,6 +2191,7 @@ XO65Enclave::XO65Enclave(Ctx &ctx)
     : InputFile(ctx, XO65EnclaveKind, MemoryBufferRef{"", "xo65-enclave"}) {}
 
 void XO65Enclave::appendSegment(const XO65Segment &segment) {
+  mHasFar |= segment.addrSize > 0x02;
   auto res = segments.insert({segment.name, segment});
   if (res.second)
     return;
@@ -2199,6 +2202,7 @@ void XO65Enclave::appendSegment(const XO65Segment &segment) {
   assert(s.flags == segment.flags);
   s.size += segment.size;
   s.alignment = std::max(s.alignment, segment.alignment);
+  s.addrSize = std::max(s.addrSize, segment.addrSize);
 }
 
 void XO65Enclave::postParse() {
@@ -2287,8 +2291,7 @@ void XO65Enclave::postWrite() {
 void XO65Enclave::generateCfgFile(llvm::raw_fd_ostream &os) const {
   size_t size = 0;
   os << "MEMORY {\n";
-  // TODO
-  bool isBanked = true;
+  bool isBanked = !ctx.xo65Enclave->hasFar();
   for (const InputSectionBase *baseSec : sections) {
     const auto &sec = *cast<XO65Section>(baseSec);
     uint64_t va = sec.getVA();

--- a/lld/ELF/InputFiles.h
+++ b/lld/ELF/InputFiles.h
@@ -410,6 +410,7 @@ struct XO65Segment {
   unsigned flags;
   uint64_t size = 0;
   uint64_t alignment = 1;
+  unsigned addrSize = 0x02;
 };
 
 class XO65File : public InputFile {
@@ -464,6 +465,8 @@ private:
   std::optional<XO65TempFile> outputFile;
   std::optional<XO65TempFile> mapFile;
 
+  bool mHasFar = false;
+
 public:
   explicit XO65Enclave(Ctx &ctx);
   static bool classof(const InputFile *f) {
@@ -474,6 +477,7 @@ public:
   void appendSegment(const XO65Segment &segment);
   void addImport(Symbol *sym) { imports.insert(sym); }
   const llvm::SetVector<Symbol *> &getImports() const { return imports; }
+  bool hasFar() const { return mHasFar; };
 
   void postParse();
 

--- a/lld/test/ELF/mos-ld65-cfg-far.s
+++ b/lld/test/ELF/mos-ld65-cfg-far.s
@@ -1,0 +1,39 @@
+; RUN: split-file %s %t
+; RUN: cp %p/Inputs/ca65-dummy.o %t/ca65.o
+; RUN: llvm-mc -filetype=obj -triple=mos -o %t/main.o %t/main.s
+; RUN: ld.lld --cc65-launcher=%python --od65-path=%p/Inputs/od65.py --ld65-path=%p/Inputs/ld65.py -o %t/a.out -T%t/link.ld %t/main.o %t/ca65.o
+; RUN: FileCheck --input-file=%t/ld65.cfg %s
+
+; CHECK:      MEMORY {
+; CHECK-NEXT:   far: start = 13452647, size = 0, file = "";
+; CHECK-NEXT:   CONTENTS_: start = 0, size = 0;
+; CHECK-NEXT: }
+; CHECK-NEXT: SEGMENTS {
+; CHECK-NEXT:   far: load = CONTENTS_, run = far;
+; CHECK-NEXT: }
+; CHECK-NEXT: SYMBOLS {
+; CHECK-NEXT:   far_sym: type = export, value = 11211316;
+; CHECK-NEXT: }
+
+;--- main.s
+;--- ca65.od65
+  Segments:
+    Count: 0
+    Index:
+      Name: "far"
+      Address size: 0x03
+  Imports:
+    Index:
+      Name: "far_sym"
+  Exports:
+    Count: 0
+;--- link.ld
+far_sym = 0xab1234;
+
+SECTIONS {
+  far 0xcd4567 : { *(far) }
+}
+;--- ld65.map
+Exports list by name:
+---------------------
+;--- ld65.hex

--- a/lld/test/ELF/mos-ld65-cfg.s
+++ b/lld/test/ELF/mos-ld65-cfg.s
@@ -6,11 +6,13 @@
 ; RUN: FileCheck --input-file=%t/ld65.cfg %s
 
 ; CHECK:      MEMORY {
-; CHECK-NEXT:   underscore__escape: start = {{.*}}, size = 0, file = "";
-; CHECK-NEXT:   CONTENTS_: start = {{.*}}, size = 0;
+; CHECK-NEXT:   underscore__escape: start = 0, size = 0, file = "";
+; CHECK-NEXT:   banked: start = 17767, size = 0, file = "", bank = 205;
+; CHECK-NEXT:   CONTENTS_: start = 0, size = 0;
 ; CHECK-NEXT: }
 ; CHECK-NEXT: SEGMENTS {
 ; CHECK-NEXT:   underscore__escape: load = CONTENTS_, run = underscore__escape;
+; CHECK-NEXT:   banked: load = CONTENTS_, run = banked;
 ; CHECK-NEXT: }
 ; CHECK-NEXT: SYMBOLS {
 ; CHECK-NEXT:   abs_sym_without_file: type = export, value = 1234;
@@ -24,6 +26,8 @@
     Count: 0
     Index:
       Name: "underscore__escape"
+    Index:
+      Name: "banked"
   Imports:
     Count: 0
     Index:
@@ -49,6 +53,11 @@
 abs_sym_without_file = 1234;
 zp_sym = 123;
 banked_sym = 0xab1234;
+
+SECTIONS {
+  underscore_escape : { *(underscore_escape) }
+  banked 0xcd4567 : { *(banked) }
+}
 ;--- ld65.map
 Exports list by name:
 ---------------------

--- a/lld/test/ELF/mos-ld65-cfg.s
+++ b/lld/test/ELF/mos-ld65-cfg.s
@@ -15,6 +15,7 @@
 ; CHECK-NEXT: SYMBOLS {
 ; CHECK-NEXT:   abs_sym_without_file: type = export, value = 1234;
 ; CHECK-NEXT:   zp_sym: addrsize = zp, type = export, value = 123;
+; CHECK-NEXT:   banked_sym: type = export, value = 4660;
 ; CHECK-NEXT: }
 
 ;--- main.s
@@ -31,6 +32,8 @@
       Name: "defined_in_other_ca65"
     Index:
       Name: "zp_sym"
+    Index:
+      Name: "banked_sym"
   Exports:
     Count: 0
 ;--- other-ca65.od65
@@ -45,6 +48,7 @@
 ;--- link.ld
 abs_sym_without_file = 1234;
 zp_sym = 123;
+banked_sym = 0xab1234;
 ;--- ld65.map
 Exports list by name:
 ---------------------


### PR DESCRIPTION
For targets with 16-bit address spaces, the ld65 config file now has all reported addresses masked to 16 bits. This prevents range errors in absolute ld65 relocations. The next higher byte of the LLD virtual address of each segment is reported to LLD as the bank value for that segment, shifted down by 16. The uppermost byte is silently discarded. Symbol addresses are summarily masked down to 16 bits, since their banks cannot be queried within ca65.

This behavior is disabled if the address size of any ld65 segment is far or long. In that case, the 32-bit LLD virtual addresses are passed through directly to ld65, and segment bank is left unset, as was the case today.

Fixes #483 