### PR TITLE
[65CE02] Use 16-bit branch relaxation to eliminate JMP trampolines

### DIFF
--- a/llvm/lib/Target/MOS/MOSInstrInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSInstrInfo.cpp
@@ -326,6 +326,11 @@ bool MOSInstrInfo::isBranchOffsetInRange(unsigned BranchOpc,
   case MOS::GBR:
   case MOS::BR:
   case MOS::BRA:
+    // 65CE02+ has 16-bit PC-relative branches; the MC layer relaxes 8-bit
+    // branches to 16-bit via BranchInstructionRelaxation table, so report
+    // the wider range to avoid unnecessary JMP trampolines at codegen level.
+    if (STI->has65CE02())
+      return -32766 <= BrOffset && BrOffset <= 32769;
     // BR range is [-128,127] starting from the PC location after the
     // instruction, which is two bytes after the start of the instruction.
     return -126 <= BrOffset && BrOffset <= 129;

--- a/llvm/test/CodeGen/MOS/branch-relaxation-65ce02.mir
+++ b/llvm/test/CodeGen/MOS/branch-relaxation-65ce02.mir
@@ -1,0 +1,169 @@
+# RUN: llc -mtriple=mos -mcpu=mos65ce02 -run-pass=branch-relaxation -verify-machineinstrs -o - %s | FileCheck %s -check-prefixes=CE02
+# RUN: llc -mtriple=mos -mcpu=mos45gs02 -run-pass=branch-relaxation -verify-machineinstrs -o - %s | FileCheck %s -check-prefixes=CE02
+# RUN: llc -mtriple=mos -mcpu=mos65c02 -run-pass=branch-relaxation -verify-machineinstrs -o - %s | FileCheck %s -check-prefixes=C02
+
+# Verify that 65CE02+ targets (including 45GS02) do not insert JMP trampolines
+# for far conditional or unconditional branches -- the MC layer will relax them
+# to 16-bit relative. Contrast with 65C02, which still needs trampolines.
+
+---
+name: far_conditional_branch
+tracksRegLiveness: true
+body: |
+  ; CE02-LABEL: name: far_conditional_branch
+  ; CE02-NOT: JMP
+  ; CE02:   BR %bb.0, $c, 0
+  ; CE02-NOT: JMP
+  ; CE02:   RTS
+
+  ; C02-LABEL: name: far_conditional_branch
+  ; C02: bb.1:
+  ; C02:   BR %bb.2, $c, 1
+  ; C02:   JMP %bb.0
+  bb.0.entry:
+    liveins: $c
+    BR %bb.1, $c, 0
+
+  bb.1:
+    liveins: $c
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    BR %bb.0.entry, $c, 0
+
+  bb.2:
+    RTS
+...
+---
+name: far_unconditional_branch
+tracksRegLiveness: true
+body: |
+  ; CE02-LABEL: name: far_unconditional_branch
+  ; CE02-NOT: JMP
+  ; CE02:   RTS
+
+  ; C02-LABEL: name: far_unconditional_branch
+  ; C02:   JMP %bb.1
+  ; C02:   RTS
+  bb.0.entry:
+    BRA %bb.1
+
+  bb.1:
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    ; This BRA is kept as-is
+    BRA %bb.1
+
+  bb.2:
+    $a = LDImm 0
+    ; This BRA exceeds 8-bit range
+    BRA %bb.1
+
+  bb.3:
+    RTS
+...
+---
+# Short branches within 8-bit range should remain untouched on all targets.
+name: short_branch
+tracksRegLiveness: true
+body: |
+  ; CE02-LABEL: name: short_branch
+  ; CE02: BR %bb.0, $c, 0
+  ; CE02-NOT: JMP
+  ; CE02:   RTS
+
+  ; C02-LABEL: name: short_branch
+  ; C02: BR %bb.0, $c, 0
+  ; C02-NOT: JMP
+  ; C02:   RTS
+  bb.0.entry:
+    liveins: $c
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    $a = LDImm 0
+    BR %bb.0.entry, $c, 0
+
+  bb.1:
+    RTS
+...


### PR DESCRIPTION
## Summary
- Expand `isBranchOffsetInRange()` to report 16-bit range on 65CE02+ targets
- The codegen BranchRelaxation pass no longer inserts JMP trampolines; the MC layer's existing iterative relaxation promotes 8-bit branches to 16-bit as needed
- Result: `vector_logo.cc` goes from 19 JMP trampolines to 0, saving code size and cycles (3 bytes/4 cycles vs 5 bytes/5+ cycles per trampoline)

## Dependencies
Depends on #549 (65CE02 PCRel16 offset fix) — without it, the 16-bit branches would land one byte off target.

## Test plan
- [x] `llvm-lit llvm/test/CodeGen/MOS/branch-relaxation-65ce02.mir` — new test with 65CE02, 45GS02, 65C02 targets
- [x] Full MOS CodeGen test suite (78/78 pass)
- [x] `vector_logo.prg` renders correctly in xmega65 emulator (0 JMP trampolines)
- [x] **Update**: Using a [patched SDK simulator with 65CE02 opcodes](https://github.com/mlund/llvm-mos-sdk/tree/sim-65ce02), this PR passes the complete [llvm-test-suite](https://github.com/llvm-mos/llvm-test-suite) and all tests in [mega65-freezer](https://github.com/mlund/mega65-freezer) a ~10k line C23 port of the original cc65 code.

Co-authored with Claude AI and humanly supervised and reviewed by @mlund in accordance with LLVM guidelines.