### PR TITLE
fix(lldb): correct MOS address size to 2 bytes

### DIFF
--- a/lldb/source/Utility/ArchSpec.cpp
+++ b/lldb/source/Utility/ArchSpec.cpp
@@ -246,7 +246,7 @@ static constexpr const CoreDefinition g_core_definitions[] = {
 
     {eByteOrderLittle, 2, 2, 4, llvm::Triple::avr, ArchSpec::eCore_avr, "avr"},
 
-    {eByteOrderLittle, 4, 1, 7, llvm::Triple::mos, ArchSpec::eCore_mos, "mos"},
+    {eByteOrderLittle, 2, 1, 7, llvm::Triple::mos, ArchSpec::eCore_mos, "mos"},
 
     {eByteOrderLittle, 4, 1, 4, llvm::Triple::wasm32, ArchSpec::eCore_wasm32,
      "wasm32"},


### PR DESCRIPTION
## Summary
- MOS is a 16-bit address space architecture
- The address size was incorrectly set to 4 bytes, now corrected to 2 bytes