### PR TITLE
feat(AsmPrinter): allow targets to defer handler initialization

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -318,6 +318,29 @@ public:
     return nullptr;
   }
 
+  /// Returns true if beginModule should be called during doInitialization.
+  ///
+  /// DwarfDebug::beginModule iterates over all GlobalVariables in the
+  /// module and creates debug info entries (DIEs) for them. Some
+  /// targets (like MOS) run GlobalDCE after AsmPrinter::doInitialization,
+  /// which can delete GlobalVariables that debug info already references.
+  /// This causes "undefined temporary symbol" linker errors because the
+  /// .debug_addr section contains relocations to symbols that no longer exist.
+  ///
+  /// Targets that run GlobalDCE after codegen starts can override this to
+  /// return false and call beginModule later via callBeginModule(), after
+  /// GlobalDCE has finished. This ensures debug info only references globals
+  /// that survive dead code elimination.
+  virtual bool shouldCallBeginModule() const { return true; }
+
+  /// Manually trigger beginModule for all debug/EH handlers.
+  ///
+  /// This is called automatically during doInitialization if
+  /// shouldCallBeginModule() returns true. Targets that override
+  /// shouldCallBeginModule() to return false, must call this manually
+  /// after any passes that may delete GlobalVariables have completed.
+  void callBeginModule(Module *M);
+
   MCSymbol *getFunctionBegin() const { return CurrentFnBegin; }
   MCSymbol *getFunctionEnd() const { return CurrentFnEnd; }
 

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -713,12 +713,17 @@ bool AsmPrinter::doInitialization(Module &M) {
   if (M.getControlFlowGuardMode() != ControlFlowGuardMode::Disabled)
     Handlers.push_back(std::make_unique<WinCFGuard>(this));
 
-  for (auto &Handler : Handlers)
-    Handler->beginModule(&M);
-  for (auto &Handler : EHHandlers)
-    Handler->beginModule(&M);
+  if (shouldCallBeginModule())
+    callBeginModule(&M);
 
   return false;
+}
+
+void AsmPrinter::callBeginModule(Module *M) {
+  for (auto &Handler : Handlers)
+    Handler->beginModule(M);
+  for (auto &Handler : EHHandlers)
+    Handler->beginModule(M);
 }
 
 static bool canBeHidden(const GlobalValue *GV, const MCAsmInfo &MAI) {


### PR DESCRIPTION
## Summary

Add `shouldCallBeginModule()` virtual and `callBeginModule()` method to
`AsmPrinter`, letting targets defer debug/EH handler initialization until
after late passes that mutate the global list.

## Background

`DwarfDebug::beginModule` iterates `Module::globals()` and materializes
DIE entries with relocations. If a target subsequently runs a pass that
deletes globals — MOS runs `MOSInternalize` which drops unreferenced
globals — the relocations in `.debug_addr` become dangling and the linker
emits errors against removed symbols.

## Changes

- **`AsmPrinter::shouldCallBeginModule()`** — new virtual, default `true` preserves current behavior
- **`AsmPrinter::callBeginModule()`** — public entry point targets can call after their late passes
- `AsmPrinter::doInitialization` skips the eager call when `shouldCallBeginModule()` returns `false`

## Test plan

- [ ] All existing AsmPrinter tests pass unchanged (default path)
- [ ] MOS target uses this to gate `beginModule` until after `MOSInternalize`

## Motivation

Prerequisite for reliable `-g` builds on MOS, where `MOSInternalize` removes
globals after `beginModule` would otherwise have committed relocations
against them. The hook is target-generic — the default
(`shouldCallBeginModule() = true`) leaves every existing target unchanged.
