### PR TITLE
fix(MOS): add terminal actions to legalizer rules for debug builds

### DIFF
--- a/llvm/lib/Target/MOS/MOSLegalizerInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSLegalizerInfo.cpp
@@ -134,7 +134,8 @@ MOSLegalizerInfo::MOSLegalizerInfo(const MOSSubtarget &STI) {
       .customFor({S8})
       .unsupportedIf(scalarNarrowerThan(0, 8))
       .widenScalarToNextMultipleOf(0, 8)
-      .maxScalar(0, S8);
+      .maxScalar(0, S8)
+      .unsupported();
 
   getActionDefinitionsBuilder(G_BITREVERSE).lower();
 
@@ -286,7 +287,8 @@ MOSLegalizerInfo::MOSLegalizerInfo(const MOSSubtarget &STI) {
                                G_INTRINSIC_TRUNC,
                                G_INTRINSIC_ROUNDEVEN,
                                G_FSINCOS})
-      .libcallFor({S32, S64});
+      .libcallFor({S32, S64})
+      .unsupported();
 
   // TODO: G_FFREXP needs custom libcall lowering with output pointer
   // (no generic LegalizerHelper support). Will fail if encountered.


### PR DESCRIPTION
## Summary

Fix LegalizerInfo verification failures that occur in debug (assertion-enabled) builds after upstream LLVM commit 018a5dc14371.

## Problem

The upstream commit tightened the LegalizerInfo verifier to require that every type index has a defined action. The verifier function `verifyTypeIdxsCoverage()` (in `LegalizerInfo.cpp:217-245`) now iterates through all type indices (0, 1, 2, ...) and checks that each has either an explicit action or is covered by a catch-all rule. This check only runs in debug builds (`#ifndef NDEBUG`).

Two MOS legalizer rule chains lacked terminal actions:

1. **G_BSWAP**: The rule chain ended with `.maxScalar(0, S8)` which only constrains type index 0 to at most S8. Types that don't match any prior rule (like vectors or types larger than S8 after widening) have no defined action.

2. **Floating-point ops** (G_FADD, G_FSUB, G_FMUL, etc.): The chain `.libcallFor({S32, S64})` only defines actions for S32 and S64 on type index 0. Other types (S16, S128, vectors) and other type indices (1, 2 for multi-result ops like G_FSINCOS) are left undefined.

The G_FSINCOS case is particularly problematic because it has 3 type indices (2 float outputs + 1 float input), and `.libcallFor()` only covers index 0.

## Symptom

```
The following opcodes have ill-defined legalization rules:
G_INTRINSIC_TRUNC G_INTRINSIC_ROUNDEVEN G_FADD G_FEXP G_BSWAP
fatal error: error in backend: ill-defined LegalizerInfo
```

This crashes during target initialization before any user code is compiled.

## Solution

Add `.unsupported()` as a terminal action to both rule chains. This provides a catch-all that marks any unhandled type/index combination as unsupported, satisfying the verifier while maintaining the existing behavior (attempting to use unsupported types will produce a clear error rather than undefined behavior).

Note: Using `.libcall()` instead of `.libcallFor({S32, S64})` was considered (it calls `markAllIdxsAsCovered()`), but this changes the semantics by allowing libcalls for any type, which is not the intended behavior.