### PR TITLE
fix(clang): ensure i32 depth arg for return/frame address builtins

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -4770,6 +4770,9 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_return_address: {
     Value *Depth = ConstantEmitter(*this).emitAbstract(E->getArg(0),
                                                    getContext().UnsignedIntTy);
+    // The intrinsic requires i32, but UnsignedIntTy may be smaller (e.g., i16
+    // on MOS). Zero-extend to i32 if needed.
+    Depth = Builder.CreateZExtOrTrunc(Depth, Int32Ty);
     Function *F = CGM.getIntrinsic(Intrinsic::returnaddress);
     return RValue::get(Builder.CreateCall(F, Depth));
   }
@@ -4780,6 +4783,9 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_frame_address: {
     Value *Depth = ConstantEmitter(*this).emitAbstract(E->getArg(0),
                                                    getContext().UnsignedIntTy);
+    // The intrinsic requires i32, but UnsignedIntTy may be smaller (e.g., i16
+    // on MOS). Zero-extend to i32 if needed.
+    Depth = Builder.CreateZExtOrTrunc(Depth, Int32Ty);
     Function *F = CGM.getIntrinsic(Intrinsic::frameaddress, AllocaInt8PtrTy);
     return RValue::get(Builder.CreateCall(F, Depth));
   }


### PR DESCRIPTION
## Summary

Fix IR generation for `__builtin_return_address` and `__builtin_frame_address` on 16-bit targets.

## Problem

The LLVM intrinsics `llvm.returnaddress` and `llvm.frameaddress` require the depth argument to be an `i32`. However, clang's builtin implementation uses the target's `unsigned int` type to emit the depth value.

On targets where `unsigned int` is smaller than 32 bits (MOS, AVR, MSP430), this produces invalid IR:

```llvm
; MOS generates i16 depth, but intrinsic expects i32
%0 = call ptr @llvm.returnaddress(i16 0)  ; ERROR: type mismatch
```

This causes IR verification failures or incorrect codegen.

## Solution

Add explicit zero-extension of the depth argument to `i32` using `CreateZExtOrTrunc` before passing it to the intrinsic. This ensures valid IR regardless of the target's native integer size.

The fix is applied to both:
- `Builtin::BI__builtin_return_address`
- `Builtin::BI__builtin_frame_address`

## Affected Targets

Any target where `sizeof(unsigned int) < 4`:
- MOS (16-bit)
- AVR (16-bit)
- MSP430 (16-bit)

## Upstream Candidate

This is a general clang bug, not specific to llvm-mos. The fix should be upstreamed to LLVM.