### PR TITLE
Allow anyone who wants to, to run LLVM-MOS workflows

### DIFF
--- a/.github/workflows/clang-tests.yml
+++ b/.github/workflows/clang-tests.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   check_clang:
-    if: github.repository_owner == 'llvm-mos'
+    if: vars.LLVM_MOS_ENABLE_WORKFLOWS == 'true'
     name: Test clang
     uses: ./.github/workflows/llvm-project-tests.yml
     with:

--- a/.github/workflows/dispatch_test.yml
+++ b/.github/workflows/dispatch_test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   dispatch:
-    if: github.repository_owner == 'llvm-mos'
+    if: vars.LLVM_MOS_ENABLE_WORKFLOWS == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch

--- a/.github/workflows/lld-tests.yml
+++ b/.github/workflows/lld-tests.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   check_lld:
-    if: github.repository_owner == 'llvm-mos'
+    if: vars.LLVM_MOS_ENABLE_WORKFLOWS == 'true'
     name: Test lld
     uses: ./.github/workflows/llvm-project-tests.yml
     with:

--- a/.github/workflows/llvm-tests.yml
+++ b/.github/workflows/llvm-tests.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   check_all:
-    if: github.repository_owner == 'llvm-mos'
+    if: vars.LLVM_MOS_ENABLE_WORKFLOWS == 'true'
     name: Build and Test
     uses: ./.github/workflows/llvm-project-tests.yml
     with:

--- a/.github/workflows/package-debug.yml
+++ b/.github/workflows/package-debug.yml
@@ -6,7 +6,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   package:
-    if: github.repository_owner == 'llvm-mos'
+    if: vars.LLVM_MOS_ENABLE_WORKFLOWS == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,7 +13,7 @@ on:
       - '.github/workflows/package.yml'
 jobs:
   package:
-    if: github.repository_owner == 'llvm-mos'
+    if: vars.LLVM_MOS_ENABLE_WORKFLOWS == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
To run LLVM-MOS workflows in your repo:

  1. Go to your repo Settings → Secrets and variables → Actions → Variables
  2. Add LLVM_MOS_ENABLE_WORKFLOWS with value true as a Repository variable
  3. Workflows will then run in your fork

This has been enabled for the LLVM-MOS project.