### PR TITLE
fix(lldb): handle empty data in DataExtractor::Checksum

### DIFF
--- a/lldb/source/Utility/DataExtractor.cpp
+++ b/lldb/source/Utility/DataExtractor.cpp
@@ -1030,6 +1030,12 @@ void DataExtractor::Checksum(llvm::SmallVectorImpl<uint8_t> &dest,
   else
     max_data = std::min(max_data, GetByteSize());
 
+  // Give up early if no data to checksum
+  if (max_data == 0 || GetDataStart() == nullptr) {
+    dest.clear();
+    return;
+  }
+
   llvm::MD5 md5;
 
   const llvm::ArrayRef<uint8_t> data(GetDataStart(), max_data);


### PR DESCRIPTION
## Summary
- Fix crash when Checksum() is called with empty or null data buffer
- LLDB was crashing when connecting to MOS target due to empty data being passed to MD5
- Returns early with cleared dest if no data to checksum