### PR TITLE
fix(MOS): implement MOSFunctionInfo::clone()

### DIFF
--- a/llvm/lib/Target/MOS/MOSMachineFunctionInfo.h
+++ b/llvm/lib/Target/MOS/MOSMachineFunctionInfo.h
@@ -22,6 +22,13 @@ class MOSSubtarget;
 struct MOSFunctionInfo : public MachineFunctionInfo {
   MOSFunctionInfo(const Function &F, const MOSSubtarget *STI) {}
 
+  MachineFunctionInfo *
+  clone(BumpPtrAllocator &Allocator, MachineFunction &DestMF,
+        const DenseMap<MachineBasicBlock *, MachineBasicBlock *> &Src2DstMBB)
+      const override {
+    return DestMF.cloneInfo<MOSFunctionInfo>(*this);
+  }
+
   int VarArgsStackIndex = -1;
   const GlobalValue *StaticStackValue = nullptr;
   const GlobalValue *ZeroPageStackValue = nullptr;


### PR DESCRIPTION
## Summary

Implement the `clone()` method for `MOSFunctionInfo`. This is required when a `MachineFunction` is cloned (e.g., during certain optimizations). Without this, the cloned function would have missing or incorrect target-specific info.

Also, without this fix, non-successful compiles can leak memory from here.