### PR TITLE
fix(MOS): don't pass --gc-sections for relocatable links

### DIFF
--- a/clang/lib/Driver/ToolChains/MOSToolchain.cpp
+++ b/clang/lib/Driver/ToolChains/MOSToolchain.cpp
@@ -69,7 +69,10 @@ void mos::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
   // Pass defaults before AddLinkerInputs, since that includes -Wl
   // options, which should override these.
-  CmdArgs.push_back("--gc-sections");
+  // Don't use --gc-sections for relocatable links (-r) since we're just
+  // combining objects, not producing a final executable.
+  if (!Args.hasArg(options::OPT_r))
+    CmdArgs.push_back("--gc-sections");
   CmdArgs.push_back("--sort-section=alignment");
 
   AddLinkerInputs(TC, Inputs, Args, CmdArgs, JA);


### PR DESCRIPTION
## Summary

Don't pass `--gc-sections` to the linker when using `-r` (relocatable link) to combine object files. Garbage collection is inappropriate for partial links since sections that appear unused may be needed when the combined object is later linked into the final binary.