### PR TITLE
[65CE02] Use ASR instruction for arithmetic shift right

### DIFF
--- a/llvm/lib/Target/MOS/MOSInstrLogical.td
+++ b/llvm/lib/Target/MOS/MOSInstrLogical.td
@@ -228,6 +228,10 @@ class MOSRotateRMW : MOSShiftRotateRMW {
 def ASL : MOSShift;
 def LSR : MOSShift;
 
+let Predicates = [Has65CE02] in {
+  def ASR : MOSShift;
+}
+
 def ASLAbs : MOSShiftRMW, PseudoInstExpansion<(ASL_ZeroPage addr8:$addr)> {
   dag InOperandList = (ins addr16:$addr);
 }

--- a/llvm/lib/Target/MOS/MOSInstructionSelector.cpp
+++ b/llvm/lib/Target/MOS/MOSInstructionSelector.cpp
@@ -1687,6 +1687,8 @@ bool MOSInstructionSelector::selectMergeValues(MachineInstr &MI) {
 
 bool MOSInstructionSelector::selectLshrShlE(MachineInstr &MI) {
   auto [Dst, CarryOut, Src, CarryIn] = MI.getFirst4Regs();
+  MachineIRBuilder Builder(MI);
+  const auto &MRI = *Builder.getMRI();
 
   unsigned ShiftOpcode, RotateOpcode;
   switch (MI.getOpcode()) {
@@ -1697,13 +1699,35 @@ bool MOSInstructionSelector::selectLshrShlE(MachineInstr &MI) {
     RotateOpcode = MOS::ROL;
     break;
   case MOS::G_LSHRE:
+    // 65CE02 ASR replaces the CMP #128 + ROR idiom for arithmetic right
+    // shift, saving one instruction per shift-by-1 iteration. Skip when
+    // Dst is unused: store folding may have already consumed the result
+    // via RORAbs RMW, and selecting ASR for a dead value would only add
+    // register pressure.
+    if (STI.has65CE02() && !MRI.use_nodbg_empty(Dst)) {
+      MachineInstr *Sbc = MRI.getVRegDef(CarryIn);
+      if (Sbc && Sbc->getOpcode() == MOS::G_SBC &&
+          Sbc->getOperand(1).getReg() == CarryIn) {
+        Register L = Sbc->getOperand(5).getReg();
+        auto R = getIConstantVRegValWithLookThrough(Sbc->getOperand(6).getReg(),
+                                                    MRI);
+        auto CIn = getIConstantVRegValWithLookThrough(
+            Sbc->getOperand(7).getReg(), MRI);
+        if (L == Src && R && R->Value.getZExtValue() == 0x80 && CIn &&
+            !CIn->Value.isZero()) {
+          auto Asr = Builder.buildInstr(MOS::ASR, {Dst, CarryOut}, {Src});
+          constrainSelectedInstRegOperands(*Asr, TII, TRI, RBI);
+          MI.eraseFromParent();
+          return true;
+        }
+      }
+    }
     ShiftOpcode = MOS::LSR;
     RotateOpcode = MOS::ROR;
     break;
   }
 
-  MachineIRBuilder Builder(MI);
-  if (mi_match(CarryIn, *Builder.getMRI(), m_SpecificICst(0))) {
+  if (mi_match(CarryIn, MRI, m_SpecificICst(0))) {
     auto Asl = Builder.buildInstr(ShiftOpcode, {Dst, CarryOut}, {Src});
     constrainSelectedInstRegOperands(*Asl, TII, TRI, RBI);
   } else {

--- a/llvm/lib/Target/MOS/MOSMCInstLower.cpp
+++ b/llvm/lib/Target/MOS/MOSMCInstLower.cpp
@@ -189,6 +189,7 @@ void MOSMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI) {
   }
   case MOS::ASL:
   case MOS::LSR:
+  case MOS::ASR:
   case MOS::ROL:
   case MOS::ROR:
     switch (MI->getOperand(0).getReg()) {
@@ -200,6 +201,9 @@ void MOSMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI) {
         break;
       case MOS::LSR:
         OutMI.setOpcode(MOS::LSR_ZeroPage);
+        break;
+      case MOS::ASR:
+        OutMI.setOpcode(MOS::ASR_ZeroPage);
         break;
       case MOS::ROL:
         OutMI.setOpcode(MOS::ROL_ZeroPage);
@@ -223,6 +227,9 @@ void MOSMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI) {
         return;
       case MOS::LSR:
         OutMI.setOpcode(MOS::LSR_Accumulator);
+        return;
+      case MOS::ASR:
+        OutMI.setOpcode(MOS::ASR_Implied);
         return;
       case MOS::ROL:
         OutMI.setOpcode(MOS::ROL_Accumulator);

--- a/llvm/test/CodeGen/MOS/asr-65ce02.ll
+++ b/llvm/test/CodeGen/MOS/asr-65ce02.ll
@@ -1,0 +1,124 @@
+; RUN: llc -mcpu=mos45gs02 -verify-machineinstrs < %s | FileCheck %s
+
+target datalayout = "e-m:e-p:16:8-p1:8:8-i16:8-i32:8-i64:8-f32:8-f64:8-a:8-Fi8-n8"
+target triple = "mos"
+
+define i8 @ashr_i8_1(i8 %a) {
+; CHECK-LABEL: ashr_i8_1:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    asr
+; CHECK-NEXT:    rts
+entry:
+  %0 = ashr i8 %a, 1
+  ret i8 %0
+}
+
+define i8 @ashr_i8_2(i8 %a) {
+; CHECK-LABEL: ashr_i8_2:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    asr
+; CHECK-NEXT:    asr
+; CHECK-NEXT:    rts
+entry:
+  %0 = ashr i8 %a, 2
+  ret i8 %0
+}
+
+; Only the highest byte needs sign preservation; lower bytes propagate carry.
+define i16 @ashr_i16_1(i16 %a) {
+; CHECK-LABEL: ashr_i16_1:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    stx __rc2
+; CHECK-NEXT:    asr __rc2
+; CHECK-NEXT:    ror
+; CHECK-NEXT:    ldx __rc2
+; CHECK-NEXT:    rts
+entry:
+  %0 = ashr i16 %a, 1
+  ret i16 %0
+}
+
+define i32 @ashr_i32_1(i32 %a) {
+; CHECK-LABEL: ashr_i32_1:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    stx __rc4
+; CHECK-NEXT:    asr __rc3
+; CHECK-NEXT:    ror __rc2
+; CHECK-NEXT:    ror __rc4
+; CHECK-NEXT:    ror
+; CHECK-NEXT:    ldx __rc4
+; CHECK-NEXT:    rts
+entry:
+  %0 = ashr i32 %a, 1
+  ret i32 %0
+}
+
+; Each shift-by-1 iteration must independently preserve the sign bit.
+define i8 @ashr_i8_3(i8 %a) {
+; CHECK-LABEL: ashr_i8_3:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    asr
+; CHECK-NEXT:    asr
+; CHECK-NEXT:    asr
+; CHECK-NEXT:    rts
+entry:
+  %0 = ashr i8 %a, 3
+  ret i8 %0
+}
+
+; Unsigned shifts must use LSR, not ASR (ASR would incorrectly preserve sign).
+define i8 @lshr_i8_1(i8 %a) {
+; CHECK-LABEL: lshr_i8_1:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    lsr
+; CHECK-NEXT:    rts
+entry:
+  %0 = lshr i8 %a, 1
+  ret i8 %0
+}
+
+; Multi-byte unsigned: high byte must use LSR to zero-extend, not ASR.
+define i16 @lshr_i16_1(i16 %a) {
+; CHECK-LABEL: lshr_i16_1:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    stx __rc2
+; CHECK-NEXT:    lsr __rc2
+; CHECK-NEXT:    ror
+; CHECK-NEXT:    ldx __rc2
+; CHECK-NEXT:    rts
+entry:
+  %0 = lshr i16 %a, 1
+  ret i16 %0
+}
+
+; Left shifts must not be affected by the ASR pattern match.
+define i16 @shl_i16_1(i16 %a) {
+; CHECK-LABEL: shl_i16_1:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    stx __rc2
+; CHECK-NEXT:    asl
+; CHECK-NEXT:    rol __rc2
+; CHECK-NEXT:    ldx __rc2
+; CHECK-NEXT:    rts
+entry:
+  %0 = shl i16 %a, 1
+  ret i16 %0
+}
+
+; Store-folded RMW: the shift result is consumed by RORAbs, leaving ASR's data
+; output dead. Selecting ASR here would only add register pressure.
+@g16 = global i16 0
+define void @ashr_global_i16() {
+; CHECK-LABEL: ashr_global_i16:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NOT:     asr
+; CHECK:         ror
+; CHECK:         ror g16
+; CHECK:         ror g16+1
+; CHECK-NEXT:    rts
+entry:
+  %v = load i16, ptr @g16
+  %s = ashr i16 %v, 1
+  store i16 %s, ptr @g16
+  ret void
+}


### PR DESCRIPTION
## Summary

- Selects the 65CE02 `ASR` instruction for signed right shifts (`ashr`), replacing the `CMP #128` + `ROR` idiom
- Skips ASR when the result is dead (store-folded RMW), avoiding register pressure regression
- Gated on `has65CE02()` — no effect on other targets

## C/C++ benefit

Any `int8_t >> n`, `int16_t >> n`, or `int32_t >> n` where `n` is a small constant. The high byte of every signed right shift uses ASR instead of two instructions. Common in:

- Audio mixing (sample attenuation: `sample >>= 1`)
- Fixed-point arithmetic (`fixed_t result = (a * b) >> 8`)
- Sprite/tile coordinate scaling
- Signed division by powers of two

## Codegen improvement (vs. baseline, zero regressions)

```
Function         | Instructions | Bytes
-----------------+--------------+------
ashr_i8_1        |      -1      |  -2
ashr_i8_2        |      -2      |  -4
ashr_i16_1       |      -3      |  -4
ashr_i32_1       |      -5      | -10
ashr_global_i16  |       0      |   0
all others       |       0      |   0
```

All 117 MOS tests pass (78 CodeGen, 39 MC).

## Test plan

- [x] `llvm/test/CodeGen/MOS/asr-65ce02.ll` — positive and negative cases
- [x] Full MOS CodeGen + MC test suite passes
- [x] Verified no regression on store-folded globals

Co-authored with Claude Opus 4.6 and humanly supervised and reviewed
by @mlund in accordance with LLVM guidelines.