### PR TITLE
fix(lld/MOS): handle R_MOS_NONE relocation

### DIFF
--- a/lld/ELF/Arch/MOS.cpp
+++ b/lld/ELF/Arch/MOS.cpp
@@ -67,11 +67,13 @@ uint32_t MOS::calcEFlags() const {
 RelExpr MOS::getRelExpr(RelType type, const Symbol &s,
                         const uint8_t *loc) const {
   switch (type) {
-  default:
-    return R_ABS;
+  case R_MOS_NONE:
+    return R_NONE;
   case R_MOS_PCREL_8:
   case R_MOS_PCREL_16:
     return R_PC;
+  default:
+    return R_ABS;
   }
 }
 


### PR DESCRIPTION
## Summary

Return `R_NONE` for `R_MOS_NONE` relocations instead of falling through to `R_ABS`. This prevents the linker from attempting to process null relocations as absolute relocations.