### PR TITLE
Emit soft stack CSRs normally, but use SP, not FP, when lowering

### DIFF
--- a/llvm/test/CodeGen/MOS/prologepilog.mir
+++ b/llvm/test/CodeGen/MOS/prologepilog.mir
@@ -386,34 +386,140 @@ body: |
 ---
 name: save_restore_csr
 stack:
-  - { id: 0, type: variable-sized }
 body: |
   bb.0.entry:
     ; CHECK-LABEL: name: save_restore_csr
-    ; CHECK: $a = frame-setup COPY $rc30
+    ; CHECK: liveins: $rc26, $rc27, $rc28, $rc29, $rc30, $rc31
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: $c = LDCImm 0
+    ; CHECK-NEXT: $a = COPY $rc0
+    ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 254, $c
+    ; CHECK-NEXT: $rc0 = COPY killed $a
+    ; CHECK-NEXT: $a = COPY $rc1
+    ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 255, $c
+    ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: $a = frame-setup COPY $rc26
     ; CHECK-NEXT: frame-setup PH killed $a
-    ; CHECK-NEXT: $a = frame-setup COPY $rc31
+    ; CHECK-NEXT: $a = frame-setup COPY $rc27
     ; CHECK-NEXT: frame-setup PH killed $a
-    ; CHECK-NEXT: $rs15 = COPY $rs0
+    ; CHECK-NEXT: $a = frame-setup COPY $rc28
+    ; CHECK-NEXT: frame-setup PH killed $a
+    ; CHECK-NEXT: $a = frame-setup COPY $rc29
+    ; CHECK-NEXT: frame-setup PH killed $a
+    ; CHECK-NEXT: $a = COPY $rc30
+    ; CHECK-NEXT: $y = LDImm 1
+    ; CHECK-NEXT: STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.0)
+    ; CHECK-NEXT: $a = COPY $rc31
+    ; CHECK-NEXT: $y = LDImm 0
+    ; CHECK-NEXT: STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.1)
+    ; CHECK-NEXT: $rs13 = IMPLICIT_DEF
+    ; CHECK-NEXT: $rs14 = IMPLICIT_DEF
     ; CHECK-NEXT: $rs15 = IMPLICIT_DEF
-    ; CHECK-NEXT: $rs16 = IMPLICIT_DEF
-    ; CHECK-NEXT: $rs17 = IMPLICIT_DEF
-    ; CHECK-NEXT: $rs0 = COPY $rs15
+    ; CHECK-NEXT: $y = LDImm 0
+    ; CHECK-NEXT: $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.1)
+    ; CHECK-NEXT: $rc31 = COPY killed $a
+    ; CHECK-NEXT: $y = LDImm 1
+    ; CHECK-NEXT: $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.0)
+    ; CHECK-NEXT: $rc30 = COPY killed $a
     ; CHECK-NEXT: $a = frame-destroy PL
-    ; CHECK-NEXT: $rc31 = frame-destroy COPY killed $a
+    ; CHECK-NEXT: $rc29 = frame-destroy COPY killed $a
     ; CHECK-NEXT: $a = frame-destroy PL
-    ; CHECK-NEXT: $rc30 = frame-destroy COPY killed $a
-    ; CHECK-NEXT: RTS implicit $rc30, implicit $rc31
+    ; CHECK-NEXT: $rc28 = frame-destroy COPY killed $a
+    ; CHECK-NEXT: $a = frame-destroy PL
+    ; CHECK-NEXT: $rc27 = frame-destroy COPY killed $a
+    ; CHECK-NEXT: $a = frame-destroy PL
+    ; CHECK-NEXT: $rc26 = frame-destroy COPY killed $a
+    ; CHECK-NEXT: $c = LDCImm 0
+    ; CHECK-NEXT: $a = COPY $rc0
+    ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 2, $c
+    ; CHECK-NEXT: $rc0 = COPY killed $a
+    ; CHECK-NEXT: $a = COPY $rc1
+    ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 0, $c
+    ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: RTS implicit $rc26, implicit $rc27, implicit $rc28, implicit $rc29, implicit $rc30, implicit $rc31
+    $rs13 = IMPLICIT_DEF
+    $rs14 = IMPLICIT_DEF
     $rs15 = IMPLICIT_DEF
-    $rs16 = IMPLICIT_DEF
-    $rs17 = IMPLICIT_DEF
+    RTS
+...
+---
+name: save_restore_csr_variable_sized
+stack:
+  - { id: 0, type: variable-sized }
+body: |
+  bb.0.entry:
+    ; CHECK-LABEL: name: save_restore_csr_variable_sized
+    ; CHECK: liveins: $rc24, $rc25, $rc26, $rc27, $rc28, $rc29
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: $c = LDCImm 0
+    ; CHECK-NEXT: $a = COPY $rc0
+    ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 252, $c
+    ; CHECK-NEXT: $rc0 = COPY killed $a
+    ; CHECK-NEXT: $a = COPY $rc1
+    ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 255, $c
+    ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: $a = frame-setup COPY $rc24
+    ; CHECK-NEXT: frame-setup PH killed $a
+    ; CHECK-NEXT: $a = frame-setup COPY $rc25
+    ; CHECK-NEXT: frame-setup PH killed $a
+    ; CHECK-NEXT: $a = frame-setup COPY $rc26
+    ; CHECK-NEXT: frame-setup PH killed $a
+    ; CHECK-NEXT: $a = frame-setup COPY $rc27
+    ; CHECK-NEXT: frame-setup PH killed $a
+    ; CHECK-NEXT: $a = COPY $rc28
+    ; CHECK-NEXT: $y = LDImm 3
+    ; CHECK-NEXT: STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.1)
+    ; CHECK-NEXT: $a = COPY $rc29
+    ; CHECK-NEXT: $y = LDImm 2
+    ; CHECK-NEXT: STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.2)
+    ; CHECK-NEXT: $a = COPY $rc30
+    ; CHECK-NEXT: $y = LDImm 1
+    ; CHECK-NEXT: STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.3)
+    ; CHECK-NEXT: $a = COPY $rc31
+    ; CHECK-NEXT: $y = LDImm 0
+    ; CHECK-NEXT: STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.4)
+    ; CHECK-NEXT: $rs15 = COPY $rs0
+    ; CHECK-NEXT: $rs12 = IMPLICIT_DEF
+    ; CHECK-NEXT: $rs13 = IMPLICIT_DEF
+    ; CHECK-NEXT: $rs14 = IMPLICIT_DEF
+    ; CHECK-NEXT: $rs0 = COPY $rs15
+    ; CHECK-NEXT: $y = LDImm 0
+    ; CHECK-NEXT: $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.4)
+    ; CHECK-NEXT: $rc31 = COPY killed $a
+    ; CHECK-NEXT: $y = LDImm 1
+    ; CHECK-NEXT: $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.3)
+    ; CHECK-NEXT: $rc30 = COPY killed $a
+    ; CHECK-NEXT: $y = LDImm 2
+    ; CHECK-NEXT: $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.2)
+    ; CHECK-NEXT: $rc29 = COPY killed $a
+    ; CHECK-NEXT: $y = LDImm 3
+    ; CHECK-NEXT: $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.1)
+    ; CHECK-NEXT: $rc28 = COPY killed $a
+    ; CHECK-NEXT: $a = frame-destroy PL
+    ; CHECK-NEXT: $rc27 = frame-destroy COPY killed $a
+    ; CHECK-NEXT: $a = frame-destroy PL
+    ; CHECK-NEXT: $rc26 = frame-destroy COPY killed $a
+    ; CHECK-NEXT: $a = frame-destroy PL
+    ; CHECK-NEXT: $rc25 = frame-destroy COPY killed $a
+    ; CHECK-NEXT: $a = frame-destroy PL
+    ; CHECK-NEXT: $rc24 = frame-destroy COPY killed $a
+    ; CHECK-NEXT: $c = LDCImm 0
+    ; CHECK-NEXT: $a = COPY $rc0
+    ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 4, $c
+    ; CHECK-NEXT: $rc0 = COPY killed $a
+    ; CHECK-NEXT: $a = COPY $rc1
+    ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 0, $c
+    ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: RTS implicit $rc24, implicit $rc25, implicit $rc26, implicit $rc27, implicit $rc28, implicit $rc29, implicit $rc30, implicit $rc31
+    $rs12 = IMPLICIT_DEF
+    $rs13 = IMPLICIT_DEF
+    $rs14 = IMPLICIT_DEF
     RTS
 ...
 ---
 name: save_restore_csr_restorepoint
 tracksRegLiveness: true
 stack:
-  - { id: 0, type: variable-sized }
 frameInfo:
   savePoint:       '%bb.0'
   restorePoint:    '%bb.1'
@@ -421,32 +527,67 @@ body: |
   ; CHECK-LABEL: name: save_restore_csr_restorepoint
   ; CHECK: bb.0.entry:
   ; CHECK-NEXT:   successors: %bb.1(0x80000000)
+  ; CHECK-NEXT:   liveins: $rc26, $rc27, $rc28, $rc29, $rc30, $rc31
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   $a = frame-setup COPY $rc30
+  ; CHECK-NEXT:   $c = LDCImm 0
+  ; CHECK-NEXT:   $a = COPY $rc0
+  ; CHECK-NEXT:   $a, $c, $v = ADCImm $a, 254, $c
+  ; CHECK-NEXT:   $rc0 = COPY killed $a
+  ; CHECK-NEXT:   $a = COPY $rc1
+  ; CHECK-NEXT:   $a, $c, $v = ADCImm $a, 255, $c
+  ; CHECK-NEXT:   $rc1 = COPY killed $a
+  ; CHECK-NEXT:   $a = frame-setup COPY $rc26
   ; CHECK-NEXT:   frame-setup PH killed $a
-  ; CHECK-NEXT:   $a = frame-setup COPY $rc31
+  ; CHECK-NEXT:   $a = frame-setup COPY $rc27
   ; CHECK-NEXT:   frame-setup PH killed $a
-  ; CHECK-NEXT:   $rs15 = COPY $rs0
+  ; CHECK-NEXT:   $a = frame-setup COPY $rc28
+  ; CHECK-NEXT:   frame-setup PH killed $a
+  ; CHECK-NEXT:   $a = frame-setup COPY $rc29
+  ; CHECK-NEXT:   frame-setup PH killed $a
+  ; CHECK-NEXT:   $a = COPY $rc30
+  ; CHECK-NEXT:   $y = LDImm 1
+  ; CHECK-NEXT:   STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.0)
+  ; CHECK-NEXT:   $a = COPY $rc31
+  ; CHECK-NEXT:   $y = LDImm 0
+  ; CHECK-NEXT:   STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.1)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   $rs13 = IMPLICIT_DEF
+  ; CHECK-NEXT:   $rs14 = IMPLICIT_DEF
   ; CHECK-NEXT:   $rs15 = IMPLICIT_DEF
-  ; CHECK-NEXT:   $rs16 = IMPLICIT_DEF
-  ; CHECK-NEXT:   $rs17 = IMPLICIT_DEF
-  ; CHECK-NEXT:   $rs0 = COPY $rs15
+  ; CHECK-NEXT:   $y = LDImm 0
+  ; CHECK-NEXT:   $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.1)
+  ; CHECK-NEXT:   $rc31 = COPY killed $a
+  ; CHECK-NEXT:   $y = LDImm 1
+  ; CHECK-NEXT:   $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.0)
+  ; CHECK-NEXT:   $rc30 = COPY killed $a
   ; CHECK-NEXT:   $a = frame-destroy PL
-  ; CHECK-NEXT:   $rc31 = frame-destroy COPY killed $a
+  ; CHECK-NEXT:   $rc29 = frame-destroy COPY killed $a
   ; CHECK-NEXT:   $a = frame-destroy PL
-  ; CHECK-NEXT:   $rc30 = frame-destroy COPY killed $a
+  ; CHECK-NEXT:   $rc28 = frame-destroy COPY killed $a
+  ; CHECK-NEXT:   $a = frame-destroy PL
+  ; CHECK-NEXT:   $rc27 = frame-destroy COPY killed $a
+  ; CHECK-NEXT:   $a = frame-destroy PL
+  ; CHECK-NEXT:   $rc26 = frame-destroy COPY killed $a
+  ; CHECK-NEXT:   $c = LDCImm 0
+  ; CHECK-NEXT:   $a = COPY $rc0
+  ; CHECK-NEXT:   $a, $c, $v = ADCImm $a, 2, $c
+  ; CHECK-NEXT:   $rc0 = COPY killed $a
+  ; CHECK-NEXT:   $a = COPY $rc1
+  ; CHECK-NEXT:   $a, $c, $v = ADCImm $a, 0, $c
+  ; CHECK-NEXT:   $rc1 = COPY killed $a
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2:
-  ; CHECK-NEXT:   RTS implicit $rc30, implicit $rc31
+  ; CHECK-NEXT:   liveins: $rc26, $rc27, $rc28, $rc29, $rc30, $rc31
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   RTS implicit $rc26, implicit $rc27, implicit $rc28, implicit $rc29, implicit $rc30, implicit $rc31
   bb.0.entry:
   bb.1:
+    $rs13 = IMPLICIT_DEF
+    $rs14 = IMPLICIT_DEF
     $rs15 = IMPLICIT_DEF
-    $rs16 = IMPLICIT_DEF
-    $rs17 = IMPLICIT_DEF
   bb.2:
     RTS
 ...


### PR DESCRIPTION
Previously, all soft stack CSR saves would be emitted within the region where FP was set up, since accessing the soft stack in a FP-needing function nomally requires FP. This never actually made sense, since FP itself is a CSR that may need to saved to the soft stack.

Instead, we can note that during frame setup and destruction, the stack pointer and frame pointer are known equal. Accordingly, we can use the SP instead of FP throughout. This means we don`t need to special case soft-stack CSR saves and restores at all.

Fixes #496