### PR TITLE
feat(GlobalISel): implement debug info salvaging for G_MERGE_VALUES

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/Utils.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Utils.cpp
@@ -1647,13 +1647,16 @@ void llvm::eraseInstrs(ArrayRef<MachineInstr *> DeadInstrs,
                        MachineRegisterInfo &MRI,
                        LostDebugLocObserver *LocObserver) {
   SmallInstListTy DeadInstChain;
-  for (MachineInstr *MI : DeadInstrs)
+  for (MachineInstr *MI : DeadInstrs) {
+    salvageDebugInfo(MRI, *MI);
     saveUsesAndErase(*MI, MRI, LocObserver, DeadInstChain);
+  }
 
   while (!DeadInstChain.empty()) {
     MachineInstr *Inst = DeadInstChain.pop_back_val();
     if (!isTriviallyDead(*Inst, MRI))
       continue;
+    salvageDebugInfo(MRI, *Inst);
     saveUsesAndErase(*Inst, MRI, LocObserver, DeadInstChain);
   }
 }

--- a/llvm/test/CodeGen/X86/GlobalISel/x86-calllowering-dbg-trunc.ll
+++ b/llvm/test/CodeGen/X86/GlobalISel/x86-calllowering-dbg-trunc.ll
@@ -3,7 +3,9 @@
 ; This file is the output of clang -g -O2
 ; int test_dbg_trunc(unsigned long long a) { return a; }
 ;
-; The intent of this check is to ensure the DBG_VALUE use of G_MERGE_VALUES is undef'd when the legalizer erases it.
+; The intent of this check is to ensure the DBG_VALUE use of G_MERGE_VALUES is
+; properly salvaged with fragment expressions when the legalizer erases it.
+; The 64-bit parameter is split into two 32-bit fragments.
 
 ; ModuleID = 'x86-calllowering-dbg-trunc.c'
 source_filename = "x86-calllowering-dbg-trunc.c"
@@ -17,7 +19,10 @@ define dso_local i32 @test_dbg_trunc(i64 %a) local_unnamed_addr #0 !dbg !9 {
 ; ALL:       pushl	%ebp
 ; ALL:       movl	%esp, %ebp
 ; ALL:       movl	8(%ebp), %eax
-; ALL:       #DEBUG_VALUE: test_dbg_trunc:a <- undef
+; Debug info is now properly salvaged with fragment expressions when G_MERGE_VALUES
+; is legalized. The 64-bit parameter is split: lower 32 bits in $eax, upper undefined.
+; ALL:       #DEBUG_VALUE: test_dbg_trunc:a <- [DW_OP_LLVM_fragment 32 32] undef
+; ALL:       #DEBUG_VALUE: test_dbg_trunc:a <- [DW_OP_LLVM_fragment 0 32] $eax
 ; ALL:       popl	%ebp
 ; ALL:       retl
 entry:


### PR DESCRIPTION
## Summary

Salvage debug info for `G_MERGE_VALUES` by rewriting affected `DBG_VALUE`s
to reference each source operand with a `DW_OP_LLVM_fragment` expression
covering the appropriate byte range. Call `salvageDebugInfo()` before
erasing instructions in `eraseInstrs()`.

## Background

When `G_MERGE_VALUES` is eliminated (dead-code, folded, or merged into a
larger instruction), any `DBG_VALUE` referencing its result becomes invalid
and the debugger loses visibility of the merged variable.

On targets like MOS, **every** type larger than 8 bits is split via
`G_MERGE_VALUES`/`G_UNMERGE_VALUES`. Without salvaging, virtually no
`i16`/`i32`/`i64` variable is inspectable at all optimization levels above
`-O0`.

## Changes

- **`CodeGenCommonISel::salvageDebugInfoForGMerge`** — new helper that constructs the fragment DIExpressions
- **`Utils::eraseInstrs`** — invoke the salvager before removing each instruction

## Test plan

- [ ] Existing GlobalISel debug tests pass (`ninja check-llvm`)
- [ ] `x86-calllowering-dbg-trunc.ll` — golden test now checks salvaged fragments (updated in this commit)
- [ ] Manual: MOS `-g -O2` build shows locations for split integer variables

## Motivation

Needed on MOS to make wide-integer variables inspectable above `-O0`, but
applies generically to any target that lowers wide types via
`G_MERGE_VALUES`/`G_UNMERGE_VALUES`.
