### PR TITLE
[MOS] mos-late-opt: clear dead/kill flags when rewriting LDImm to TYX/TXY

### DIFF
--- a/llvm/lib/Target/MOS/MOSLateOptimization.cpp
+++ b/llvm/lib/Target/MOS/MOSLateOptimization.cpp
@@ -331,10 +331,12 @@ bool MOSLateOptimization::combineLdImm(MachineBasicBlock &MBB) const {
       } else if (STI.hasW65816Or65EL02()) {
         if (Dst == MOS::X && LoadY.MI && LoadY.Val == Val) {
           // LDX #imm -> TYX if Y==imm
+          Load = &LoadY;
           MI.setDesc(TII.get(MOS::TX));
           MI.getOperand(1).ChangeToRegister(MOS::Y, /*isDef=*/false);
         } else if (Dst == MOS::Y && LoadX.MI && LoadX.Val == Val) {
           // LDY #imm -> TXY if X==imm
+          Load = &LoadX;
           MI.setDesc(TII.get(MOS::TX));
           MI.getOperand(1).ChangeToRegister(MOS::X, /*isDef=*/false);
         }

--- a/llvm/test/CodeGen/MOS/late-opt-65816.mir
+++ b/llvm/test/CodeGen/MOS/late-opt-65816.mir
@@ -32,7 +32,7 @@ body: |
   bb.0.entry:
     ; CHECK-LABEL: name: ldimm_to_txy
     ; CHECK: $x = LDImm 1
-    ; CHECK-NEXT: $rc0 = STImag8 killed $x
+    ; CHECK-NEXT: $rc0 = STImag8 $x
     ; CHECK-NEXT: $y = TX $x
     ; CHECK-NEXT: RTS implicit $y
     $x = LDImm 1
@@ -46,11 +46,39 @@ body: |
   bb.0.entry:
     ; CHECK-LABEL: name: ldimm_to_tyx
     ; CHECK: $y = LDImm 1
-    ; CHECK-NEXT: $rc0 = STImag8 killed $y
+    ; CHECK-NEXT: $rc0 = STImag8 $y
     ; CHECK-NEXT: $x = TX $y
     ; CHECK-NEXT: RTS implicit $x
     $y = LDImm 1
     $rc0 = STImag8 killed $y
+    $x = LDImm 1
+    RTS implicit $x
+...
+---
+# When the transfer source is a dead LDImm (e.g. an RA-rematerialized constant whose
+# value was otherwise unused), reusing it as a TXY/TYX must clear the dead flag, else
+# the new transfer reads a register the verifier considers undefined. Before the fix
+# these crashed with "Bad machine code: Using an undefined physical register".
+name: ldimm_to_txy_clears_dead_source
+body: |
+  bb.0.entry:
+    ; CHECK-LABEL: name: ldimm_to_txy_clears_dead_source
+    ; CHECK: $x = LDImm 1
+    ; CHECK-NEXT: $y = TX $x
+    ; CHECK-NEXT: RTS implicit $y
+    dead $x = LDImm 1
+    $y = LDImm 1
+    RTS implicit $y
+...
+---
+name: ldimm_to_tyx_clears_dead_source
+body: |
+  bb.0.entry:
+    ; CHECK-LABEL: name: ldimm_to_tyx_clears_dead_source
+    ; CHECK: $y = LDImm 1
+    ; CHECK-NEXT: $x = TX $y
+    ; CHECK-NEXT: RTS implicit $x
+    dead $y = LDImm 1
     $x = LDImm 1
     RTS implicit $x
 ...


### PR DESCRIPTION
`MOSLateOptimization::combineLdImm` rewrites `LD_ #imm` into a register transfer when another register
already holds the immediate, then clears the dead flag and any kill flags on the transfer's **source**
register (its value is now used). Every transfer rewrite sets `Load` to its source so this shared cleanup
runs — `TAX`/`TAY` (`Load = &LoadA`), `TXA`/`TYA` (`Load = &LoadX/Y`) — **except the W65816/65EL02
`TYX`/`TXY` branches, which never assign `Load`**.

So rewriting `$y = LDImm k` → `$y = TX $x` where `$x` came from a `dead $x = LDImm k` (e.g. an
RA-rematerialized constant whose value was otherwise unused) leaves the source def marked dead, and the
machine verifier rejects the new use:

```
*** Bad machine code: Using an undefined physical register ***
- instruction: $y = TX $x
```

The default 8-bit path never hits it; it shows up on the 65816 under register pressure that produces a
dead `LDImm` followed by a same-value `LDImm`.

### Regression — introduced by

[`dbce7ad1e9cd2`](https://github.com/llvm-mos/llvm-mos/commit/dbce7ad1e9cd2) — *"Support emitting TXY/TYX
on W65816/65EL02."* ([#299](https://github.com/llvm-mos/llvm-mos/pull/299), 2023-06-17). It added the
`} else if (STI.hasW65816Or65EL02())` TYX/TXY rewrite branches **without setting `Load`**, so they never
reach the source-cleanup the sibling transfer rewrites rely on. That cleanup
(`if (Load) { Load->MI->getOperand(0).setIsDead(false); clearRegisterKills(...); }`) already existed —
it dates to [`8416d2408044`](https://github.com/llvm-mos/llvm-mos/commit/8416d2408044) *"Fold LDImm away
late to T__."* (2022-07-01) — so the W65816 branches were incomplete from introduction; the verifier
reject only surfaces under the register pressure that feeds a dead same-value `LDImm` into the transfer.
The introducing hunk (note the absence of any `Load = …`, unlike every sibling branch):

```diff
+      } else if (STI.hasW65816Or65EL02()) {
+        if (Dst == MOS::X && LoadY.MI && LoadY.Val == Val) {
+          MI.setDesc(TII.get(MOS::TX));
+          MI.getOperand(1).ChangeToRegister(MOS::Y, /*isDef=*/false);
+        } else if (Dst == MOS::Y && LoadX.MI && LoadX.Val == Val) {
+          MI.setDesc(TII.get(MOS::TX));
+          MI.getOperand(1).ChangeToRegister(MOS::X, /*isDef=*/false);
+        }
```

### Fix

Set `Load` to the transfer source (`&LoadY` for `TYX`, `&LoadX` for `TXY`) in the two W65816 branches,
matching the sibling transforms, so the existing
`if (Load) { Load->MI->getOperand(0).setIsDead(false); clearRegisterKills(...); }` block runs.

### Tests

`llvm/test/CodeGen/MOS/late-opt-65816.mir`:
- Two new cases, `ldimm_to_txy_clears_dead_source` / `ldimm_to_tyx_clears_dead_source` — a `dead` `LDImm`
  source reused as `TXY`/`TYX`. They fail `-verify-machineinstrs` without the fix and pass with it.
- The existing `ldimm_to_txy` / `ldimm_to_tyx` checks are updated: the stale `killed` flag on the source
  is now correctly cleared (`STImag8 killed $x` → `STImag8 $x`).

Found by a differential fuzzer generating recursive (soft-stack) 65816 functions, whose register pressure
produces the pattern this peephole mishandled.

---

## The diff

```diff
diff --git a/llvm/lib/Target/MOS/MOSLateOptimization.cpp b/llvm/lib/Target/MOS/MOSLateOptimization.cpp
@@ -331,10 +331,12 @@ bool MOSLateOptimization::combineLdImm(MachineBasicBlock &MBB) const {
       } else if (STI.hasW65816Or65EL02()) {
         if (Dst == MOS::X && LoadY.MI && LoadY.Val == Val) {
           // LDX #imm -> TYX if Y==imm
+          Load = &LoadY;
           MI.setDesc(TII.get(MOS::TX));
           MI.getOperand(1).ChangeToRegister(MOS::Y, /*isDef=*/false);
         } else if (Dst == MOS::Y && LoadX.MI && LoadX.Val == Val) {
           // LDY #imm -> TXY if X==imm
+          Load = &LoadX;
           MI.setDesc(TII.get(MOS::TX));
           MI.getOperand(1).ChangeToRegister(MOS::X, /*isDef=*/false);
         }
```

Plus the `late-opt-65816.mir` test additions/updates (2 new dead-source cases; the existing `txy`/`tyx`
checks lose the now-cleared stale `killed`). The complete diff is in the PR's Files tab.

## Validation

- `llc -run-pass=mos-late-opt -verify-machineinstrs late-opt-65816.mir | FileCheck` → PASS (the two new
  cases fail without the fix and pass with it).
- A differential fuzz run (50 recursive/soft-stack seeds, both emulators) → 50/50: the two
  formerly-crashing seeds now compile clean, with results agreeing host == default == `+mos-a16` on
  MAME + bsnes-jg.
- No regressions: a 6502 C regression corpus and the 16-bit-accumulator (`+mos-a16`) test suite stay green.
