### PR TITLE
[CodeGen] Reject remat that would produce class-mismatched instruction

### DIFF
--- a/llvm/lib/CodeGen/SplitKit.cpp
+++ b/llvm/lib/CodeGen/SplitKit.cpp
@@ -594,26 +594,33 @@ SlotIndex SplitEditor::buildCopy(Register FromReg, Register ToReg,
 bool SplitEditor::rematWillIncreaseRestriction(const MachineInstr *DefMI,
                                                MachineBasicBlock &MBB,
                                                SlotIndex UseIdx) const {
-  const MachineInstr *UseMI = LIS.getInstructionFromIndex(UseIdx);
-  if (!UseMI)
-    return false;
-
   // Currently code assumes rematerialization only happens for a def at 0.
   const unsigned DefOperandIdx = 0;
-  // We want to compute the static register class constraint for the instruction
-  // def. If it is a smaller subclass than getLargestLegalSuperClass at the use
-  // site, then rematerializing it will increase the constraints.
   const TargetRegisterClass *DefConstrainRC =
       DefMI->getRegClassConstraint(DefOperandIdx, &TII, &TRI);
   if (!DefConstrainRC)
     return false;
 
   const TargetRegisterClass *RC = MRI.getRegClass(Edit->getReg());
-
-  // We want to find the register class that can be inflated to after the split
-  // occurs in recomputeRegClass
   const TargetRegisterClass *SuperRC =
       TRI.getLargestLegalSuperClass(RC, *MBB.getParent());
+
+  // Correctness: the rematerialized instruction's op0 constraint is
+  // DefConstrainRC, but cloneVirtualRegister makes the new vreg inherit the
+  // edit-vreg's class RC. The verifier invariant requires the new vreg's
+  // class to be a subclass of DefConstrainRC. Normally recomputeRegClass
+  // (called by calculateRegClassAndHint after the split) narrows the new
+  // vreg's class to honor the cloned instruction's constraints, but it has
+  // an early exit when OldRC is already the largest legal super class, so
+  // no narrowing happens in that case. Detect it and skip remat if RC
+  // wouldn't already satisfy DefConstrainRC; defFromParent falls back to
+  // emitting a COPY, which imposes no static class constraint.
+  if (SuperRC == RC && !DefConstrainRC->hasSubClassEq(RC))
+    return true;
+
+  const MachineInstr *UseMI = LIS.getInstructionFromIndex(UseIdx);
+  if (!UseMI)
+    return false;
 
   Register DefReg = DefMI->getOperand(DefOperandIdx).getReg();
   const TargetRegisterClass *UseConstrainRC =

--- a/llvm/test/CodeGen/AArch64/clear-dead-implicit-def-impdef.ll
+++ b/llvm/test/CodeGen/AArch64/clear-dead-implicit-def-impdef.ll
@@ -21,6 +21,7 @@ define void @_ZN38SanitizerCommonInterceptors_Scanf_Test8TestBodyEv(ptr %.str.40
 ; CHECK-NEXT:    mov x23, x1
 ; CHECK-NEXT:    mov x25, x0
 ; CHECK-NEXT:    str xzr, [sp]
+; CHECK-NEXT:    mov w26, #1 ; =0x1
 ; CHECK-NEXT:    mov x0, #0 ; =0x0
 ; CHECK-NEXT:    mov w1, #1 ; =0x1
 ; CHECK-NEXT:    bl __ZL9testScanfPKcjz
@@ -39,7 +40,6 @@ define void @_ZN38SanitizerCommonInterceptors_Scanf_Test8TestBodyEv(ptr %.str.40
 ; CHECK-NEXT:    mov x0, #0 ; =0x0
 ; CHECK-NEXT:    mov w1, #0 ; =0x0
 ; CHECK-NEXT:    bl __ZL9testScanfPKcjz
-; CHECK-NEXT:    mov w26, #1 ; =0x1
 ; CHECK-NEXT:    stp xzr, x26, [sp]
 ; CHECK-NEXT:    mov x0, #0 ; =0x0
 ; CHECK-NEXT:    mov w1, #0 ; =0x0

--- a/llvm/test/CodeGen/AArch64/regalloc-last-chance-recolor-with-split.mir
+++ b/llvm/test/CodeGen/AArch64/regalloc-last-chance-recolor-with-split.mir
@@ -275,7 +275,6 @@ body:             |
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def dead $sp, implicit $sp
   ; CHECK-NEXT:   dead $w1 = MOVi32imm 526, implicit-def $x1
   ; CHECK-NEXT:   dead $w2 = MOVi32imm 2, implicit-def $x2
-  ; CHECK-NEXT:   renamable $w19 = MOVi32imm 2, implicit-def $x19
   ; CHECK-NEXT:   STATEPOINT 2882400000, 0, 4, @bar, undef $x0, $x1, $x2, undef $x3, 2, 0, 2, 4, 2, 39, 2, 0, 2, 1, 2, 0, 2, 42, 2, 2, 2, 14, 2, 0, 2, 3, 2, 400, 2, 3, 2, 400, 2, 0, 1, 8, %stack.0, 0, 2, 7, 2, 0, 2, 3, 2, 95, 2, 7, 2, 0, 2, 3, 2, -11, 2, 3, 2, -8280, 2, 3, 2, 45, 2, 3, 2, 230, 2, 7, 2, 0, 2, 4, 2, 5, 2, 7, 2, 0, 2, 3, 2, 1, 2, 7, 2, 0, 2, 7, 2, 0, 2, 1, 1, 8, %stack.0, 0, 2, 0, 2, 1, 0, 0, csr_aarch64_aapcs, implicit-def $sp, implicit-def $x0, implicit-def dead early-clobber $lr :: (load store (s64) on %stack.0)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def dead $sp, implicit $sp
   ; CHECK-NEXT:   renamable $x20 = COPY $x0
@@ -321,9 +320,9 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.bb23:
   ; CHECK-NEXT:   successors:
-  ; CHECK-NEXT:   liveins: $x19
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def dead $sp, implicit $sp
+  ; CHECK-NEXT:   renamable $w19 = MOVi32imm 2, implicit-def $x19
   ; CHECK-NEXT:   renamable $w20 = MOVi32imm 95
   ; CHECK-NEXT:   STATEPOINT 2882400000, 0, 0, @wombat, 2, 0, 2, 0, 2, 39, 2, 0, 2, 1, 2, 0, 2, 117, 2, 2, 2, 14, 2, 0, 2, 3, 2, 3, 2, 3, 2, 109, 2, 0, 1, 8, %stack.0, 0, 2, 7, 2, 0, 2, 3, killed renamable $w20, 2, 3, renamable $w19, 2, 3, 2, 3, 2, 3, 2, -8280, 2, 7, 2, 0, 2, 3, 2, 230, 2, 7, 2, 0, 2, 4, 2, 5, 2, 7, 2, 0, 2, 3, 2, 1, 2, 0, 2, 4278124286, 2, 7, 2, 0, 2, 2, 1, 8, %stack.0, 0, 2, 4278124286, 2, 0, 2, 2, 0, 0, 1, 1, csr_aarch64_aapcs, implicit-def $sp, implicit-def dead early-clobber $lr, implicit killed $x19 :: (load store (s64) on %stack.0)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def dead $sp, implicit $sp


### PR DESCRIPTION
SplitEditor::rematWillIncreaseRestriction didn't consider that cloneVirtualRegister makes the rematerialized instruction's new vreg inherit the edit-vreg's class RC, which may be strictly wider than the def's static operand-0 constraint DefConstrainRC. When RC is not a subclass of DefConstrainRC, remat produces a verifier-illegal instruction (vreg class must be a subclass of every touching instruction's constraint). recomputeRegClass can't fix this after the fact when RC is already at the top of its superclass lattice, because it early-exits before applying constraint narrowing.

This surfaces on MOS where getLargestLegalSuperClass(GPR) = Anyi8 deliberately inflates split-out vregs whose defs are GPR-constrained LDImm, but the same invariant gap is latent upstream.

Add an explicit correctness check: skip remat when RC is not contained in DefConstrainRC. defFromParent then falls back to buildCopy, which imposes no static class constraint.