### PR TITLE
[MOS] Pass addrspace(1) (8-bit direct-page) pointer arguments in an 8-bit register

### DIFF
--- a/llvm/lib/Target/MOS/MOSCallingConv.td
+++ b/llvm/lib/Target/MOS/MOSCallingConv.td
@@ -58,6 +58,16 @@ let Entry = 1 in {
 def CC_MOS : CallingConv<[
   CCIfType<[i1], CCPromoteToType<i8>>,
 
+  // An 8-bit direct-page (addrspace 1) pointer is only 8 bits wide, so it must take
+  // an 8-bit slot like an i8 value -- NOT the 16-bit RS pair the generic CCIfPtr rule
+  // below would assign, which yields an illegal size-mismatched COPY ((p1) = COPY
+  // $rsN, def 8 / src 16) at argument materialization / return. Mirror the i8 register
+  // pool; placed BEFORE CCIfPtr so it claims the DP pointer first.
+  CCIfPtrAddrSpace<1, CCAssignToReg<[
+    A, X, RC2, RC3, RC4, RC5, RC6, RC7, RC8, RC9, RC10, RC11, RC12, RC13, RC14,
+    RC15
+  ]>>,
+
   // Pointers are preferentially assigned to imaginary registers so indirect
   // addressing modes work without additional copying.
   //

--- a/llvm/test/CodeGen/MOS/dp-pointer-arg.ll
+++ b/llvm/test/CodeGen/MOS/dp-pointer-arg.ll
@@ -1,0 +1,24 @@
+; RUN: llc -mtriple=mos -verify-machineinstrs < %s | FileCheck %s
+
+; A direct-page (addrspace 1) pointer is 8-bit (datalayout p1:8:8). Passed as an
+; argument it must take an 8-bit register, not a 16-bit RS pair — the latter made
+; argument materialization emit an illegal size-mismatched COPY ((p1) = COPY $rs,
+; def 8 / src 16) that -verify-machineinstrs rejects and that crashes a release build.
+; The pointer's value is an 8-bit direct-page offset, so the deref is a zero-page
+; indexed access.
+
+define i8 @load_dp(ptr addrspace(1) %p) {
+; CHECK-LABEL: load_dp:
+; CHECK:       lda 0,x
+; CHECK:       rts
+  %v = load i8, ptr addrspace(1) %p
+  ret i8 %v
+}
+
+define void @store_dp(ptr addrspace(1) %p, i8 %v) {
+; CHECK-LABEL: store_dp:
+; CHECK:       sta 0,x
+; CHECK:       rts
+  store i8 %v, ptr addrspace(1) %p
+  ret void
+}


### PR DESCRIPTION
A function that takes a pointer in **address space 1** — the 8-bit direct-page space (`p1:8:8` in the MOS
data layout) — as an **argument** crashes the backend. The calling convention assigns *every* pointer
argument to a 16-bit `RS` register pair, but an `addrspace(1)` pointer is only 8 bits wide, so argument
materialization emits a size-mismatched physical-register copy:

```
%0:_(p1) = COPY $rs1        ; Def Size = 8, Src Size = 16
```

`-verify-machineinstrs` rejects it (*"Copy Instruction is illegal with mismatching sizes"*); a release build
without the verifier carries the illegal copy into register allocation and crashes. It reproduces on the
base `mos6502` target — no 65816 / 16-bit features needed:

```c
#define DP __attribute__((address_space(1)))
char d(char DP *p) { return *p; }   // crashes
```

### Cause

`CC_MOS` in `llvm/lib/Target/MOS/MOSCallingConv.td` assigns pointer arguments with:

```tablegen
CCIfPtr<CCAssignToReg<[RS1, RS2, RS3, RS4, RS5, RS6, RS7]>>,
```

`CCIfPtr` is `CCIf<"ArgFlags.isPointer()">` — address-space-blind — so the 8-bit `addrspace(1)` pointer is
handed a 16-bit `RS` slot. This has been latent since `addrspace(1)` direct-page pointers were introduced
(`e618537e7d5e`, *"Use address space 1 for ZP pointers."*); the rule predates it
(`80c2618c0576`, *"Use RISC-V-like calling convention."*) and was correct while every pointer was 16-bit.

### Fix

Assign an 8-bit `addrspace(1)` pointer to an 8-bit register slot — the same pool an `i8` uses — with a rule
placed before the generic `CCIfPtr`:

```tablegen
CCIfPtrAddrSpace<1, CCAssignToReg<[
  A, X, RC2, RC3, RC4, RC5, RC6, RC7, RC8, RC9, RC10, RC11, RC12, RC13, RC14, RC15
]>>,
```

The same rule covers `addrspace(1)` pointer **returns** (there is no separate return CC). Variadic
arguments are unaffected — they already pass on the stack. A DP pointer argument then arrives in an 8-bit
register and dereferences via zero-page-indexed addressing (`lda 0,x` / `sta 0,x`).

### Test

`llvm/test/CodeGen/MOS/dp-pointer-arg.ll` — a load and a store through an `addrspace(1)` pointer argument,
run under `-verify-machineinstrs` (which fails on the unfixed backend) with `CHECK` lines pinning the
zero-page-indexed access.

Fixes #561.
