### PR TITLE
fix(transforms): handle null return from emitMemCpyChk

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
@@ -4450,9 +4450,11 @@ Value *FortifiedLibCallSimplifier::optimizeStrpCpyChk(CallInst *CI,
   Type *SizeTTy = IntegerType::get(CI->getContext(), SizeTBits);
   Value *LenV = ConstantInt::get(SizeTTy, Len);
   Value *Ret = emitMemCpyChk(Dst, Src, LenV, ObjSize, B, DL, TLI);
+  if (!Ret)
+    return nullptr;
   // If the function was an __stpcpy_chk, and we were able to fold it into
   // a __memcpy_chk, we still need to return the correct end pointer.
-  if (Ret && Func == LibFunc_stpcpy_chk)
+  if (Func == LibFunc_stpcpy_chk)
     return B.CreateInBoundsGEP(B.getInt8Ty(), Dst,
                                ConstantInt::get(SizeTTy, Len - 1));
   return copyFlags(*CI, cast<CallInst>(Ret));


### PR DESCRIPTION
## Summary
- Handle null return from `emitMemCpyChk` in `optimizeStrpCpyChk` before using the result
- Previously the code would call `cast<CallInst>(nullptr)` causing an assertion failure
- This is exposed by targets like MOS that lack `__memcpy_chk` libcall