### PR TITLE
Fix undefined behaviors and incorrect type coercion

### DIFF
--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSAsmBackend.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSAsmBackend.cpp
@@ -312,8 +312,7 @@ static bool isImmediateBankRelaxable(const MCSubtargetInfo &STI, int64_t Imm,
   if (BankRelax)
     return Imm >= 0 && Imm <= UINT16_MAX;
 
-  uint32_t ZpAddrOffset =
-      static_cast<const MOSSubtarget &>(STI).getZeroPageOffset();
+  uint32_t ZpAddrOffset = STI.hasFeature(MOS::FeatureHUC6280) ? 0x2000 : 0;
   return Imm >= ZpAddrOffset && Imm <= ZpAddrOffset + 0xFF;
 }
 

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCInstrAnalysis.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCInstrAnalysis.cpp
@@ -52,8 +52,7 @@ MOSMCInstrAnalysis::evaluateMemoryOperandAddress(const MCInst &Inst,
                                                  const MCSubtargetInfo *STI,
                                                  uint64_t Addr,
                                                  uint64_t Size) const {
-  uint64_t ZpAddrOffset = static_cast<const MOSSubtarget *>(STI)
-                              ->getZeroPageOffset();
+  uint64_t ZpAddrOffset = STI->hasFeature(MOS::FeatureHUC6280) ? 0x2000 : 0;
   uint64_t AbsAddrMask = STI->hasFeature(MOS::FeatureW65816)
                              ? 0xFFFFFF : 0xFFFF;
 

--- a/llvm/lib/Target/MOS/MOSInstructionSelector.cpp
+++ b/llvm/lib/Target/MOS/MOSInstructionSelector.cpp
@@ -493,7 +493,7 @@ bool MOSInstructionSelector::selectAddSub(MachineInstr &MI) {
   }
 
   Register Idx;
-  bool ZP;
+  bool ZP = false;
   if (MI.getOpcode() == MOS::G_ADD) {
     Success = mi_match(
         Dst, MRI,
@@ -640,7 +640,7 @@ bool MOSInstructionSelector::selectLogical(MachineInstr &MI) {
   }
 
   Register Idx;
-  bool ZP;
+  bool ZP = false;
   switch (MI.getOpcode()) {
   case MOS::G_AND:
     Success = mi_match(
@@ -1038,7 +1038,7 @@ bool MOSInstructionSelector::selectBrCondImm(MachineInstr &MI) {
     return true;
   }
   Register Idx;
-  bool ZP;
+  bool ZP = false;
   if (mi_match(CondReg, MRI, m_CmpNZIdx(LHS, Addr, Idx, Flag, Load, ZP, AA))) {
     auto Branch = Builder.buildInstr(ZP ? MOS::CmpBrZpIdx : MOS::CmpBrAbsIdx)
                       .addMBB(Tgt)
@@ -1159,7 +1159,7 @@ bool MOSInstructionSelector::selectSbc(MachineInstr &MI) {
               .cloneMemRefs(*Load);
     }
     Register Idx;
-    bool ZP;
+    bool ZP = false;
     if (!Instr && mi_match(MI.getOperand(6).getReg(), MRI,
                            m_all_of(m_MInstr(Load),
                                     m_FoldedLdIdx(MI, Addr, Idx, ZP, AA)))) {
@@ -1214,7 +1214,7 @@ bool MOSInstructionSelector::selectSbc(MachineInstr &MI) {
                   .cloneMemRefs(*Load);
     }
     Register Idx;
-    bool ZP;
+    bool ZP = false;
     if (!Instr && mi_match(MI.getOperand(6).getReg(), MRI,
                            m_all_of(m_MInstr(Load),
                                     m_FoldedLdIdx(MI, Addr, Idx, ZP, AA)))) {
@@ -1590,7 +1590,7 @@ bool MOSInstructionSelector::selectRMW(MachineInstr &MI) {
   } else if (MI.getOpcode() == MOS::G_STORE_ABS_IDX) {
     MachineOperand Addr = MachineOperand::CreateReg(0, false);
     Register Idx;
-    bool ZP;
+    bool ZP = false;
     if (mi_match(Val, MRI,
                  m_GAdd(m_all_of(m_MInstr(Load),
                                  m_FoldedLdIdx(MI, Addr, Idx, ZP, AA)),
@@ -1803,7 +1803,7 @@ bool MOSInstructionSelector::selectAddE(MachineInstr &MI) {
           .addUse(CarryIn);
     }
     Register Idx;
-    bool ZP;
+    bool ZP = false;
     if (mi_match(L, MRI, m_FoldedLdIdx(MI, Addr, Idx, ZP, AA)))
       std::swap(L, R);
     if (mi_match(R, MRI, m_FoldedLdIdx(MI, Addr, Idx, ZP, AA))) {

--- a/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
@@ -64,6 +64,10 @@ protected:
     if (Triple.isARM())
       GTEST_SKIP();
 
+    // MOS is not supported yet
+    if (Triple.isMOS())
+      GTEST_SKIP();
+
     auto EPC = SelfExecutorProcessControl::Create();
     if (!EPC) {
       consumeError(EPC.takeError());


### PR DESCRIPTION
There are several problems fixed here which are likely causing difficult-to-debug crashes in the field.  The fixes themselves seem to cause memory layout differences which in turn break the build in unrelated areas.  These were worked around as well.

1. The MOS instruction selector was using unsanitized boolean variables, causing UBSAN errors when these variables contained garbage.  This probably resulted in at least some code choosing wrongly between zero-page and absolute addressing modes.

2. The constructor receives an MCSubtargetInfo object but unsafely casts it to MOSSubtarget using static_cast. These are fundamentally incompatible types.  This was likely causing use-after-free problems of an indeterminate character in the field.

3. The build process for ORC JIT tests is failing on it for Windows; disable it for our target platform, as other platforms do.