### PR TITLE
Fix critical heap-use-after-free in InstructionSelect analysis pointer management

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/InstructionSelect.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/InstructionSelect.cpp
@@ -154,6 +154,11 @@ bool InstructionSelect::runOnMachineFunction(MachineFunction &MF) {
     if (PSI && PSI->hasProfileSummary())
       BFI = &getAnalysis<LazyBlockFrequencyInfoPass>().getBFI();
     AA = &getAnalysis<AAResultsWrapperPass>().getAAResults();
+  } else {
+    // When not optimizing, explicitly clear analysis pointers to avoid stale values
+    AA = nullptr;
+    PSI = nullptr;
+    BFI = nullptr;
   }
 
   return selectMachineFunction(MF);


### PR DESCRIPTION
When OptLevel == CodeGenOptLevel::None, InstructionSelect::runOnMachineFunction() skips analysis pointer acquisition but retains stale pointers from previous optimized functions. This causes use-after-free crashes when targets access freed AAResults objects.

Root cause: Analysis pointers (AA, PSI, BFI) are stored as member variables that persist across function calls. The conditional acquisition code only updates these pointers when optimizing, leaving stale values when processing unoptimized functions after optimized ones.

MOS is uniquely affected because it's the only LLVM target that uses AAResults during instruction selection (for W65C02 addressing mode optimizations in shouldFoldMemAccess()). Other targets receive the same stale pointers but never dereference them.

Fix: Explicitly clear analysis pointers to nullptr when not optimizing. MachineInstr::mayAlias() safely handles null AA by defaulting to conservative aliasing assumptions.

Impact: Resolves crashes in W65C02 debug builds with C++ global constructors. No performance impact on optimized builds (unchanged code path).

This fix should probably go upstream, even though we are the only target currently affected.  It is too easy for a reasonable programmer to wander into this use-after-free condition.