### PR TITLE
feat(lld/ELF): support garbage collection of .debug_frame sections

### DIFF
--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -46,6 +46,7 @@ class ELFFileBase;
 class SharedFile;
 class InputSectionBase;
 class EhInputSection;
+class DebugFrameInputSection;
 class Defined;
 class Undefined;
 class Symbol;
@@ -59,6 +60,7 @@ struct Partition;
 struct PhdrEntry;
 
 class BssSection;
+class DebugFrameSection;
 class GdbIndexSection;
 class GotPltSection;
 class GotSection;
@@ -597,6 +599,7 @@ struct InStruct {
   std::unique_ptr<SyntheticSection> ibtPlt;
   std::unique_ptr<RelocationBaseSection> relaPlt;
   // Non-SHF_ALLOC sections
+  std::unique_ptr<DebugFrameSection> debugFrame;
   std::unique_ptr<SyntheticSection> debugNames;
   std::unique_ptr<GdbIndexSection> gdbIndex;
   std::unique_ptr<StringTableSection> shStrTab;
@@ -683,6 +686,7 @@ struct Ctx : CommonLinkerContext {
   XO65Enclave *xo65Enclave = nullptr;
   SmallVector<InputSectionBase *, 0> inputSections;
   SmallVector<EhInputSection *, 0> ehInputSections;
+  SmallVector<DebugFrameInputSection *, 0> debugFrameInputSections;
 
   SmallVector<SymbolAux, 0> symAux;
   // Duplicate symbol candidates.

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -55,6 +55,7 @@
 #include "llvm/Remarks/HotnessThresholdParser.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compression.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/GlobPattern.h"
 #include "llvm/Support/LEB128.h"
@@ -68,6 +69,8 @@
 #include <cstdlib>
 #include <tuple>
 #include <utility>
+
+#define DEBUG_TYPE "lld"
 
 using namespace llvm;
 using namespace llvm::ELF;
@@ -3446,6 +3449,12 @@ template <class ELFT> void LinkerDriver::link(opt::InputArgList &args) {
           continue;
         if (LLVM_UNLIKELY(isa<EhInputSection>(s)))
           ctx.ehInputSections.push_back(cast<EhInputSection>(s));
+        else if (LLVM_UNLIKELY(isa<DebugFrameInputSection>(s))) {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "Driver: collecting DebugFrameInputSection from "
+                     << f->getName() << "\n");
+          ctx.debugFrameInputSections.push_back(cast<DebugFrameInputSection>(s));
+        }
         else
           ctx.inputSections.push_back(s);
       }
@@ -3545,8 +3554,10 @@ template <class ELFT> void LinkerDriver::link(opt::InputArgList &args) {
   // Some input sections that are used for exception handling need to be moved
   // into synthetic sections. Do that now so that they aren't assigned to
   // output sections in the usual way.
-  if (!ctx.arg.relocatable)
+  if (!ctx.arg.relocatable) {
     combineEhSections(ctx);
+    combineDebugFrameSections(ctx);
+  }
 
   // Merge .hexagon.attributes sections.
   if (ctx.arg.emachine == EM_HEXAGON)

--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -24,6 +24,7 @@
 #include "llvm/Support/AArch64AttributeParser.h"
 #include "llvm/Support/ARMAttributeParser.h"
 #include "llvm/Support/ARMBuildAttributes.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FileUtilities.h"
@@ -34,6 +35,8 @@
 #include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/raw_ostream.h"
 #include <optional>
+
+#define DEBUG_TYPE "lld"
 
 using namespace llvm;
 using namespace llvm::ELF;
@@ -1185,6 +1188,17 @@ InputSectionBase *ObjFile<ELFT>::createInputSection(uint32_t idx,
   // class. For relocatable outputs, they are just passed through.
   if (name == ".eh_frame" && !ctx.arg.relocatable)
     return makeThreadLocal<EhInputSection>(*this, sec, name);
+
+  // .debug_frame sections need special handling to discard FDEs for
+  // garbage-collected functions, similar to .eh_frame. This only matters
+  // when --gc-sections is active; otherwise the pass-through path handles
+  // .debug_frame correctly and preserves its natural section ordering.
+  if (name == ".debug_frame" && !ctx.arg.relocatable && ctx.arg.gcSections) {
+    LLVM_DEBUG(llvm::dbgs() << "creating DebugFrameInputSection for "
+                            << this->getName() << " size=" << sec.sh_size
+                            << "\n");
+    return makeThreadLocal<DebugFrameInputSection>(*this, sec, name);
+  }
 
   if ((sec.sh_flags & SHF_MERGE) && shouldMerge(sec, name))
     return makeThreadLocal<MergeInputSection>(*this, sec, name);

--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -18,12 +18,15 @@
 #include "lld/Common/DWARF.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Compression.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/LEB128.h"
 #include "llvm/Support/xxhash.h"
 #include <algorithm>
 #include <optional>
 #include <vector>
+
+#define DEBUG_TYPE "lld"
 
 using namespace llvm;
 using namespace llvm::ELF;
@@ -217,6 +220,21 @@ uint64_t SectionBase::getOffset(uint64_t offset) const {
     if (!es->content().empty())
       if (InputSection *isec = es->getParent())
         return isec->outSecOff + es->getParentOffset(offset);
+    return offset;
+  }
+  case DebugFrame: {
+    // Analogous to EHFrame's second path only. .debug_frame pieces (CIEs and
+    // FDEs) may be dropped when their referenced functions are GC'd, so an
+    // input offset does not equal the output offset -- use getParentOffset
+    // to walk the surviving pieces and produce the compacted output offset.
+    //
+    // The EHFrame case has a first path for crtbegin/crtbeginT boundary
+    // symbols; that does not apply here because .debug_frame is not
+    // SHF_ALLOC and no CRT code references its start.
+    const DebugFrameInputSection *dfs = cast<DebugFrameInputSection>(this);
+    if (!dfs->content().empty())
+      if (SyntheticSection *ss = dfs->getParent())
+        return ss->outSecOff + dfs->getParentOffset(offset);
     return offset;
   }
   case Merge:
@@ -1617,3 +1635,133 @@ template void EhInputSection::split<ELF32LE>();
 template void EhInputSection::split<ELF32BE>();
 template void EhInputSection::split<ELF64LE>();
 template void EhInputSection::split<ELF64BE>();
+
+template <class ELFT>
+DebugFrameInputSection::DebugFrameInputSection(ObjFile<ELFT> &f,
+                                               const typename ELFT::Shdr &header,
+                                               StringRef name)
+    : InputSectionBase(f, header, name, InputSectionBase::DebugFrame) {}
+
+SyntheticSection *DebugFrameInputSection::getParent() const {
+  return cast_or_null<SyntheticSection>(parent);
+}
+
+// Return the offset within the parent synthetic section for a given input
+// offset. Mirrors EhInputSection::getParentOffset: pieces (CIEs, FDEs) may
+// be dropped when the FDE's target function is GC'd, and the surviving
+// pieces are re-packed in DebugFrameSection::finalizeContents. A dropped
+// piece keeps its default outputOff of -1; report a piece-relative offset
+// in that case so that callers do not produce addresses that overlap
+// unrelated pieces in the compacted output.
+uint64_t DebugFrameInputSection::getParentOffset(uint64_t offset) const {
+  auto it = partition_point(
+      fdes, [=](EhSectionPiece p) { return p.inputOff <= offset; });
+  if (it == fdes.begin() || it[-1].inputOff + it[-1].size <= offset) {
+    it = partition_point(
+        cies, [=](EhSectionPiece p) { return p.inputOff <= offset; });
+    if (it == cies.begin()) // invalid piece
+      return offset;
+  }
+  if (it[-1].outputOff == -1) // dropped piece
+    return offset - it[-1].inputOff;
+  return it[-1].outputOff + (offset - it[-1].inputOff);
+}
+
+// .debug_frame is a sequence of CIE or FDE records, similar to .eh_frame
+// but with different CIE identification (0xFFFFFFFF instead of 0).
+template <class ELFT> void DebugFrameInputSection::split() {
+  LLVM_DEBUG(llvm::dbgs()
+             << "DebugFrameInputSection::split(): file=" << file->getName()
+             << " contentSize=" << content().size() << "\n");
+  const RelsOrRelas<ELFT> elfRels = relsOrRelas<ELFT>();
+  if (elfRels.areRelocsCrel())
+    preprocessRelocs<ELFT>(elfRels.crels);
+  else if (elfRels.areRelocsRel())
+    preprocessRelocs<ELFT>(elfRels.rels);
+  else
+    preprocessRelocs<ELFT>(elfRels.relas);
+  LLVM_DEBUG(llvm::dbgs() << "DebugFrameInputSection::split(): preprocessed "
+                          << rels.size() << " relocs\n");
+
+  // The loop below expects the relocations to be sorted by offset.
+  auto cmp = [](const Relocation &a, const Relocation &b) {
+    return a.offset < b.offset;
+  };
+  if (!llvm::is_sorted(rels, cmp))
+    llvm::stable_sort(rels, cmp);
+
+  ArrayRef<uint8_t> d = content();
+  const char *msg = nullptr;
+  unsigned relI = 0;
+  while (!d.empty()) {
+    if (d.size() < 4) {
+      msg = "CIE/FDE too small";
+      break;
+    }
+    uint64_t size = endian::read32<ELFT::Endianness>(d.data());
+    if (size == 0) // ZERO terminator
+      break;
+    uint32_t id = endian::read32<ELFT::Endianness>(d.data() + 4);
+    size += 4;
+    if (LLVM_UNLIKELY(size > d.size())) {
+      msg = size == UINT32_MAX + uint64_t(4)
+                ? "CIE/FDE too large"
+                : "CIE/FDE ends past the end of the section";
+      break;
+    }
+
+    // Find the first relocation that points to [off,off+size). Relocations
+    // have been sorted by r_offset.
+    const uint64_t off = d.data() - content().data();
+    while (relI != rels.size() && rels[relI].offset < off)
+      ++relI;
+    unsigned firstRel = -1;
+    if (relI != rels.size() && rels[relI].offset < off + size)
+      firstRel = relI;
+    // In .debug_frame, CIE is identified by id == 0xFFFFFFFF (not 0 like .eh_frame)
+    LLVM_DEBUG(llvm::dbgs()
+               << "DebugFrameInputSection::split(): record at " << off
+               << " size=" << size << " id=" << id << " is "
+               << (id == 0xFFFFFFFF ? "CIE" : "FDE")
+               << " firstRel=" << (int)firstRel << "\n");
+    (id == 0xFFFFFFFF ? cies : fdes).emplace_back(off, this, size, firstRel);
+    d = d.slice(size);
+  }
+  LLVM_DEBUG(llvm::dbgs() << "DebugFrameInputSection::split(): found "
+                          << cies.size() << " CIEs and " << fdes.size()
+                          << " FDEs\n");
+  if (msg)
+    Err(file->ctx) << "corrupted .debug_frame: " << msg << "\n>>> defined in "
+                   << getObjMsg(d.data() - content().data());
+}
+
+template <class ELFT, class RelTy>
+void DebugFrameInputSection::preprocessRelocs(Relocs<RelTy> elfRels) {
+  Ctx &ctx = file->ctx;
+  rels.reserve(elfRels.size());
+  for (auto rel : elfRels) {
+    uint64_t offset = rel.r_offset;
+    Symbol &sym = file->getSymbol(rel.getSymbol(ctx.arg.isMips64EL));
+    RelType type = rel.getType(ctx.arg.isMips64EL);
+    RelExpr expr = ctx.target->getRelExpr(type, sym, content().data() + offset);
+    int64_t addend =
+        RelTy::HasAddend
+            ? getAddend<ELFT>(rel)
+            : ctx.target->getImplicitAddend(content().data() + offset, type);
+    rels.push_back({expr, type, offset, addend, &sym});
+  }
+}
+
+template DebugFrameInputSection::DebugFrameInputSection(ObjFile<ELF32LE> &,
+                                                        const ELF32LE::Shdr &, StringRef);
+template DebugFrameInputSection::DebugFrameInputSection(ObjFile<ELF32BE> &,
+                                                        const ELF32BE::Shdr &, StringRef);
+template DebugFrameInputSection::DebugFrameInputSection(ObjFile<ELF64LE> &,
+                                                        const ELF64LE::Shdr &, StringRef);
+template DebugFrameInputSection::DebugFrameInputSection(ObjFile<ELF64BE> &,
+                                                        const ELF64BE::Shdr &, StringRef);
+
+template void DebugFrameInputSection::split<ELF32LE>();
+template void DebugFrameInputSection::split<ELF32BE>();
+template void DebugFrameInputSection::split<ELF64LE>();
+template void DebugFrameInputSection::split<ELF64BE>();

--- a/lld/ELF/InputSection.h
+++ b/lld/ELF/InputSection.h
@@ -64,6 +64,7 @@ public:
     Synthetic,
     Spill,
     EHFrame,
+    DebugFrame,
     Merge,
     Output,
     Class,
@@ -411,6 +412,34 @@ public:
 
   // Preprocessed relocations in uniform format to avoid REL/RELA/CREL
   // relocation format handling throughout the codebase.
+  SmallVector<Relocation, 0> rels;
+};
+
+// This corresponds to a .debug_frame section of an input file.
+// Unlike .eh_frame, .debug_frame is not loaded at runtime and uses
+// absolute CIE pointers (not relative offsets).
+class DebugFrameInputSection : public InputSectionBase {
+public:
+  template <class ELFT>
+  DebugFrameInputSection(ObjFile<ELFT> &f, const typename ELFT::Shdr &header,
+                         StringRef name);
+  static bool classof(const SectionBase *s) {
+    return s->kind() == DebugFrame;
+  }
+  template <class ELFT> void split();
+  template <class ELFT, class RelTy> void preprocessRelocs(Relocs<RelTy> rels);
+
+  // Splittable sections are handled as a sequence of data
+  // rather than a single large blob of data.
+  SmallVector<EhSectionPiece, 0> cies, fdes;
+
+  SyntheticSection *getParent() const;
+
+  // Map an input offset to the corresponding offset within the parent
+  // synthetic section, taking piece drops and repacking into account.
+  uint64_t getParentOffset(uint64_t offset) const;
+
+  // Preprocessed relocations in uniform format.
   SmallVector<Relocation, 0> rels;
 };
 

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -35,12 +35,15 @@
 #include "llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h"
 #include "llvm/DebugInfo/DWARF/DWARFDebugPubTable.h"
 #include "llvm/Support/DJB.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/LEB128.h"
 #include "llvm/Support/Parallel.h"
 #include "llvm/Support/TimeProfiler.h"
 #include <cinttypes>
 #include <cstdlib>
+
+#define DEBUG_TYPE "lld"
 
 using namespace llvm;
 using namespace llvm::dwarf;
@@ -493,6 +496,226 @@ bool EhFrameHeader::updateAllocSize(Ctx &ctx) {
   size_t oldSize = size;
   finalizeContents();
   return size != oldSize;
+}
+
+// .debug_frame section implementation.
+// Unlike .eh_frame, .debug_frame is not loaded at runtime. We still process
+// it to discard FDEs for garbage-collected functions.
+DebugFrameSection::DebugFrameSection(Ctx &ctx)
+    : SyntheticSection(ctx, ".debug_frame", SHT_PROGBITS, 0, 1) {}
+
+// Check if an FDE is live (i.e., its function was not garbage-collected).
+// Unlike .eh_frame where the first relocation points to the function,
+// in .debug_frame the first relocation points to the CIE (absolute offset)
+// and the second relocation points to the function's start address.
+Defined *DebugFrameSection::isFdeLive(EhSectionPiece &fde,
+                                       ArrayRef<Relocation> rels) {
+  unsigned firstRelI = fde.firstRelocation;
+  if (firstRelI == (unsigned)-1) {
+    LLVM_DEBUG(llvm::dbgs() << "DebugFrame isFdeLive: FDE at " << fde.inputOff
+                            << " has no relocations\n");
+    return nullptr;
+  }
+
+  // In .debug_frame, FDE layout is:
+  //   Bytes 0-3: Length
+  //   Bytes 4-7: CIE pointer (relocated - points to .debug_frame)
+  //   Bytes 8-11: Initial location (PC start - points to function)
+  // So we need to find the relocation at FDE offset + 8, not the first one.
+  uint64_t pcRelOffset = fde.inputOff + 8;
+
+  LLVM_DEBUG(llvm::dbgs() << "DebugFrame isFdeLive: FDE at " << fde.inputOff
+                          << " size=" << fde.size << " firstRelI=" << firstRelI
+                          << " looking for reloc at " << pcRelOffset << "\n");
+
+  // Find the relocation that points to the function's start address.
+  for (unsigned i = firstRelI; i < rels.size(); ++i) {
+    LLVM_DEBUG(llvm::dbgs() << "DebugFrame isFdeLive: checking rel[" << i
+                            << "] offset=" << rels[i].offset << "\n");
+    if (rels[i].offset >= fde.inputOff + fde.size)
+      break; // Past this FDE
+    if (rels[i].offset == pcRelOffset) {
+      // FDEs for garbage-collected or merged-by-ICF sections are dead.
+      if (auto *d = dyn_cast<Defined>(rels[i].sym)) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "DebugFrame isFdeLive: found Defined sym, folded="
+                   << d->folded << " section="
+                   << (d->section ? d->section->name.str() : "null")
+                   << " isLive="
+                   << (d->section ? d->section->isLive() : false) << "\n");
+        if (!d->folded && d->section && d->section->isLive())
+          return d;
+      } else {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "DebugFrame isFdeLive: sym is not Defined\n");
+      }
+      return nullptr;
+    }
+  }
+  LLVM_DEBUG(llvm::dbgs() << "DebugFrame isFdeLive: no reloc found at offset "
+                          << pcRelOffset << "\n");
+  return nullptr;
+}
+
+template <endianness E>
+void DebugFrameSection::addRecords(DebugFrameInputSection *sec) {
+  LLVM_DEBUG(llvm::dbgs() << "DebugFrame addRecords: file="
+                          << sec->file->getName() << " cies=" << sec->cies.size()
+                          << " fdes=" << sec->fdes.size()
+                          << " rels=" << sec->rels.size() << "\n");
+  auto rels = sec->rels;
+  // Track which CIEs (by input offset within this section) are referenced by
+  // any surviving FDE from the same section.
+  llvm::DenseSet<size_t> usedCieOffsets;
+
+  for (EhSectionPiece &fde : sec->fdes) {
+    if (!isFdeLive(fde, rels))
+      continue;
+    // In .debug_frame the CIE pointer is an absolute offset from the start
+    // of the input section, stored at fde.data()[4..7].
+    uint32_t cieOffset = endian::read32<E>(fde.data().data() + 4);
+    LLVM_DEBUG(llvm::dbgs() << "DebugFrame addRecords: FDE at " << fde.inputOff
+                            << " is LIVE, cieOffset=" << cieOffset << "\n");
+    usedCieOffsets.insert(cieOffset);
+    liveFdes.push_back(&fde);
+  }
+
+  for (EhSectionPiece &cie : sec->cies) {
+    if (usedCieOffsets.contains(cie.inputOff)) {
+      LLVM_DEBUG(llvm::dbgs() << "DebugFrame addRecords: CIE at "
+                              << cie.inputOff << " is LIVE\n");
+      liveCies.push_back(&cie);
+    }
+  }
+  LLVM_DEBUG(llvm::dbgs() << "DebugFrame addRecords: totals liveCies="
+                          << liveCies.size() << " liveFdes=" << liveFdes.size()
+                          << "\n");
+}
+
+void DebugFrameSection::finalizeContents() {
+  LLVM_DEBUG(llvm::dbgs() << "DebugFrame finalizeContents: sections.size="
+                          << sections.size() << "\n");
+  assert(!this->size); // Not finalized.
+
+  switch (ctx.arg.ekind) {
+  case ELFNoneKind:
+    llvm_unreachable("invalid ekind");
+  case ELF32LEKind:
+  case ELF64LEKind:
+    for (DebugFrameInputSection *sec : sections) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "DebugFrame finalizeContents: processing section, cies="
+                 << sec->cies.size() << " fdes=" << sec->fdes.size() << "\n");
+      // .debug_frame is a non-SHF_ALLOC section, so partition is not set.
+      // Process all input sections unconditionally.
+      addRecords<endianness::little>(sec);
+    }
+    break;
+  case ELF32BEKind:
+  case ELF64BEKind:
+    for (DebugFrameInputSection *sec : sections)
+      addRecords<endianness::big>(sec);
+    break;
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "DebugFrame finalizeContents: liveCies="
+                          << liveCies.size() << " liveFdes=" << liveFdes.size()
+                          << "\n");
+
+  // Assign output offsets: all CIEs first, then all FDEs. Preserves the
+  // per-collection input order (i.e. per-file grouping), which keeps FDE
+  // CIE-pointer fixups localised to their originating file.
+  size_t off = 0;
+  for (EhSectionPiece *cie : liveCies) {
+    cie->outputOff = off;
+    off += cie->size;
+  }
+  for (EhSectionPiece *fde : liveFdes) {
+    fde->outputOff = off;
+    off += fde->size;
+  }
+
+  this->size = off;
+  LLVM_DEBUG(llvm::dbgs() << "DebugFrame finalizeContents: final size="
+                          << this->size << "\n");
+}
+
+size_t DebugFrameSection::getSize() const {
+  LLVM_DEBUG(llvm::dbgs() << "DebugFrame getSize() returning " << size
+                          << " parent="
+                          << (getParent() ? getParent()->name.str() : "null")
+                          << "\n");
+  return size;
+}
+
+void DebugFrameSection::writeTo(uint8_t *buf) {
+  LLVM_DEBUG(llvm::dbgs() << "DebugFrame writeTo: buf=" << (void *)buf
+                          << " size=" << size
+                          << " liveCies=" << liveCies.size()
+                          << " liveFdes=" << liveFdes.size() << "\n");
+  switch (ctx.arg.ekind) {
+  case ELFNoneKind:
+    llvm_unreachable("invalid ekind");
+  case ELF32LEKind:
+  case ELF64LEKind:
+    writeToImpl<endianness::little>(buf);
+    break;
+  case ELF32BEKind:
+  case ELF64BEKind:
+    writeToImpl<endianness::big>(buf);
+    break;
+  }
+}
+
+template <endianness E> void DebugFrameSection::writeToImpl(uint8_t *buf) {
+  // .debug_frame uses absolute CIE pointers, so each FDE's CIE-pointer field
+  // (bytes 4..7 of the FDE) must be rewritten to the CIE's new offset in the
+  // synthetic output section.
+  //
+  // The lookup is keyed by (input section, input offset) rather than input
+  // offset alone. Every compiled .o typically emits its CIE at input offset
+  // 0, so a bare input-offset key would collide across files and every FDE
+  // would end up pointing at the last file's CIE.
+  llvm::DenseMap<std::pair<InputSectionBase *, uint64_t>, size_t>
+      cieInputToOutput;
+  for (EhSectionPiece *cie : liveCies)
+    cieInputToOutput[{cie->sec, cie->inputOff}] = cie->outputOff;
+
+  // Copy CIE bytes verbatim; CIEs have no absolute intra-section pointers.
+  for (EhSectionPiece *cie : liveCies)
+    memcpy(buf + cie->outputOff, cie->data().data(), cie->size);
+
+  // Copy FDE bytes and patch the CIE pointer.
+  for (EhSectionPiece *fde : liveFdes) {
+    memcpy(buf + fde->outputOff, fde->data().data(), fde->size);
+    uint32_t cieOffset = endian::read32<E>(fde->data().data() + 4);
+    auto it = cieInputToOutput.find({fde->sec, cieOffset});
+    if (it != cieInputToOutput.end())
+      endian::write32<E>(buf + fde->outputOff + 4, it->second);
+  }
+
+  // Apply relocations. For FDEs, skip the CIE-pointer relocation at offset
+  // 4 -- that field is patched by the loop above from cieInputToOutput.
+  auto applyRelocs = [&](EhSectionPiece *piece, bool isFde) {
+    auto *s = cast<DebugFrameInputSection>(piece->sec);
+    for (const Relocation &rel : s->rels) {
+      if (rel.offset < piece->inputOff ||
+          rel.offset >= piece->inputOff + piece->size)
+        continue;
+      size_t relOffsetInPiece = rel.offset - piece->inputOff;
+      if (isFde && relOffsetInPiece == 4)
+        continue;
+      uint64_t va = 0;
+      if (auto *d = dyn_cast<Defined>(rel.sym))
+        va = d->getVA(ctx, rel.addend);
+      ctx.target->relocateNoSym(buf + piece->outputOff + relOffsetInPiece,
+                                rel.type, static_cast<int64_t>(va));
+    }
+  };
+  for (EhSectionPiece *cie : liveCies)
+    applyRelocs(cie, /*isFde=*/false);
+  for (EhSectionPiece *fde : liveFdes)
+    applyRelocs(fde, /*isFde=*/true);
 }
 
 GotSection::GotSection(Ctx &ctx)
@@ -3808,6 +4031,8 @@ template <class ELFT> void elf::splitSections(Ctx &ctx) {
         s->splitIntoPieces();
       else if (auto *eh = dyn_cast<EhInputSection>(sec))
         eh->split<ELFT>();
+      else if (auto *df = dyn_cast<DebugFrameInputSection>(sec))
+        df->split<ELFT>();
     }
 
     // For non-section Defined symbols in merge sections, pre-resolve the piece
@@ -3853,6 +4078,29 @@ void elf::combineEhSections(Ctx &ctx) {
     return s->kind() == SectionBase::Regular && part.armExidx &&
            part.armExidx->addSection(cast<InputSection>(s));
   });
+}
+
+void elf::combineDebugFrameSections(Ctx &ctx) {
+  LLVM_DEBUG(llvm::dbgs()
+             << "combineDebugFrameSections: ctx.in.debugFrame="
+             << (ctx.in.debugFrame ? "exists" : "null")
+             << " inputSections.size=" << ctx.debugFrameInputSections.size()
+             << "\n");
+  if (!ctx.in.debugFrame)
+    return;
+
+  llvm::TimeTraceScope timeScope("Combine debug frame sections");
+  DebugFrameSection &df = *ctx.in.debugFrame;
+  for (DebugFrameInputSection *sec : ctx.debugFrameInputSections) {
+    LLVM_DEBUG(llvm::dbgs() << "combineDebugFrameSections: adding section from "
+                            << sec->file->getName()
+                            << " size=" << sec->getSize() << "\n");
+    sec->parent = &df;
+    df.addralign = std::max(df.addralign, sec->addralign);
+    df.sections.push_back(sec);
+  }
+  LLVM_DEBUG(llvm::dbgs() << "combineDebugFrameSections: total sections="
+                          << df.sections.size() << "\n");
 }
 
 ARMExidxSyntheticSection::ARMExidxSyntheticSection(Ctx &ctx)
@@ -4705,6 +4953,18 @@ template <class ELFT> void elf::createSyntheticSections(Ctx &ctx) {
   if (ctx.arg.gdbIndex) {
     ctx.in.gdbIndex = GdbIndexSection::create<ELFT>(ctx);
     add(*ctx.in.gdbIndex);
+  }
+
+  // Create .debug_frame section if we have any debug frame input sections.
+  // This filters out FDEs for garbage-collected functions.
+  LLVM_DEBUG(llvm::dbgs()
+             << "createSyntheticSections: debugFrameInputSections.size="
+             << ctx.debugFrameInputSections.size() << "\n");
+  if (!ctx.debugFrameInputSections.empty()) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "createSyntheticSections: creating DebugFrameSection\n");
+    ctx.in.debugFrame = std::make_unique<DebugFrameSection>(ctx);
+    add(*ctx.in.debugFrame);
   }
 
   // .note.GNU-stack is always added when we are creating a re-linkable

--- a/lld/ELF/SyntheticSections.h
+++ b/lld/ELF/SyntheticSections.h
@@ -111,6 +111,36 @@ public:
   size_t size = 0;
 };
 
+// Section for .debug_frame. Unlike .eh_frame, this is not loaded at runtime
+// and uses absolute CIE pointers. We discard FDEs for garbage-collected
+// functions to prevent debuggers from seeing stale frame information.
+class DebugFrameSection final : public SyntheticSection {
+public:
+  DebugFrameSection(Ctx &);
+  void writeTo(uint8_t *buf) override;
+  void finalizeContents() override;
+  bool isNeeded() const override { return !sections.empty(); }
+  size_t getSize() const override;
+
+  static bool classof(const SectionBase *d) {
+    return SyntheticSection::classof(d) && d->name == ".debug_frame";
+  }
+
+  SmallVector<DebugFrameInputSection *, 0> sections;
+
+private:
+  template <llvm::endianness E> void addRecords(DebugFrameInputSection *s);
+  template <llvm::endianness E> void writeToImpl(uint8_t *buf);
+  Defined *isFdeLive(EhSectionPiece &piece, ArrayRef<Relocation> rels);
+
+  // Live CIEs and FDEs to be written to output, kept separate so that
+  // downstream code never needs to re-derive CIE-vs-FDE classification by
+  // re-reading id bytes (which would require knowing endianness).
+  SmallVector<EhSectionPiece *, 0> liveCies;
+  SmallVector<EhSectionPiece *, 0> liveFdes;
+  size_t size = 0;
+};
+
 class GotSection final : public SyntheticSection {
 public:
   GotSection(Ctx &);
@@ -1361,6 +1391,7 @@ InputSection *createInterpSection(Ctx &);
 MergeInputSection *createCommentSection(Ctx &);
 template <class ELFT> void splitSections(Ctx &);
 void combineEhSections(Ctx &);
+void combineDebugFrameSections(Ctx &);
 
 bool hasMemtag(Ctx &);
 bool canHaveMemtagGlobals(Ctx &);

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -1501,7 +1501,14 @@ template <class ELFT> void Writer<ELFT>::resolveShfLinkOrder() {
 }
 
 static void finalizeSynthetic(Ctx &ctx, SyntheticSection *sec) {
-  if (sec && sec->isNeeded() && sec->getParent()) {
+  if (!sec)
+    return;
+  LLVM_DEBUG(llvm::dbgs()
+             << "finalizeSynthetic: " << sec->name
+             << " isNeeded=" << sec->isNeeded() << " getParent="
+             << (sec->getParent() ? sec->getParent()->name.str() : "null")
+             << "\n");
+  if (sec->isNeeded() && sec->getParent()) {
     llvm::TimeTraceScope timeScope("Finalize synthetic sections", sec->name);
     sec->finalizeContents();
   }
@@ -1922,6 +1929,10 @@ template <class ELFT> void Writer<ELFT>::finalizeSections() {
       for (Partition &part : ctx.partitions)
         finalizeSynthetic(ctx, part.ehFrame.get());
     }
+
+    // Finalize .debug_frame early so its size is known before assignAddresses.
+    // Unlike .eh_frame, this is not loaded at runtime.
+    finalizeSynthetic(ctx, ctx.in.debugFrame.get());
   }
 
   // If the previous code block defines any non-hidden symbols (e.g.
@@ -2189,6 +2200,7 @@ template <class ELFT> void Writer<ELFT>::finalizeSections() {
     // static symbol table.
     finalizeSynthetic(ctx, ctx.in.symTab.get());
     finalizeSynthetic(ctx, ctx.in.debugNames.get());
+    // Note: debugFrame is finalized early (near ehFrame) for proper sizing.
     finalizeSynthetic(ctx, ctx.in.ppc64LongBranchTarget.get());
     finalizeSynthetic(ctx, ctx.in.armCmseSGSection.get());
   }

--- a/lld/test/ELF/gc-sections-debug-frame-multifile.s
+++ b/lld/test/ELF/gc-sections-debug-frame-multifile.s
@@ -1,0 +1,72 @@
+# REQUIRES: x86
+
+## Multi-file regression test for .debug_frame under --gc-sections. Two
+## input files each contribute a CIE at input-offset 0 plus FDEs that
+## reference it via a section-relative absolute pointer. Under GC:
+##
+## - The surviving FDE from each file must reference ITS OWN CIE in the
+##   output, not the other file's. The linker keys per-input CIEs by their
+##   (input-section, input-offset) pair; keying by input-offset alone would
+##   have every FDE at cieOffset=0 point at whichever file's CIE was
+##   inserted last.
+## - The dead functions from both files are collected and their FDEs
+##   dropped, leaving no tombstoned FDEs at pc=0.
+
+# RUN: rm -rf %t && split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-linux %t/a.s -o %t/a.o
+# RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-linux %t/b.s -o %t/b.o
+# RUN: ld.lld %t/a.o %t/b.o -o %t.out --gc-sections
+# RUN: llvm-readobj --symbols %t.out | FileCheck --check-prefix=SYM %s
+# RUN: llvm-dwarfdump --debug-frame %t.out | FileCheck --check-prefix=DF %s
+
+# SYM-NOT: dead_a
+# SYM-NOT: dead_b
+
+## Exactly two CIEs (one per input file) and two FDEs (one per surviving
+## function). Each FDE's cie= must reference the corresponding file's CIE
+## by output offset. Using FileCheck capture-and-reuse ([[CIE_A:...]] then
+## [[CIE_A]]) proves the two FDEs point at distinct CIEs; if the map-key
+## collision were present the two cie= values would collapse to one.
+
+# DF:      .debug_frame contents:
+# DF:      [[CIE_A:[0-9a-f]+]] {{[0-9a-f]+}} ffffffff CIE
+# DF:      [[CIE_B:[0-9a-f]+]] {{[0-9a-f]+}} ffffffff CIE
+# DF:      FDE cie=[[CIE_A]] pc={{[0-9a-f]+}}...
+# DF:      FDE cie=[[CIE_B]] pc={{[0-9a-f]+}}...
+# DF-NOT:  CIE
+# DF-NOT:  FDE
+
+#--- a.s
+	.cfi_sections .debug_frame
+
+	.section	.text.dead_a,"ax",@progbits
+	.globl	dead_a
+dead_a:
+	.cfi_startproc
+	ret
+	.cfi_endproc
+
+	.section	.text.live_a,"ax",@progbits
+	.globl	live_a
+live_a:
+	.cfi_startproc
+	ret
+	.cfi_endproc
+
+#--- b.s
+	.cfi_sections .debug_frame
+
+	.section	.text.dead_b,"ax",@progbits
+	.globl	dead_b
+dead_b:
+	.cfi_startproc
+	ret
+	.cfi_endproc
+
+	.section	.text.live_b,"ax",@progbits
+	.globl	_start
+_start:
+	.cfi_startproc
+	call live_a
+	ret
+	.cfi_endproc

--- a/lld/test/ELF/gc-sections-debug-frame.s
+++ b/lld/test/ELF/gc-sections-debug-frame.s
@@ -1,0 +1,52 @@
+# REQUIRES: x86
+
+## Verify that FDEs in .debug_frame for functions garbage-collected by
+## --gc-sections are dropped from the output, and that surviving FDEs
+## reference the correct PC (not tombstoned to 0). Without the linker
+## dropping dead FDEs, the tombstone value written into the CIE-pointer
+## and PC-start relocations would leave multiple FDEs claiming to describe
+## code at address 0, which is undetectable by consumers because DWARF
+## CFI has no codified tombstone-recognition convention.
+
+# RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-linux %s -o %t.o
+
+## With --gc-sections: dead_fn is collected, so only the FDE for _start
+## survives, referencing a non-zero PC.
+# RUN: ld.lld %t.o -o %t.gc --gc-sections
+# RUN: llvm-readobj --symbols %t.gc | FileCheck --check-prefix=GC-SYM %s
+# RUN: llvm-dwarfdump --debug-frame %t.gc | FileCheck --check-prefix=GC-DF %s
+
+## Without --gc-sections: both functions live, both FDEs present.
+# RUN: ld.lld %t.o -o %t.nogc
+# RUN: llvm-readobj --symbols %t.nogc | FileCheck --check-prefix=NOGC-SYM %s
+# RUN: llvm-dwarfdump --debug-frame %t.nogc | FileCheck --check-prefix=NOGC-DF %s
+
+# GC-SYM-NOT: dead_fn
+# NOGC-SYM: dead_fn
+
+# GC-DF: .debug_frame contents:
+# GC-DF: CIE
+# GC-DF: FDE cie={{.*}} pc={{[0-9a-f]+}}...
+# GC-DF-NOT: FDE
+
+# NOGC-DF: .debug_frame contents:
+# NOGC-DF: CIE
+# NOGC-DF: FDE cie={{.*}} pc={{[0-9a-f]+}}...
+# NOGC-DF: FDE cie={{.*}} pc={{[0-9a-f]+}}...
+# NOGC-DF-NOT: FDE
+
+	.cfi_sections .debug_frame
+
+	.section	.text.dead,"ax",@progbits
+	.globl	dead_fn
+dead_fn:
+	.cfi_startproc
+	ret
+	.cfi_endproc
+
+	.section	.text.live,"ax",@progbits
+	.globl	_start
+_start:
+	.cfi_startproc
+	ret
+	.cfi_endproc


### PR DESCRIPTION
## Summary

Add `DebugFrameInputSection` and `DebugFrameSection` to handle `.debug_frame`
similarly to `.eh_frame`. When `--gc-sections` is used, FDEs whose functions
were garbage-collected are discarded rather than left with dangling
relocations.

## Background

MOS uses `--gc-sections` by default. When compiling with CFI enabled (`-g` or
explicit CFI), each function emits an FDE in `.debug_frame` that references
the function's start via a relocation. If GC then discards the function's
`.text` section, LLD emits relocation errors against the deleted symbol.

`.eh_frame` already has this handling. `.debug_frame` is structurally similar
but not identical:

- CIE is identified by `0xFFFFFFFF` (vs. `0` for `.eh_frame`)
- CIE pointer in FDE is an absolute offset from section start (vs. relative
  for `.eh_frame`)
- Not loaded at runtime — `SHT_PROGBITS`, no `SHF_ALLOC`
- FDE's function reference is the second relocation (offset 8), not the
  first (offset 0 is the CIE pointer)

## Changes

- **`DebugFrameInputSection`** — parses input `.debug_frame` sections into CIE/FDE pieces
- **`DebugFrameSection`** — synthesizes the output section, keeping only live FDEs and their referenced CIEs
- **`combineDebugFrameSections`** — merges per-file input sections into the synthetic output
- Section is created lazily when any input has `.debug_frame` content

## Test plan

- [ ] Existing LLD test suite passes (`ninja check-lld`)
- [ ] Manual: link an MOS program with `-g --gc-sections` and confirm no relocation errors
- [ ] Manual: verify surviving `.debug_frame` records reference only live functions

## Motivation

Needed to close the debug-support gap on MOS. Without this, `-g` builds of
any non-trivial MOS program fail at link.