### PR TITLE
[compiler-rt] hand-tuned single-precision softfloat for MOS 6502

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -845,6 +845,7 @@ set(mips64el_SOURCES ${GENERIC_TF_SOURCES}
 
 set(mos_SOURCES
   mos/addsf3.c
+  mos/divsf3.c
   mos/mulsf3.c
   mos/subsf3.c
   ${GENERIC_SOURCES}
@@ -852,6 +853,7 @@ set(mos_SOURCES
 # MOS-specific replacements for GENERIC_SOURCES (smaller/faster than generic).
 list(REMOVE_ITEM mos_SOURCES
   addsf3.c
+  divsf3.c
   mulsf3.c
   subsf3.c
 )

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -846,12 +846,14 @@ set(mips64el_SOURCES ${GENERIC_TF_SOURCES}
 set(mos_SOURCES
   mos/addsf3.c
   mos/mulsf3.c
+  mos/subsf3.c
   ${GENERIC_SOURCES}
 )
 # MOS-specific replacements for GENERIC_SOURCES (smaller/faster than generic).
 list(REMOVE_ITEM mos_SOURCES
   addsf3.c
   mulsf3.c
+  subsf3.c
 )
 # MOS SDK implementations are already smaller and faster.
 list(REMOVE_ITEM mos_SOURCES

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -843,7 +843,14 @@ set(mips64_SOURCES ${GENERIC_TF_SOURCES}
 set(mips64el_SOURCES ${GENERIC_TF_SOURCES}
                      ${mips_SOURCES})
 
-set(mos_SOURCES ${GENERIC_SOURCES})
+set(mos_SOURCES
+  mos/addsf3.c
+  ${GENERIC_SOURCES}
+)
+# MOS-specific replacements for GENERIC_SOURCES (smaller/faster than generic).
+list(REMOVE_ITEM mos_SOURCES
+  addsf3.c
+)
 # MOS SDK implementations are already smaller and faster.
 list(REMOVE_ITEM mos_SOURCES
   ashldi3.c

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -845,11 +845,13 @@ set(mips64el_SOURCES ${GENERIC_TF_SOURCES}
 
 set(mos_SOURCES
   mos/addsf3.c
+  mos/mulsf3.c
   ${GENERIC_SOURCES}
 )
 # MOS-specific replacements for GENERIC_SOURCES (smaller/faster than generic).
 list(REMOVE_ITEM mos_SOURCES
   addsf3.c
+  mulsf3.c
 )
 # MOS SDK implementations are already smaller and faster.
 list(REMOVE_ITEM mos_SOURCES

--- a/compiler-rt/lib/builtins/mos/addsf3.c
+++ b/compiler-rt/lib/builtins/mos/addsf3.c
@@ -1,0 +1,867 @@
+//===-- lib/mos/addsf3.c - Single-precision addition (MOS) -------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// __addsf3(a, b) -- IEEE 754 binary32 addition for MOS (6502).
+//
+// Rounding: round-to-nearest-ties-to-even, hardcoded.  There is no
+// support for fenv (no dynamic rounding mode, no inexact flag).  This
+// is a deliberate choice: MOS programs almost never manipulate the
+// floating-point environment, and the generic compiler-rt fenv machinery
+// (__fe_getround, __fe_raise_inexact) is ~30x more expensive per call
+// than the arithmetic it wraps.
+//
+// This file is intended to serve as the template for future single- and
+// double-precision soft-float routines on MOS (subsf3, mulsf3, divsf3,
+// adddf3, muldf3, ...).  The extensive reference material below is here
+// to make those follow-on implementations straightforward.
+//
+// ============================================================================
+// REFERENCE: IEEE 754 binary32 memory layout (little-endian)
+// ============================================================================
+//
+//   byte 3  : [S | EEEEEEE ]     S     = sign bit
+//   byte 2  : [E | MMMMMMM ]     EEEEE = 8-bit biased exponent, split
+//   byte 1  : [MMMMMMMM    ]     M     = 23-bit stored mantissa
+//   byte 0  : [MMMMMMMM    ]     (implicit leading 1 for normals)
+//
+// So the 8-bit biased exponent EEEEEEEE spans byte3's low 7 bits AND
+// byte2's high bit.  To extract it we shift bit 7 of byte2 into the carry
+// with ASL, then load byte3 and ROL through carry:
+//
+//     LDA byte2 ; ASL A    -- C = byte2[7] = E0 (low bit of exp)
+//     LDA byte3 ; ROL A    -- A = (byte3 << 1) | C = biased exp
+//
+// Number semantics by exponent field:
+//   exp == 0xFF, mantissa != 0 -- NaN (quiet if bit 22 (m3 bit 6) is set)
+//   exp == 0xFF, mantissa == 0 -- +/- infinity
+//   exp == 0x00, mantissa != 0 -- subnormal (value = M * 2^-149)
+//   exp == 0x00, mantissa == 0 -- +/- zero (sign preserved)
+//   exp in [1,254]             -- normal (value = 1.M * 2^(exp-127))
+//
+// For arithmetic we restore the implicit leading 1 for normal operands
+// so the mantissa is 24 bits [1.MMMMMMMMMMMMMMMMMMMMMMM].  We store it
+// in the top three bytes of a 4-byte tuple [m3:m2:m1:m0] where m0 is a
+// sub-LSB byte holding round + guard bits shifted down during alignment.
+// A separate `stk` byte accumulates a running sticky OR of bits that
+// fall off the bottom of m0.
+//
+//   4-byte working mantissa: [m3 : m2 : m1 : m0]  (little-endian; m0 low)
+//        m3 bit 7 = implicit leading 1 for normals (set on unpack)
+//        m1..m3   = 24-bit true mantissa
+//        m0       = sub-LSB byte (round + guard + partial sticky)
+//   +  1-byte stk = sticky OR of bits shifted below m0's bit 0
+//
+// ============================================================================
+// REFERENCE: MOS calling convention for this function
+// ============================================================================
+//
+// float __addsf3(float a, float b) with the standard llvm-mos ABI:
+//
+//   INPUT:  a's bytes in A, X, __rc2, __rc3  (byte 0 in A ... byte 3 in rc3)
+//           b's bytes in __rc4, __rc5, __rc6, __rc7
+//   OUTPUT: result bytes in A, X, __rc2, __rc3
+//
+//   Caller-saved:  A, X, Y, flags, __rc2..__rc19 (RS1..RS9)
+//   Callee-saved:  __rc0/__rc1 (RS0 = soft SP), __rc20..__rc31 (RS10..RS15)
+//
+// Because this is `__attribute__((naked, noinline))`, the compiler emits
+// no prologue or epilogue.  We are responsible for everything, but the
+// benefit is enormous: since we confine all state to caller-saved slots
+// we pay zero cycles/bytes to save/restore callee-saved registers.
+//
+// ============================================================================
+// REFERENCE: zero-page layout during arithmetic
+// ============================================================================
+//
+// Fields are chosen so that on entry the incoming byte order (A, X in
+// registers; b's bytes starting at __rc4) maps cleanly to our working
+// slots with the fewest moves during unpack.
+//
+//     Slot     Name    Purpose
+//     ------   ------  ---------------------------------------------------
+//     __rc2    B_M0    b's sub-LSB byte (0 on entry, holds R/G bits)
+//     __rc3    B_M1    b's low mantissa byte  (was b_byte0 on entry)
+//     __rc4    B_M2    b's mid mantissa byte  (was b_byte1 on entry)
+//     __rc5    B_M3    b's high mantissa byte (implicit 1 in bit 7 for normal)
+//     __rc6    B_EXP   b's biased exponent
+//     __rc7    B_SIGN  b's sign in bit 7 (0x00 or 0x80)
+//     __rc8    B_STK   b's sticky bit (0 or nonzero)
+//
+//     __rc9    TMP     scratch used in align/pack/round
+//
+//     __rc10   A_M0    a's sub-LSB byte
+//     __rc11   A_M1    a's low mantissa byte
+//     __rc12   A_M2    a's mid mantissa byte
+//     __rc13   A_M3    a's high mantissa byte
+//     __rc14   A_EXP   a's biased exponent
+//     __rc15   A_SIGN  a's sign in bit 7
+//     __rc16   A_STK   a's sticky bit
+//
+//     __rc17   TMP2    scratch used in align
+//     __rc18/19 unused
+//
+// After the magnitude-compare swap, `a` always holds the operand with
+// the larger absolute value, so the special-case dispatch only needs to
+// classify a (and check b in a handful of sub-cases).
+//
+// ============================================================================
+// REFERENCE: MOS assembler gotchas we work around
+// ============================================================================
+//
+// 1. Assembler-local labels use the ".L" prefix (stripped from the object
+//    symbol table).  Under LTO the whole link is codegenned into one .s,
+//    so ".L" scoping is per-assembler-invocation, NOT per-source-file --
+//    two mos/*.c files defining ".Lpack_a" WILL collide.  We work around
+//    this with a per-function prefix (".L__addsf3_pack_a" etc.) so every
+//    label is unique across the LTO unit.
+//    Numeric labels (1:, 2:, ..., 32:) work the same way inside inline
+//    asm: they become .L__addsf3_tmpNN and each `Nf` refers to the next `N:`
+//    forward.  Do NOT reuse the same numeric label multiple times.
+//
+// 2. Out-of-range branch offsets are silently TRUNCATED to 8 bits rather
+//    than reported as an error.  A BEQ/BNE/BCC/BCS whose target is more
+//    than +127/-128 bytes away will wrap around to a totally different
+//    address and execute garbage.  For any conditional branch that
+//    reaches a label past that limit we use the invert-and-jump pattern:
+//        bne .L__addsf3_skip / jmp .L__addsf3_far_target / .L__addsf3_skip:
+//    OR, when several far branches share a common target, we place a
+//    small trampoline (jmp .L__addsf3_far_target) within byte range of all of
+//    them and branch to the trampoline.  See .L__addsf3_tramp_pack_a below.
+//
+// 3. Even-numbered __rcN slots (rc2, rc4, ...) are declared with
+//    PROVIDE() in the linker script, so a platform can reorder them.
+//    The only guaranteed-contiguous groups are pointer pairs:
+//    (rc0,rc1), (rc2,rc3), (rc4,rc5), ...  This means we can NOT use
+//    zp,x indexed addressing across our named slots -- every access has
+//    to be by name.  See the do_swap section below.
+//
+// ============================================================================
+// REFERENCE: algorithm phases
+// ============================================================================
+//
+//   1. UNPACK A: split A/X/rc2/rc3 into sign/exp/mantissa/sticky in
+//      __rc10..__rc16.  Restore implicit-1 bit in m3 for normals.
+//   2. UNPACK B: same for b's bytes in rc4..rc7, target __rc2..__rc8.
+//   3. COMPARE + SWAP: compare |a| vs |b| by (exp, m3, m2, m1) tuple;
+//      if a < b, swap all five fields so a becomes the larger.
+//   4. INF/NAN DISPATCH: if a's exp is 0xFF, classify (NaN vs inf) and
+//      handle (quiet NaN, inf+inf sign check, etc.).
+//   5. ZERO DISPATCH: if a is zero, b is zero too; return signed zero.
+//   6. ALIGN: shift b's mantissa right by (a.exp - b.exp) using a
+//      whole-byte fast path for shifts >= 8 and a bit loop for the
+//      residual, accumulating sticky in B_STK.
+//   7. ADD or SUBTRACT: same-sign -> add; opposite-sign -> subtract.
+//      Same-sign carry-out triggers a right-shift and exp++.
+//   8. NORMALIZE (subtract only): shift left until bit 7 of m3 is set
+//      or exp reaches 0 (subnormal result).
+//   9. SUBNORMAL FIX: if arithmetic produced m3 bit 7 set with exp==0,
+//      bump exp to 1 so pack keeps the implicit bit.
+//  10. OVERFLOW: exp >= 0xFF -> signed infinity.
+//  11. ROUND: nearest-ties-to-even using round/guard/sticky in m0/stk;
+//      ripple-increment m1..m3 and possibly bump exp to overflow.
+//  12. PACK: reassemble result bytes back into A, X, __rc2, __rc3.
+//
+//===----------------------------------------------------------------------===//
+
+#include "../int_lib.h"
+#include <stdint.h>
+
+#define B_M0   "__rc2"
+#define B_M1   "__rc3"
+#define B_M2   "__rc4"
+#define B_M3   "__rc5"
+#define B_EXP  "__rc6"
+#define B_SIGN "__rc7"
+#define B_STK  "__rc8"
+#define A_M0   "__rc10"
+#define A_M1   "__rc11"
+#define A_M2   "__rc12"
+#define A_M3   "__rc13"
+#define A_EXP  "__rc14"
+#define A_SIGN "__rc15"
+#define A_STK  "__rc16"
+// __rc17..__rc18 are free; align scratch reuses __rc9 (TMP).
+#define TMP    "__rc9"
+#define TMP2   "__rc17"                      // second scratch (align)
+
+__attribute__((naked, noinline))
+COMPILER_RT_ABI float __addsf3(float af, float bf) {
+    asm volatile (
+        // ================================================================
+        // Phase 1 -- UNPACK A: A/X/__rc2/__rc3 (a's incoming bytes) into
+        // our working slots __rc10..__rc16.  See the "IEEE 754 binary32
+        // memory layout" reference at top of file.
+        //
+        // On entry: A = a_byte0 (low mantissa), X = a_byte1,
+        //           __rc2 = a_byte2 (E0|MMMMMMM), __rc3 = a_byte3 (S|EEEEEEE)
+        //
+        // A_M1 and A_M2 come straight from A and X.
+        // A_EXP uses the ASL/ROL trick: ASL __rc2 puts byte2's bit 7 (E0)
+        //   in C, then ROL A on byte3 gives (byte3<<1)|C = 8-bit biased exp.
+        // A_SIGN is byte3's bit 7 preserved as 0x00 or 0x80.
+        // A_M3 is byte2's low 7 mantissa bits, with the implicit leading 1
+        //   restored (bit 7 set) iff we're normal (exp != 0).
+        // A_M0 and A_STK start at 0 (no sub-LSB bits, no sticky yet).
+        // ================================================================
+        "sta " A_M1 "\n"                        // A_M1 = byte0
+        "stx " A_M2 "\n"                        // A_M2 = byte1
+
+        // Extract biased exponent from (byte3<<1)|(byte2>>7)
+        "lda __rc2\n"                           // A = byte2
+        "asl a\n"                               // C = byte2[7] = E0
+        "lda __rc3\n"                           // A = byte3, C preserved
+        "rol a\n"                               // A = (byte3<<1)|C = biased exp
+        "sta " A_EXP "\n"
+
+        // Extract sign bit (byte3 & 0x80)
+        "lda __rc3\n"
+        "and #$80\n"
+        "sta " A_SIGN "\n"
+
+        // Restore mantissa MSB with implicit leading 1 for normals:
+        //   A_M3 = (byte2 & 0x7f) | (exp!=0 ? 0x80 : 0)
+        "lda __rc2\n"
+        "and #$7f\n"                            // strip E0
+        "ldy " A_EXP "\n"                       // check exp
+        "beq 1f\n"                              // exp==0 -> subnormal, no bit 7
+        "ora #$80\n"                            // exp!=0 -> set implicit 1
+        "1: sta " A_M3 "\n"
+
+        // Initialise sub-LSB byte and sticky.
+        "lda #0\n"
+        "sta " A_M0 "\n"
+        "sta " A_STK "\n"
+
+        // ================================================================
+        // Phase 2 -- UNPACK B: __rc4..__rc7 (b's incoming bytes) into
+        // __rc2..__rc8.  Same shape as unpack A.  We can safely overwrite
+        // __rc2/__rc3 now because a's data has been fully extracted.
+        //
+        // Order matters: we read __rc4/__rc5 (b_byte0/1) before writing
+        // to B_M1 (=__rc3), which happens to be safe because we're
+        // writing to __rc3 and reading from __rc4/__rc5 which are
+        // preserved.
+        // ================================================================
+        "lda __rc4\n"                           // b_byte0
+        "sta " B_M1 "\n"
+        "lda __rc5\n"                           // b_byte1
+        "sta " B_M2 "\n"
+
+        // Biased exp via the ASL/ROL trick, stashed in Y temporarily
+        // so we can consult it while computing B_M3.
+        "lda __rc6\n"
+        "asl a\n"
+        "lda __rc7\n"
+        "rol a\n"
+        "tay\n"                                 // Y = b_exp
+
+        "lda __rc6\n"
+        "and #$7f\n"
+        "cpy #0\n"
+        "beq 2f\n"
+        "ora #$80\n"
+        "2: sta " B_M3 "\n"
+        "sty " B_EXP "\n"
+
+        "lda __rc7\n"
+        "and #$80\n"
+        "sta " B_SIGN "\n"
+
+        "lda #0\n"
+        "sta " B_M0 "\n"
+        "sta " B_STK "\n"
+
+        // ================================================================
+        // COMPARE |a| vs |b|; swap if |a| < |b|
+        // ================================================================
+        // ================================================================
+        // Phase 3 -- MAGNITUDE COMPARE and SWAP.
+        //
+        // We want |a| >= |b| after this phase, so the arithmetic can
+        // freely assume a is the "larger" operand (align always shifts
+        // b, subtract never underflows a, special-case dispatch only
+        // checks a's classification).
+        //
+        // Since sign is stored separately, |a| = a's exp:m3:m2:m1 as an
+        // unsigned tuple.  IEEE 754's clever bit layout makes this a
+        // straight byte-wise lexicographic compare from high (exp) to
+        // low (m1) -- m0 and stk are both 0 for both operands at this
+        // point so we can ignore them.
+        //
+        // BCC/BNE cascade: at each level, BCC on "a<b at this byte"
+        // jumps to swap; BNE on "a>b at this byte" jumps past swap.
+        // Only equality falls through to the next-lower byte.
+        // ================================================================
+        "lda " A_EXP "\n"
+        "cmp " B_EXP "\n"
+        "bcc .L__addsf3_do_swap\n"
+        "bne .L__addsf3_no_swap\n"
+        "lda " A_M3 "\n"
+        "cmp " B_M3 "\n"
+        "bcc .L__addsf3_do_swap\n"
+        "bne .L__addsf3_no_swap\n"
+        "lda " A_M2 "\n"
+        "cmp " B_M2 "\n"
+        "bcc .L__addsf3_do_swap\n"
+        "bne .L__addsf3_no_swap\n"
+        "lda " A_M1 "\n"
+        "cmp " B_M1 "\n"
+        "bcs .L__addsf3_no_swap\n"
+
+        ".L__addsf3_do_swap:\n"
+        // Swap 5 fields (m1, m2, m3, exp, sign).  MUST be unrolled --
+        // we cannot use zp,x indexed addressing over the __rcN range
+        // because only pair members rc(2N)/rc(2N+1) are guaranteed
+        // contiguous; the platform's imag-regs.ld may reorder even-rc
+        // slots between pairs.  See llvm-mos-sdk .../lib/imag-regs.ld.
+        // m0 and stk are known 0 for both operands here, so no need to
+        // swap them.
+        "ldx " A_M1 " \n" "lda " B_M1 " \n" "sta " A_M1 " \n" "stx " B_M1 "\n"
+        "ldx " A_M2 " \n" "lda " B_M2 " \n" "sta " A_M2 " \n" "stx " B_M2 "\n"
+        "ldx " A_M3 " \n" "lda " B_M3 " \n" "sta " A_M3 " \n" "stx " B_M3 "\n"
+        "ldx " A_EXP "\n" "lda " B_EXP "\n" "sta " A_EXP "\n" "stx " B_EXP "\n"
+        "ldx " A_SIGN "\n""lda " B_SIGN "\n""sta " A_SIGN "\n""stx " B_SIGN "\n"
+
+        ".L__addsf3_no_swap:\n"
+
+        // ================================================================
+        // Phase 4 -- INF/NAN dispatch.
+        //
+        // Exp == 0xFF marks a special value.  Since |a| >= |b|, we only
+        // need to check a first; b's classification only matters in
+        // sub-cases (b is also NaN, or inf+inf with opposite signs).
+        //
+        // Distinguishing NaN vs inf: mantissa != 0 -> NaN, mantissa == 0
+        // -> inf.  We inline the (m3&0x7f)|m2|m1 OR check at each site
+        // rather than precomputing it globally, because common-path
+        // inputs (exp in [1,254]) never need it.
+        //
+        // IEEE 754 propagates NaN: NaN + anything = NaN.  We "quiet" the
+        // NaN by setting bit 22 (which is bit 6 of m3, or 0x40 in
+        // "high byte + implicit 1 restored" form).
+        // ================================================================
+        "lda " A_EXP "\n"
+        "cmp #$ff\n"
+        "bne .L__addsf3_not_infnan\n"
+
+        // a_exp == 0xff.  Is a a NaN or an inf?
+        "lda " A_M3 "\n"
+        "and #$7f\n"
+        "ora " A_M2 "\n"
+        "ora " A_M1 "\n"
+        "beq .L__addsf3_a_is_inf\n"
+        // a is NaN -> quiet and return a
+        "lda " A_M3 "\n"
+        "ora #$40\n"
+        "sta " A_M3 "\n"
+        "jmp .L__addsf3_pack_a\n"
+
+        ".L__addsf3_a_is_inf:\n"
+        // a is +/- inf.  If b is finite, result is a.
+        "lda " B_EXP "\n"
+        "cmp #$ff\n"
+        // .L__addsf3_pack_a is > 127 bytes away and the assembler silently
+        // truncates out-of-range branch offsets, so instead of a bare
+        // "bne .L__addsf3_pack_a" we branch to the .L__addsf3_tramp_pack_a trampoline
+        // placed just a few instructions below (in byte range).
+        "bne .L__addsf3_tramp_pack_a\n"
+        // b is also inf or NaN -- classify with an inline OR check.
+        "lda " B_M3 "\n"
+        "and #$7f\n"
+        "ora " B_M2 "\n"
+        "ora " B_M1 "\n"
+        "beq .L__addsf3_both_inf\n"
+        // b is NaN -> quiet b and return b.  The result flows through
+        // the pack_b_to_a prologue which copies b's fields into a's
+        // slots then falls into the shared pack_a exit.
+        "lda " B_M3 "\n"
+        "ora #$40\n"
+        "sta " B_M3 "\n"
+        "jmp .L__addsf3_pack_b_to_a\n"
+
+        // Shared trampoline: both .L__addsf3_a_is_inf and .L__addsf3_both_inf branch here
+        // to reach .L__addsf3_pack_a (which is >127 bytes below, past all the
+        // arithmetic phases).  Position matters -- it must be within
+        // byte range of every branch that targets it.  Both callers
+        // above are within ~20 bytes, so this location is fine.
+        ".L__addsf3_tramp_pack_a:\n"
+        "jmp .L__addsf3_pack_a\n"
+
+        ".L__addsf3_both_inf:\n"
+        // Both operands are +/- inf.  Same sign -> return that inf.
+        // Different signs -> +inf + -inf is IEEE-undefined and returns
+        // a qNaN (canonical 0x7fc00000).
+        "lda " A_SIGN "\n"
+        "cmp " B_SIGN "\n"
+        "beq .L__addsf3_tramp_pack_a\n"                  // same sign -> return a
+        // Different signs: build 0x7fc00000 directly into the ABI return
+        // slots and RTS.  byte0=0 (in A), byte1=0 (in X), byte2=0xc0
+        // (in __rc2), byte3=0x7f (in __rc3).
+        "lda #$7f\n"
+        "sta __rc3\n"
+        "lda #$c0\n"
+        "sta __rc2\n"
+        "ldx #0\n"
+        "lda #0\n"
+        "rts\n"
+
+        ".L__addsf3_not_infnan:\n"
+        // ================================================================
+        // Phase 5 -- ZERO dispatch.
+        //
+        // Since |a| >= |b|, if a is zero then b must also be zero.
+        // IEEE 754 signed-zero rule for addition:
+        //     +0 + +0 = +0        -0 + -0 = -0
+        //     +0 + -0 = +0        -0 + +0 = +0
+        // Equivalently: result sign = a_sign AND b_sign (bit 7 semantic).
+        //
+        // If a has exp==0 with a nonzero mantissa, it's a subnormal
+        // (not zero), and we fall through to the normal arithmetic path.
+        // ================================================================
+        "lda " A_EXP "\n"
+        "bne .L__addsf3_not_zero\n"
+        // a_exp == 0 -- is it a zero (all mantissa bits 0) or subnormal?
+        "lda " A_M3 "\n"
+        "and #$7f\n"
+        "ora " A_M2 "\n"
+        "ora " A_M1 "\n"
+        "bne .L__addsf3_not_zero\n"                     // subnormal -> normal path
+        // a is +/- 0.  b is also +/- 0.  Apply signed-zero rule to b's
+        // sign in place, then dispatch through pack_b_to_a.
+        "lda " B_SIGN "\n"
+        "and " A_SIGN "\n"
+        "sta " B_SIGN "\n"
+        "jmp .L__addsf3_pack_b_to_a\n"
+
+        ".L__addsf3_not_zero:\n"
+        // ================================================================
+        // Phase 6 -- ALIGN b's mantissa to a's exponent.
+        //
+        // Shift count = a_effective_exp - b_effective_exp, where the
+        // "effective exp" of a subnormal (biased exp = 0) is 1 (since
+        // the smallest normal has biased exp 1 and represents 2^-126,
+        // and a subnormal represents the same power range with the
+        // implicit-1 removed).
+        //
+        // Cases:
+        //   both normal:                shift = a_exp - b_exp
+        //   a normal, b subnormal:      shift = a_exp - 1
+        //   both subnormal (a_exp==0):  shift = 0  (early exit)
+        //   a subnormal, b normal:      impossible after swap (|a|>=|b|)
+        //
+        // Do the a_exp-first check to skip everything for the "both
+        // subnormal" case (no shift needed).  Otherwise SBC on B_EXP
+        // gives a_exp - b_exp; the correction "-1 more if b was 0" is a
+        // single SBC #1 whose C-input is still set from the previous
+        // SBC (which cannot have borrowed because a >= b).
+        // ================================================================
+        "lda " A_EXP "\n"
+        "beq .L__addsf3_align_done\n"                   // both subnormal, no shift
+        "sec\n"
+        "sbc " B_EXP "\n"                       // A = a_exp - b_exp
+        // If b_exp was 0, we need one more decrement (want a_exp - 1).
+        // C is still set from the SBC above (a>=b -> no borrow).
+        "ldy " B_EXP "\n"
+        "bne 7f\n"
+        "sbc #1\n"
+        "7: beq .L__addsf3_align_done\n"                 // shift == 0, no work
+
+        // If shift count is >= 32, b's entire 4-byte mantissa is discarded
+        // and the sticky bit is set (b was nonzero -- else we'd have taken
+        // the zero-dispatch path).  This is a size/cycles win over letting
+        // the bit loop iterate 32+ times.
+        "cmp #32\n"
+        "bcc .L__addsf3_align_byte_check\n"
+        "lda #0\n"
+        "sta " B_M0 "\n"
+        "sta " B_M1 "\n"
+        "sta " B_M2 "\n"
+        "sta " B_M3 "\n"
+        "lda #1\n"
+        "sta " B_STK "\n"
+        "jmp .L__addsf3_align_done\n"
+
+        // Whole-byte fast path: while count >= 8, shift the tuple down by
+        // 8 bits with a byte-shuffle (m0 <- m1, m1 <- m2, m2 <- m3, m3 <- 0)
+        // and decrement count by 8.  Anything that would have shifted out
+        // of m0 becomes sticky (we OR in the old m0's whole byte because
+        // sticky is "any bit was 1 anywhere below the LSB" -- exact value
+        // doesn't matter, only nonzero-ness).
+        //
+        // Count is saved on hardware stack via PHA/PLA around the shuffle
+        // since we need A for the byte moves.
+        ".L__addsf3_align_byte_check:\n"
+        "cmp #8\n"
+        "bcc .L__addsf3_align_bit_setup\n"
+        "sec\n"
+        "sbc #8\n"
+        "pha\n"                              // save residual count
+        "lda " B_M0 "\n"
+        "beq 11f\n"
+        "sta " B_STK "\n"                    // any nonzero suffices for sticky
+        "11: lda " B_M1 "\n"
+        "sta " B_M0 "\n"
+        "lda " B_M2 "\n"
+        "sta " B_M1 "\n"
+        "lda " B_M3 "\n"
+        "sta " B_M2 "\n"
+        "lda #0\n"
+        "sta " B_M3 "\n"
+        "pla\n"
+        "jmp .L__addsf3_align_byte_check\n"
+
+        // Bit loop for the residual 1..7 shifts.  After the LSR/ROR chain,
+        // C holds the bit that just fell off m0's LSB -- if set, mark
+        // sticky.  Y is the loop counter (DEY sets Z, BNE loops).
+        ".L__addsf3_align_bit_setup:\n"
+        "tay\n"
+        "beq .L__addsf3_align_done\n"                 // residual == 0, done
+        ".L__addsf3_align_bit_loop:\n"
+        "lsr " B_M3 "\n"
+        "ror " B_M2 "\n"
+        "ror " B_M1 "\n"
+        "ror " B_M0 "\n"
+        "bcc 12f\n"                          // C = bit that fell off m0[0]
+        "lda #1\n"
+        "sta " B_STK "\n"
+        "12: dey\n"
+        "bne .L__addsf3_align_bit_loop\n"
+
+        ".L__addsf3_align_done:\n"
+
+        // ================================================================
+        // Phase 7 -- ADD or SUBTRACT the aligned mantissas.
+        //
+        // Same-sign path is a straight 4-byte ADC chain over the
+        // [m3:m2:m1:m0] tuple.  A carry out of m3 means the sum grew
+        // past 2.0; we shift the whole tuple right by 1 and increment
+        // the exponent to keep the mantissa in [1.0, 2.0) form.
+        //
+        // Opposite-sign path is a 4-byte SBC chain; since a is the
+        // larger operand (post-swap), no borrow can propagate out of
+        // m3.  A result of exactly zero means exact cancellation -> +0.
+        // Otherwise we normalize (shift left until m3 bit 7 is set) to
+        // restore the leading-1 form.
+        //
+        // In both paths we OR b's sticky bit into a's sticky.
+        // ================================================================
+        "lda " A_SIGN "\n"
+        "cmp " B_SIGN "\n"
+        "bne .L__addsf3_do_subtract\n"
+
+        // ---- SAME-SIGN ADD ----
+        // Straight ADC chain, byte-by-byte, low to high.
+        "clc\n"
+        "lda " A_M0 "\n" "adc " B_M0 "\n" "sta " A_M0 "\n"
+        "lda " A_M1 "\n" "adc " B_M1 "\n" "sta " A_M1 "\n"
+        "lda " A_M2 "\n" "adc " B_M2 "\n" "sta " A_M2 "\n"
+        "lda " A_M3 "\n" "adc " B_M3 "\n" "sta " A_M3 "\n"
+        "bcc .L__addsf3_add_no_carry\n"
+        // Carry out of the top: the sum has exceeded 24-bit mantissa
+        // space (there's now a virtual bit 24 = the carry).  Shift the
+        // whole tuple right by 1 to bring bit 24 back to bit 23, then
+        // OR in the implicit-1 marker (bit 7 of m3), and bump exp.
+        // C after the LSR/ROR chain is the bit that fell off m0 -- OR
+        // into sticky.
+        "lsr " A_M3 "\n"
+        "ror " A_M2 "\n"
+        "ror " A_M1 "\n"
+        "ror " A_M0 "\n"
+        "bcc 13f\n"
+        "lda #1\n"
+        "sta " A_STK "\n"
+        "13: lda " A_M3 "\n"
+        "ora #$80\n"
+        "sta " A_M3 "\n"
+        "inc " A_EXP "\n"
+        ".L__addsf3_add_no_carry:\n"
+        // Merge b's sticky into a's sticky (as a plain OR: any nonzero
+        // b-stk makes a-stk nonzero).
+        "lda " B_STK "\n"
+        "beq .L__addsf3_skip_stk_or\n"
+        "lda #1\n"
+        "sta " A_STK "\n"
+        ".L__addsf3_skip_stk_or:\n"
+        "jmp .L__addsf3_after_arith\n"
+
+        ".L__addsf3_do_subtract:\n"
+        // ---- OPPOSITE-SIGN SUBTRACT ----
+        // Straight SBC chain low-to-high.  Since |a|>=|b| post-swap,
+        // borrow cannot propagate out of m3.  Result sign is a's sign.
+        "sec\n"
+        "lda " A_M0 "\n" "sbc " B_M0 "\n" "sta " A_M0 "\n"
+        "lda " A_M1 "\n" "sbc " B_M1 "\n" "sta " A_M1 "\n"
+        "lda " A_M2 "\n" "sbc " B_M2 "\n" "sta " A_M2 "\n"
+        "lda " A_M3 "\n" "sbc " B_M3 "\n" "sta " A_M3 "\n"
+        // Merge b's sticky into a's sticky.
+        "lda " B_STK "\n"
+        "beq 9f\n"
+        "lda #1\n"
+        "sta " A_STK "\n"
+        "9:\n"
+
+        // Exact cancellation (whole tuple + sticky all zero) -> +0.
+        // Per IEEE 754, "correctly-rounded x - x" returns +0 for any
+        // finite x under round-to-nearest.
+        "lda " A_M3 "\n"
+        "ora " A_M2 "\n"
+        "ora " A_M1 "\n"
+        "ora " A_M0 "\n"
+        "ora " A_STK "\n"
+        "bne .L__addsf3_do_normalize\n"
+        "lda #0\n"
+        "sta __rc2\n"
+        "sta __rc3\n"
+        "ldx #0\n"
+        "lda #0\n"
+        "rts\n"
+
+        ".L__addsf3_do_normalize:\n"
+        // ================================================================
+        // Phase 8 -- NORMALIZE (subtract path only).
+        //
+        // After cancellation, m3's bit 7 may no longer be set.  Shift
+        // the tuple left until it is, decrementing exp accordingly.  If
+        // exp reaches 0 first, the result is subnormal (or exact
+        // cancellation, already handled).
+        //
+        // Whole-byte fast path is taken when m3 == 0 (all bits) AND exp
+        // is high enough to afford an 8-bit shift.  Each iteration
+        // shifts everything up by a byte and decrements exp by 8.  When
+        // m3 has any bit set we bail to the bit loop (which will take
+        // at most 7 iterations to place bit 7).
+        // ================================================================
+        ".L__addsf3_norm_byte_check:\n"
+        "bit " A_M3 "\n"                     // N flag <- bit 7 of A_M3
+        "bmi .L__addsf3_norm_done\n"                  // bit 7 set -> normalized
+        "lda " A_EXP "\n"
+        "cmp #9\n"
+        "bcc .L__addsf3_norm_bit_loop\n"              // exp < 9: byte-shift would
+                                             // drop exp below 1; use bits
+        "lda " A_M3 "\n"
+        "bne .L__addsf3_norm_bit_loop\n"              // m3 has bits (below bit 7):
+                                             // bit shift will finish faster
+        // Whole-byte shift left:
+        //   m3 <- m2, m2 <- m1, m1 <- m0, m0 <- (stk ? 0x80 : 0)
+        // The sticky-bit-becomes-new-m0-bit-7 rule is because sticky
+        // represents "some non-zero bit was below m0"; when we shift
+        // that region up into m0, it collapses to a single bit at the
+        // topmost position (bit 7).
+        "lda " A_M2 "\n"
+        "sta " A_M3 "\n"
+        "lda " A_M1 "\n"
+        "sta " A_M2 "\n"
+        "lda " A_M0 "\n"
+        "sta " A_M1 "\n"
+        "lda " A_STK "\n"
+        "beq 14f\n"
+        "lda #$80\n"
+        "14: sta " A_M0 "\n"
+        "lda #0\n"
+        "sta " A_STK "\n"
+        // exp -= 8
+        "lda " A_EXP "\n"
+        "sec\n"
+        "sbc #8\n"
+        "sta " A_EXP "\n"
+        "jmp .L__addsf3_norm_byte_check\n"
+
+        // Bit loop: shift left 1 per iteration, folding sticky bit into
+        // the new m0 LSB via LSR of stk into C, then ROL through the
+        // tuple.  After the ROL chain, stk is fully consumed (set to 0).
+        ".L__addsf3_norm_bit_loop:\n"
+        "bit " A_M3 "\n"
+        "bmi .L__addsf3_norm_done\n"
+        "lda " A_EXP "\n"
+        "beq .L__addsf3_norm_done\n"                  // subnormal -- stop
+        "lda " A_STK "\n"
+        "lsr a\n"                            // C <- stk bit 0
+        "rol " A_M0 "\n"                     // shift with sticky into new m0[0]
+        "rol " A_M1 "\n"
+        "rol " A_M2 "\n"
+        "rol " A_M3 "\n"
+        "lda #0\n"
+        "sta " A_STK "\n"
+        "dec " A_EXP "\n"
+        "jmp .L__addsf3_norm_bit_loop\n"
+
+        ".L__addsf3_norm_done:\n"
+        // ================================================================
+        // NORMALIZE OVERSHOOT CORRECTION (subtract path only).
+        //
+        // The normalize loop above shifts left until m3 bit 7 is set OR
+        // exp reaches 0.  When the pre-normalize value is between
+        // 2^-149 and 2^-126 (subnormal territory), those two stop
+        // conditions can BOTH be reached at the same iteration: exp
+        // decrements to 0 exactly as the shift sets m3 bit 7.  That
+        // state overshoots the subnormal boundary by one bit: encoded
+        // as "exp==0, m3 bit 7 set" the value would be 2x too large.
+        // Correct by shifting the tuple right by 1 (undoing the last
+        // normalize shift), sending the bit that falls off m0 to
+        // sticky.  Post-correction: m3 bit 7 is clear, so the subnormal
+        // fix below skips, and pack encodes it as a valid subnormal.
+        //
+        // This only bites the subtract path, since only subtract calls
+        // normalize.  The add path jumps straight to .L__addsf3_after_arith and
+        // takes the "subnormal grew into normal" fix (which needs the
+        // OPPOSITE handling -- bump exp to 1, leave mantissa alone).
+        // ================================================================
+        "lda " A_EXP "\n"
+        "bne .L__addsf3_after_arith\n"                // exp > 0, no overshoot
+        "bit " A_M3 "\n"
+        "bpl .L__addsf3_after_arith\n"                // m3 bit 7 clear, valid subnormal
+        // exp == 0 AND m3 bit 7 set: overshoot.  Shift right by 1.
+        "lsr " A_M3 "\n"
+        "ror " A_M2 "\n"
+        "ror " A_M1 "\n"
+        "ror " A_M0 "\n"
+        "bcc .L__addsf3_after_arith\n"
+        "lda #1\n"                           // bit fell off m0 -> sticky
+        "sta " A_STK "\n"
+
+        ".L__addsf3_after_arith:\n"
+        // ================================================================
+        // Phase 9 -- SUBNORMAL-GREW-INTO-NORMAL FIX (add path only).
+        //
+        // Two subnormal operands can add to a value >= 2^-126 (smallest
+        // normal); the mantissa's implicit-1 bit (m3 bit 7) is set but
+        // exp is still 0.  IEEE 754 requires that be encoded with exp=1.
+        // Pack expects exp>=1 when m3 bit 7 is set, so bump exp here.
+        //
+        // The subtract path can't reach this state: its overshoot
+        // correction above shifts the tuple such that m3 bit 7 is
+        // guaranteed clear when exp is 0.
+        // ================================================================
+        "lda " A_EXP "\n"
+        "bne .L__addsf3_skip_subnorm_fix\n"           // exp != 0, nothing to do
+        "bit " A_M3 "\n"
+        "bpl .L__addsf3_skip_subnorm_fix\n"           // m3 bit 7 clear -> true subnormal
+        "lda #1\n"
+        "sta " A_EXP "\n"
+        ".L__addsf3_skip_subnorm_fix:\n"
+
+        // ================================================================
+        // Phase 10 -- OVERFLOW -> signed infinity.
+        //
+        // exp >= 0xFF means we've saturated.  Return +/- inf with a's
+        // sign.  Encoding: byte3 = sign|0x7F, byte2 = 0x80, low bytes 0.
+        // ================================================================
+        "lda " A_EXP "\n"
+        "cmp #$ff\n"
+        "bcc .L__addsf3_do_round\n"
+
+        ".L__addsf3_return_inf:\n"
+        "lda #$80\n"
+        "sta __rc2\n"
+        "lda " A_SIGN "\n"
+        "ora #$7f\n"
+        "sta __rc3\n"
+        "ldx #0\n"
+        "lda #0\n"
+        "rts\n"
+
+        ".L__addsf3_do_round:\n"
+        // ================================================================
+        // Phase 11 -- ROUND to nearest, ties to even.
+        //
+        // Our round + guard + sticky bits are packed in m0 and stk:
+        //   R = m0 bit 7      (round bit; nearest tie boundary)
+        //   G = m0 bit 6      (guard; disambiguates > half from == half)
+        //   S = (m0 & 0x3f) != 0  ||  stk != 0
+        //   LSB = m1 bit 0    (destination LSB; for ties-to-even)
+        //
+        // Round-up condition: R && (G || S || LSB).
+        //   - R=0: below half, round down (no increment).
+        //   - R=1, G|S=1: strictly above half, round up.
+        //   - R=1, G=0, S=0: exactly half, tie to even -> round up iff
+        //     LSB is odd (would make it even after +1).
+        // ================================================================
+        "bit " A_M0 "\n"
+        "bpl .L__addsf3_pack_a\n"                     // R bit clear -> no round
+
+        // Compute (G | S | LSB) via ORs; branch to pack_a if all zero
+        // (exact tie with even LSB -> no round).
+        "lda " A_M0 "\n"
+        "and #$7f\n"                          // G bit + partial sticky bits
+        "ora " A_STK "\n"                     // fold in accumulated sticky
+        "sta " TMP "\n"
+        "lda " A_M1 "\n"
+        "and #1\n"                            // LSB for tie-to-even
+        "ora " TMP "\n"
+        "beq .L__addsf3_pack_a\n"                      // exact tie, LSB even -> no round
+
+        // Round up: ripple-increment the 24-bit mantissa.  If it wraps
+        // all the way to zero, that means m1..m3 were 0xFFFFFF and the
+        // rounded value is exactly 2^(exp+1) -- restore m3 bit 7 and
+        // bump exp (which may overflow to infinity).
+        "inc " A_M1 "\n"
+        "bne .L__addsf3_pack_a\n"
+        "inc " A_M2 "\n"
+        "bne .L__addsf3_pack_a\n"
+        "inc " A_M3 "\n"
+        "bne .L__addsf3_pack_a\n"
+        "lda #$80\n"
+        "sta " A_M3 "\n"
+        "inc " A_EXP "\n"
+        "lda " A_EXP "\n"
+        "cmp #$ff\n"
+        "bcs .L__addsf3_return_inf\n"
+
+        // ================================================================
+        // Phase 12a -- PACK B_TO_A prologue.
+        //
+        // The "b is NaN quiet" and "both zero" paths want to return b's
+        // value.  Rather than maintain a duplicate packer for b's slots,
+        // copy b's five fields into a's slots and fall through into the
+        // single shared .L__addsf3_pack_a exit.  Costs 5 load/store pairs (~30
+        // cycles on rare paths) in exchange for ~35 bytes of code we'd
+        // otherwise emit twice.
+        // ================================================================
+        ".L__addsf3_pack_b_to_a:\n"
+        "lda " B_M1 "\n"   "sta " A_M1 "\n"
+        "lda " B_M2 "\n"   "sta " A_M2 "\n"
+        "lda " B_M3 "\n"   "sta " A_M3 "\n"
+        "lda " B_EXP "\n"  "sta " A_EXP "\n"
+        "lda " B_SIGN "\n" "sta " A_SIGN "\n"
+        // fall through
+
+        // ================================================================
+        // Phase 12b -- PACK a into the ABI return position.
+        //
+        // Return convention: byte0 in A, byte1 in X, byte2 in __rc2,
+        // byte3 in __rc3.  We reconstruct the IEEE 754 layout by
+        // splitting the biased exponent between byte3's low 7 bits and
+        // byte2's high bit, and dropping the implicit-1 marker from m3.
+        //
+        //   byte3 = sign | (exp >> 1)          (S | E7..E1)
+        //   byte2 = (m3 & 0x7f) | ((exp & 1) << 7)  (E0 | M22..M16)
+        //   byte1 = m2                          (M15..M8)
+        //   byte0 = m1                          (M7..M0)
+        //
+        // Trick: LSR of exp puts the low bit in C.  That C is preserved
+        // through LDA/AND (which don't touch C), so we can BCC/BCS on
+        // it after loading m3 and ANDing to strip its bit 7.
+        // ================================================================
+        ".L__addsf3_pack_a:\n"
+        "lda " A_EXP "\n"
+        "lsr a\n"                            // A = exp>>1, C = exp bit 0 (E0)
+        "sta " TMP "\n"                       // stash exp>>1 for byte3
+        "lda " A_M3 "\n"
+        "and #$7f\n"                          // strip implicit-1 marker
+        "bcc .L__addsf3_pack_no_bit7\n"                // if E0 was 0, no bit 7
+        "ora #$80\n"                          // if E0 was 1, set bit 7
+        ".L__addsf3_pack_no_bit7:\n"
+        "sta __rc2\n"                         // byte2 = E0|(m3&0x7f)
+        "lda " TMP "\n"
+        "ora " A_SIGN "\n"
+        "sta __rc3\n"                         // byte3 = sign|(exp>>1)
+        "lda " A_M1 "\n"                      // byte0 -> A
+        "ldx " A_M2 "\n"                      // byte1 -> X
+        "rts\n"
+    );
+}

--- a/compiler-rt/lib/builtins/mos/divsf3.c
+++ b/compiler-rt/lib/builtins/mos/divsf3.c
@@ -1,0 +1,859 @@
+//===-- lib/mos/divsf3.c - Single-precision division (MOS) -----*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// __divsf3(a, b) -- IEEE 754 binary32 division for MOS (6502).
+//
+// Rounding: round-to-nearest-ties-to-even, hardcoded.  No fenv support.
+//
+// Same overall shape as addsf3.c and mulsf3.c: one naked top-level
+// function with all state in caller-saved zero-page (__rc2..__rc19),
+// .L-prefixed local labels, invert-and-jmp for far branches.  See
+// addsf3.c for the reference material on IEEE 754 layout and the
+// assembler gotchas that applies unchanged here.
+//
+// ============================================================================
+// REFERENCE: division algorithm outline
+// ============================================================================
+//
+// value(a/b) = (-1)^(sa^sb) * (Ma/Mb) * 2^((ea-eb))     for normal a,b
+//
+// Sign of result is the XOR of input signs.  Magnitude is a 24 x 24 ->
+// 25-bit mantissa division plus an exponent subtract.  Since both input
+// mantissas are in [2^23, 2^24) (implicit-1 restored), the mantissa
+// ratio Ma/Mb is in (0.5, 2.0).  Two cases fall out:
+//
+//   Case A (Ma >= Mb, ratio in [1, 2)):  the true (Ma * 2^24) / Mb
+//     quotient is a 25-bit value with bit 24 = 1.  The result mantissa
+//     (with implicit-1) is the top 24 bits of that quotient.
+//   Case B (Ma < Mb, ratio in [0.5, 1)):  quotient is a 24-bit value
+//     in [2^23, 2^24).  The result mantissa is those 24 bits directly,
+//     and the result exponent is decremented by 1 (to compensate for
+//     the [0.5, 1) → [1, 2) normalization).
+//
+// Which case applies is determined by a pre-loop 24-bit compare of
+// Ma and Mb; the flag is stored in Q_HI (1 for case A, 0 for case B).
+//
+// The divide loop is a standard 6502 shift-subtract long division.
+// Init: R = Ma; Q = 0.  For case A, we also pre-subtract D once from
+// R (matching the "would-be first quotient bit = 1" of the 25-bit
+// quotient) to establish the loop invariant "R < D".  Case B needs no
+// pre-subtract because Ma < Mb already satisfies it.
+//
+// Then 24 iterations of:
+//
+//   1. Shift [R:Q] left by 1.  The bit that falls off R2's MSB
+//      (captured in the C flag as C_out) reflects whether pre-shift R
+//      had bit 23 set -- i.e. whether the "true" 25-bit post-shift R
+//      was >= 2^24 > D.
+//   2. If C_out = 1:  force subtract D from the 24-bit R.  The 24-bit
+//      SBC's borrow "consumes" the 2^24 bit that shifted out, so the
+//      stored 24-bit R correctly reflects the 25-bit R minus D.
+//   3. Else:  trial subtract R - D.  Commit only if no borrow.
+//   4. If we subtracted (in either branch), set Q bit 0 = 1.
+//
+// A post-loop cleanup handles the exact-division boundary: if R >= D
+// after 24 iterations, subtract D once more and increment Q.  (Without
+// this, exact-divisible cases like Ma == Mb would end with R = D and
+// Q one short.)
+//
+// After the loop, Q holds the 24-bit low bits of the true quotient
+// (which is 24-bit in case B or the low 24 bits of a 25-bit value in
+// case A):
+//
+//   Case A: mantissa = 0x800000 | (Q >> 1); round bit = Q bit 0.
+//   Case B: mantissa = Q; round bit computed from a "virtual 25th
+//     iteration" (shift R left, compare/sub with D, round bit = 1 iff
+//     the virtual subtract commits).
+//
+// Sticky = (R != 0) after all shifts and the virtual iteration.
+//
+// Underflow (R_EXP <= 0) triggers a shift-right of the mantissa with
+// careful round/sticky tracking:  the old round bit becomes part of
+// the new sticky before each shift, and the bit that falls off each
+// shift becomes the new round bit.  After (1 - R_EXP) shifts, the
+// mantissa is in subnormal-encoding form and R_EXP is set to 0.
+//
+// ============================================================================
+// REFERENCE: result exponent
+// ============================================================================
+//
+//   R_EXP = a_exp + (127 - b_exp)
+//         = (a_exp - b_exp) + 127
+//
+// For normal inputs (a_exp, b_exp in [1, 254]) this is in
+// [1-254+127, 254-1+127] = [-126, 380].  Fits in signed 16-bit.
+// Subnormals renormalize like in mulsf3 -- shift the significand left
+// until bit 23 is set, adjust the effective exponent one per shift.
+//
+// After the divide loop's mantissa case-B branch (ratio < 1), R_EXP
+// gets one more decrement.
+//
+// ============================================================================
+// REFERENCE: special cases
+// ============================================================================
+//
+//   NaN / anything = quiet(a)
+//   anything / NaN = quiet(b)
+//   Inf / Inf      = qNaN
+//   Inf / finite   = signed Inf
+//   finite / Inf   = signed 0
+//   x / 0 (x != 0) = signed Inf     (IEEE 754 "divide by zero" -- we
+//                                    don't raise a flag, we just return)
+//   0 / x (x != 0) = signed 0
+//   0 / 0          = qNaN
+//
+// Sign of Inf and 0 in x/0 and 0/x follows the XOR of the operand signs.
+//
+// ============================================================================
+// REFERENCE: zero-page layout
+// ============================================================================
+//
+// Same input constraints as addsf3/mulsf3 (a in A/X/__rc2/__rc3;
+// b in __rc4..__rc7).  Unpack transforms in place where possible.
+//
+//     __rc2   A_M2      a mantissa top (implicit 1 in bit 7 for normals)
+//     __rc3   A_EXP     a's biased exponent
+//     __rc4   D0        b mantissa byte 0 (unchanged from input)
+//     __rc5   D1        b mantissa byte 1 (unchanged from input)
+//     __rc6   D2        b mantissa top (implicit 1 restored)
+//     __rc7   B_EXP     b's biased exponent
+//     __rc8   A_M0      a mantissa byte 0 (from register A)
+//     __rc9   A_M1      a mantissa byte 1 (from register X)
+//     __rc10  A_SIGN -> Q_HI     a's sign in bit 7; after dispatch reused
+//                                as bit 24 of the quotient
+//     __rc11  B_SIGN -> TMP0     b's sign; after dispatch reused as trial-
+//                                subtract scratch
+//     __rc12  R_SIGN            result sign in bit 7
+//     __rc13  R_EXP_LO          signed 16-bit result exponent, low byte
+//     __rc14  R_EXP_HI          ... high byte
+//     __rc15  R0                remainder byte 0
+//     __rc16  R1
+//     __rc17  R2
+//     __rc18  CNT               divide loop counter (25 iterations)
+//     __rc19  TMP1              trial-subtract scratch / round bit / pack
+//
+// A_M0/A_M1/A_M2 double as Q0/Q1/Q2 during the divide loop (numerator
+// is consumed as quotient bits shift up from below).
+//
+//===----------------------------------------------------------------------===//
+
+#include "../int_lib.h"
+#include <stdint.h>
+
+#define A_M2     "__rc2"
+#define A_EXP    "__rc3"
+#define D0       "__rc4"
+#define D1       "__rc5"
+#define D2       "__rc6"
+#define B_EXP    "__rc7"
+#define A_M0     "__rc8"
+#define A_M1     "__rc9"
+#define A_SIGN   "__rc10"
+#define Q_HI     "__rc10"
+#define B_SIGN   "__rc11"
+#define TMP0     "__rc11"
+#define R_SIGN   "__rc12"
+#define R_EXP_LO "__rc13"
+#define R_EXP_HI "__rc14"
+#define R0       "__rc15"
+#define R1       "__rc16"
+#define R2       "__rc17"
+#define CNT      "__rc18"
+#define TMP1     "__rc19"
+
+__attribute__((naked, noinline))
+COMPILER_RT_ABI float __divsf3(float af, float bf) {
+    asm volatile (
+        // ================================================================
+        // Phase 1 -- UNPACK A (identical to mulsf3's unpack A).
+        // ================================================================
+        "sta " A_M0 "\n"
+        "stx " A_M1 "\n"
+
+        "lda __rc3\n"
+        "and #$80\n"
+        "sta " A_SIGN "\n"
+
+        "lda __rc2\n"
+        "asl a\n"
+        "lda __rc3\n"
+        "rol a\n"
+        "sta " A_EXP "\n"
+
+        "lda __rc2\n"
+        "and #$7f\n"
+        "ldx " A_EXP "\n"
+        "beq 1f\n"
+        "ora #$80\n"
+        "1: sta " A_M2 "\n"
+
+        // ================================================================
+        // Phase 2 -- UNPACK B.
+        // ================================================================
+        "lda __rc7\n"
+        "and #$80\n"
+        "sta " B_SIGN "\n"
+
+        "lda __rc6\n"
+        "asl a\n"
+        "lda __rc7\n"
+        "rol a\n"
+        "sta " B_EXP "\n"
+
+        "lda __rc6\n"
+        "and #$7f\n"
+        "ldx " B_EXP "\n"
+        "beq 2f\n"
+        "ora #$80\n"
+        "2: sta " D2 "\n"
+
+        // ================================================================
+        // Phase 3 -- RESULT SIGN (XOR of input signs, in bit 7).
+        // ================================================================
+        "lda " A_SIGN "\n"
+        "eor " B_SIGN "\n"
+        "sta " R_SIGN "\n"
+
+        // ================================================================
+        // Phase 4 -- INF/NAN dispatch.
+        //
+        //   NaN / anything -> quiet(a) with a's sign
+        //   anything / NaN -> quiet(b) with b's sign
+        //   Inf / Inf      -> qNaN
+        //   Inf / finite   -> signed Inf
+        //   finite / Inf   -> signed 0
+        // ================================================================
+        "lda " A_EXP "\n"
+        "cmp #$ff\n"
+        "bne .L__divsf3_chk_b_special\n"
+
+        // a's exp is 0xFF.  NaN or Inf?
+        "lda " A_M2 "\n"
+        "and #$7f\n"
+        "ora " A_M1 "\n"
+        "ora " A_M0 "\n"
+        "beq .L__divsf3_a_is_inf\n"
+
+        // a is NaN -> quiet a, use a's sign.
+        "lda " A_M2 "\n"
+        "ora #$40\n"
+        "sta " A_M2 "\n"
+        "lda " A_SIGN "\n"
+        "sta " R_SIGN "\n"
+        "jmp .L__divsf3_pack_a\n"
+
+        ".L__divsf3_a_is_inf:\n"
+        // a is Inf.  Check b.
+        "lda " B_EXP "\n"
+        "cmp #$ff\n"
+        "beq .L__divsf3_a_inf_b_infnan\n"
+        // b is finite -> return signed Inf.
+        "jmp .L__divsf3_return_signed_inf\n"
+
+        ".L__divsf3_a_inf_b_infnan:\n"
+        // b's exp is 0xFF.  NaN or Inf?
+        "lda " D2 "\n"
+        "and #$7f\n"
+        "ora " D1 "\n"
+        "ora " D0 "\n"
+        "beq .L__divsf3_return_qnan\n"                // Inf / Inf = qNaN
+        // b is NaN -> return quiet(b).
+        "jmp .L__divsf3_return_quiet_b\n"
+
+        ".L__divsf3_chk_b_special:\n"
+        // a is not special.  Is b special?
+        "lda " B_EXP "\n"
+        "cmp #$ff\n"
+        "bne .L__divsf3_chk_zero\n"
+
+        // b is Inf or NaN.
+        "lda " D2 "\n"
+        "and #$7f\n"
+        "ora " D1 "\n"
+        "ora " D0 "\n"
+        "beq .L__divsf3_b_is_inf\n"
+        // b is NaN -> return quiet(b).
+        ".L__divsf3_return_quiet_b:\n"
+        "lda " D2 "\n"
+        "ora #$40\n"
+        "sta " A_M2 "\n"
+        "lda " D1 "\n"
+        "sta " A_M1 "\n"
+        "lda " D0 "\n"
+        "sta " A_M0 "\n"
+        "lda " B_EXP "\n"
+        "sta " A_EXP "\n"
+        "lda " B_SIGN "\n"
+        "sta " R_SIGN "\n"
+        "jmp .L__divsf3_pack_a\n"
+
+        ".L__divsf3_b_is_inf:\n"
+        // b is Inf, a is finite.  Return signed 0.
+        "jmp .L__divsf3_return_zero\n"
+
+        ".L__divsf3_return_signed_inf:\n"
+        "lda #0\n"
+        "sta " A_M0 "\n"
+        "sta " A_M1 "\n"
+        "lda #$80\n"
+        "sta " A_M2 "\n"
+        "lda #$ff\n"
+        "sta " A_EXP "\n"
+        "jmp .L__divsf3_pack_a\n"
+
+        ".L__divsf3_return_qnan:\n"
+        // Canonical qNaN 0x7fc00000.
+        "lda #$c0\n"
+        "sta __rc2\n"
+        "lda #$7f\n"
+        "sta __rc3\n"
+        "ldx #0\n"
+        "lda #0\n"
+        "rts\n"
+
+        // ================================================================
+        // Phase 5 -- ZERO dispatch.
+        //
+        //   0 / 0            -> qNaN
+        //   0 / nonzero      -> signed 0
+        //   nonzero / 0      -> signed Inf
+        //   nonzero / nonzero -> normal path
+        // ================================================================
+        ".L__divsf3_chk_zero:\n"
+        // Test a for zero: exp | m0 | m1 | m2 == 0.
+        "lda " A_EXP "\n"
+        "ora " A_M0 "\n"
+        "ora " A_M1 "\n"
+        "ora " A_M2 "\n"
+        "sta " TMP0 "\n"                     // TMP0 = 0 iff a is zero
+        "lda " B_EXP "\n"
+        "ora " D0 "\n"
+        "ora " D1 "\n"
+        "ora " D2 "\n"
+        "sta " TMP1 "\n"                     // TMP1 = 0 iff b is zero
+        // Dispatch:
+        "lda " TMP0 "\n"
+        "bne .L__divsf3_a_nonzero\n"
+        // a is zero.
+        "lda " TMP1 "\n"
+        "beq .L__divsf3_return_qnan\n"                // 0 / 0
+        "jmp .L__divsf3_return_zero\n"                // 0 / nonzero
+
+        ".L__divsf3_a_nonzero:\n"
+        "lda " TMP1 "\n"
+        "beq .L__divsf3_return_signed_inf\n"          // nonzero / 0
+        // Both nonzero, proceed to renormalize.
+
+        // ================================================================
+        // Phase 6 -- COMPUTE R_EXP AND RENORMALIZE SUBNORMALS.
+        //
+        // R_EXP = a_exp - b_exp + 127  (16-bit signed).  For subnormals,
+        // fold the "effective exp is 1-k where k is shift count" via
+        // pre-decrement + one dec per shift, just like mulsf3.
+        // ================================================================
+
+        // R_EXP = a_exp + 127 (as unsigned 8-bit + high 0).
+        "clc\n"
+        "lda " A_EXP "\n"
+        "adc #127\n"
+        "sta " R_EXP_LO "\n"
+        "lda #0\n"
+        "adc #0\n"
+        "sta " R_EXP_HI "\n"
+
+        // R_EXP -= b_exp.
+        "sec\n"
+        "lda " R_EXP_LO "\n"
+        "sbc " B_EXP "\n"
+        "sta " R_EXP_LO "\n"
+        "lda " R_EXP_HI "\n"
+        "sbc #0\n"
+        "sta " R_EXP_HI "\n"
+
+        // If a subnormal (a_exp == 0): R_EXP += 1, then shift A_M left
+        // until A_M2 bit 7 set, decrementing R_EXP per shift.
+        "lda " A_EXP "\n"
+        "bne .L__divsf3_renorm_b\n"
+        "inc " R_EXP_LO "\n"
+        "bne 3f\n"
+        "inc " R_EXP_HI "\n"
+        "3:\n"
+        ".L__divsf3_renorm_a_loop:\n"
+        "bit " A_M2 "\n"
+        "bmi .L__divsf3_renorm_b\n"
+        "asl " A_M0 "\n"
+        "rol " A_M1 "\n"
+        "rol " A_M2 "\n"
+        "lda " R_EXP_LO "\n"
+        "bne 4f\n"
+        "dec " R_EXP_HI "\n"
+        "4: dec " R_EXP_LO "\n"
+        "jmp .L__divsf3_renorm_a_loop\n"
+
+        ".L__divsf3_renorm_b:\n"
+        // If b subnormal: R_EXP -= 1 (subtract 1 from effective b_exp),
+        // then shift D left, INCREMENTING R_EXP per shift (because
+        // R_EXP has b_exp SUBTRACTED, and shifting b's mantissa left
+        // means b's effective exponent decreases, so R_EXP increases).
+        "lda " B_EXP "\n"
+        "bne .L__divsf3_div_init\n"
+        // Subnormal b's effective exp is (1 - k), so R_EXP was computed
+        // with too much subtracted (b_exp = 0 was used, should be
+        // 1 - k).  Adjust: R_EXP -= 1 initially (so we're at
+        // R_EXP - (-1 + k) = R_EXP + 1 - k conceptually), then INC per
+        // shift.  Actually: subtracting b_exp=0 vs b_eff=1-k means
+        // R_EXP is too HIGH by (1-k) - 0 = 1 - k.  Correct by decrementing
+        // by (1-k) = 1 - k, i.e. R_EXP -= 1 then INC per shift.
+        "lda " R_EXP_LO "\n"
+        "bne 5f\n"
+        "dec " R_EXP_HI "\n"
+        "5: dec " R_EXP_LO "\n"
+        ".L__divsf3_renorm_b_loop:\n"
+        "bit " D2 "\n"
+        "bmi .L__divsf3_div_init\n"
+        "asl " D0 "\n"
+        "rol " D1 "\n"
+        "rol " D2 "\n"
+        "inc " R_EXP_LO "\n"
+        "bne 6f\n"
+        "inc " R_EXP_HI "\n"
+        "6:\n"
+        "jmp .L__divsf3_renorm_b_loop\n"
+
+        // ================================================================
+        // Phase 7a -- DIVIDE LOOP INIT.
+        //
+        // Init R = M_A (numerator in the "high half" of a 48-bit
+        // dividend [R:Q] = M_A * 2^24), Q = 0.
+        //
+        // 24 iterations of shift-subtract-with-force will produce the
+        // 24-bit quotient in Q (low 24 bits of the true 24- or 25-bit
+        // quotient).  The "would-be bit 24" (implicit-1 for the case
+        // when M_A/M_B >= 1) is not captured in Q; it's detected via a
+        // pre-loop compare stored in Q_HI.
+        // ================================================================
+        ".L__divsf3_div_init:\n"
+        // Pre-loop compare M_A vs D (24-bit unsigned).  Store 1 in Q_HI
+        // if M_A >= M_B (case A), 0 otherwise (case B).
+        "lda " A_M2 "\n"
+        "cmp " D2 "\n"
+        "bcc .L__divsf3_case_b_init\n"
+        "bne .L__divsf3_case_a_init\n"
+        "lda " A_M1 "\n"
+        "cmp " D1 "\n"
+        "bcc .L__divsf3_case_b_init\n"
+        "bne .L__divsf3_case_a_init\n"
+        "lda " A_M0 "\n"
+        "cmp " D0 "\n"
+        "bcc .L__divsf3_case_b_init\n"
+
+        ".L__divsf3_case_a_init:\n"
+        "lda #1\n"
+        "sta " Q_HI "\n"
+        "jmp .L__divsf3_div_setup\n"
+
+        ".L__divsf3_case_b_init:\n"
+        "lda #0\n"
+        "sta " Q_HI "\n"
+
+        ".L__divsf3_div_setup:\n"
+        // Move M_A into R (as the "high half" of the 48-bit dividend).
+        // Zero out Q slots.
+        "lda " A_M0 "\n"
+        "sta " R0 "\n"
+        "lda " A_M1 "\n"
+        "sta " R1 "\n"
+        "lda " A_M2 "\n"
+        "sta " R2 "\n"
+        "lda #0\n"
+        "sta " A_M0 "\n"                     // Q0 = 0
+        "sta " A_M1 "\n"                     // Q1 = 0
+        "sta " A_M2 "\n"                     // Q2 = 0
+
+        // For case A (M_A >= M_B), pre-subtract D from R to establish
+        // the loop invariant "R < D".  The invariant is required for
+        // the shift-subtract algorithm to produce binary quotient bits.
+        // (The pre-subtract accounts for the "would-be bit 24 = 1" of
+        // the true 25-bit quotient; we already recorded that in Q_HI.)
+        "lda " Q_HI "\n"
+        "beq .L__divsf3_no_presub\n"
+        "sec\n"
+        "lda " R0 "\n"
+        "sbc " D0 "\n"
+        "sta " R0 "\n"
+        "lda " R1 "\n"
+        "sbc " D1 "\n"
+        "sta " R1 "\n"
+        "lda " R2 "\n"
+        "sbc " D2 "\n"
+        "sta " R2 "\n"
+        ".L__divsf3_no_presub:\n"
+
+        "lda #24\n"
+        "sta " CNT "\n"
+
+        // ================================================================
+        // Phase 7b -- DIVIDE LOOP: 24 iterations of shift-subtract.
+        //
+        // Layout: [R2:R1:R0:Q2:Q1:Q0] as a 48-bit shift register.
+        // Each iteration:
+        //   1. Shift left [R:Q] by 1.  Bit 23 of Q shifts into R bit 0.
+        //      The bit shifted out of R2's MSB (call it R_hi) reflects
+        //      whether the pre-shift R had bit 23 set -- i.e. whether
+        //      "true" post-shift R was >= 2^24 > D.
+        //   2. If R_hi = 1: force subtract D from R (the borrow in the
+        //      24-bit SBC exactly cancels the 2^24 bit we shifted out).
+        //   3. Else: trial subtract; commit only if no borrow.
+        //   4. If we subtracted, set Q bit 0 = 1.
+        // ================================================================
+        ".L__divsf3_div_loop:\n"
+        "asl " A_M0 "\n"                     // ASL Q0
+        "rol " A_M1 "\n"                     // ROL Q1
+        "rol " A_M2 "\n"                     // ROL Q2
+        "rol " R0 "\n"
+        "rol " R1 "\n"
+        "rol " R2 "\n"                       // C_out = pre-shift R2 bit 7
+        "bcs .L__divsf3_div_force_sub\n"
+
+        // C_out = 0: trial subtract.
+        "sec\n"
+        "lda " R0 "\n"
+        "sbc " D0 "\n"
+        "sta " TMP0 "\n"
+        "lda " R1 "\n"
+        "sbc " D1 "\n"
+        "sta " TMP1 "\n"
+        "lda " R2 "\n"
+        "sbc " D2 "\n"
+        "bcc .L__divsf3_div_no_sub\n"
+        // Commit trial subtract.
+        "sta " R2 "\n"
+        "lda " TMP1 "\n"
+        "sta " R1 "\n"
+        "lda " TMP0 "\n"
+        "sta " R0 "\n"
+        "inc " A_M0 "\n"                     // Q bit 0 = 1
+        "jmp .L__divsf3_div_no_sub\n"
+
+        ".L__divsf3_div_force_sub:\n"
+        // C_out = 1: true post-shift R was in [2^24, 2^25) > D.  Sub D
+        // from 24-bit R; the resulting borrow reflects the 2^24 bit we
+        // shifted out.  The 24-bit stored R is the correct low-24 bits
+        // of the 25-bit post-subtract value.
+        "sec\n"
+        "lda " R0 "\n"
+        "sbc " D0 "\n"
+        "sta " R0 "\n"
+        "lda " R1 "\n"
+        "sbc " D1 "\n"
+        "sta " R1 "\n"
+        "lda " R2 "\n"
+        "sbc " D2 "\n"
+        "sta " R2 "\n"
+        "inc " A_M0 "\n"                     // Q bit 0 = 1
+
+        ".L__divsf3_div_no_sub:\n"
+        "dec " CNT "\n"
+        "bne .L__divsf3_div_loop\n"
+
+        // ================================================================
+        // Phase 7c -- POST-LOOP CLEANUP.
+        //
+        // The algorithm maintains the invariant Q * D + R = dividend,
+        // but at the boundary case where the dividend is an exact
+        // multiple of D, R can end at R = D (rather than R = 0 with
+        // Q += 1).  Detect and correct: if R >= D, subtract D from R
+        // and increment Q.
+        // ================================================================
+        // Compare R with D (24-bit high byte first).
+        "lda " R2 "\n"
+        "cmp " D2 "\n"
+        "bcc .L__divsf3_div_end\n"
+        "bne .L__divsf3_div_cleanup\n"
+        "lda " R1 "\n"
+        "cmp " D1 "\n"
+        "bcc .L__divsf3_div_end\n"
+        "bne .L__divsf3_div_cleanup\n"
+        "lda " R0 "\n"
+        "cmp " D0 "\n"
+        "bcc .L__divsf3_div_end\n"
+
+        ".L__divsf3_div_cleanup:\n"
+        "sec\n"
+        "lda " R0 "\n"
+        "sbc " D0 "\n"
+        "sta " R0 "\n"
+        "lda " R1 "\n"
+        "sbc " D1 "\n"
+        "sta " R1 "\n"
+        "lda " R2 "\n"
+        "sbc " D2 "\n"
+        "sta " R2 "\n"
+        // Q += 1 (ripple through Q0/Q1/Q2).
+        "inc " A_M0 "\n"
+        "bne .L__divsf3_div_end\n"
+        "inc " A_M1 "\n"
+        "bne .L__divsf3_div_end\n"
+        "inc " A_M2 "\n"
+
+        ".L__divsf3_div_end:\n"
+
+        // ================================================================
+        // Phase 8 -- POST-LOOP MANTISSA EXTRACTION.
+        //
+        // Q_HI bit 0 = 1 (Ma >= Mb, ratio in [1, 2)):
+        //   mantissa = 0x800000 | (Q >> 1)
+        //   round bit = Q bit 0
+        //   R_EXP unchanged
+        //
+        // Q_HI bit 0 = 0 (Ma < Mb, ratio in [0.5, 1)):
+        //   mantissa = Q (bit 23 should already be set)
+        //   round bit = 0 (approximated -- see algorithm outline)
+        //   R_EXP -= 1
+        //
+        // Sticky = (R != 0).
+        //
+        // Store round bit in TMP1, sticky in TMP0 for the round phase.
+        // ================================================================
+        "lda " Q_HI "\n"
+        "and #1\n"
+        "beq .L__divsf3_case_b\n"
+
+        // Case A: Q_HI bit 0 = 1.  Shift Q right by 1, capture bit 0 as
+        // round bit, OR bit 23 into position (from Q_HI).
+        // Round bit = Q0 bit 0 pre-shift.
+        "lda " A_M0 "\n"
+        "and #1\n"
+        "sta " TMP1 "\n"                     // TMP1 = round bit
+        "lsr " A_M2 "\n"
+        "ror " A_M1 "\n"
+        "ror " A_M0 "\n"
+        "lda " A_M2 "\n"
+        "ora #$80\n"                         // set implicit-1 at bit 23
+        "sta " A_M2 "\n"
+        "jmp .L__divsf3_compute_sticky\n"
+
+        ".L__divsf3_case_b:\n"
+        // Case B: Q_HI bit 0 = 0.  Q is mantissa as-is.  Round bit
+        // requires a "virtual 25th iteration": shift R left, then
+        // compare with D.  If (2*R) >= D (or shift produced C_out=1),
+        // round bit = 1 and new R = 2*R - D; else round = 0 and new
+        // R = 2*R.  The updated R provides sticky info.  R_EXP -= 1.
+        "asl " R0 "\n"
+        "rol " R1 "\n"
+        "rol " R2 "\n"
+        "bcs .L__divsf3_round_b_do_sub\n"             // C_out=1: true R > D, always sub
+        // Compare 24-bit R with D.
+        "lda " R2 "\n"
+        "cmp " D2 "\n"
+        "bcc .L__divsf3_round_b_zero\n"
+        "bne .L__divsf3_round_b_do_sub\n"
+        "lda " R1 "\n"
+        "cmp " D1 "\n"
+        "bcc .L__divsf3_round_b_zero\n"
+        "bne .L__divsf3_round_b_do_sub\n"
+        "lda " R0 "\n"
+        "cmp " D0 "\n"
+        "bcc .L__divsf3_round_b_zero\n"
+
+        ".L__divsf3_round_b_do_sub:\n"
+        "sec\n"
+        "lda " R0 "\n"
+        "sbc " D0 "\n"
+        "sta " R0 "\n"
+        "lda " R1 "\n"
+        "sbc " D1 "\n"
+        "sta " R1 "\n"
+        "lda " R2 "\n"
+        "sbc " D2 "\n"
+        "sta " R2 "\n"
+        "lda #1\n"
+        "sta " TMP1 "\n"                     // round bit = 1
+        "jmp .L__divsf3_case_b_exp_dec\n"
+
+        ".L__divsf3_round_b_zero:\n"
+        "lda #0\n"
+        "sta " TMP1 "\n"                     // round bit = 0
+
+        ".L__divsf3_case_b_exp_dec:\n"
+        // R_EXP -= 1.
+        "lda " R_EXP_LO "\n"
+        "bne 7f\n"
+        "dec " R_EXP_HI "\n"
+        "7: dec " R_EXP_LO "\n"
+
+        ".L__divsf3_compute_sticky:\n"
+        // Sticky = R != 0.
+        "lda " R0 "\n"
+        "ora " R1 "\n"
+        "ora " R2 "\n"
+        "beq 8f\n"
+        "lda #1\n"
+        "8: sta " TMP0 "\n"                  // TMP0 = sticky (0 or 1)
+
+        // ================================================================
+        // Phase 9 -- OVERFLOW / UNDERFLOW dispatch (same as mulsf3).
+        //
+        //   R_EXP < 0            -> underflow (subnormal or zero)
+        //   R_EXP == 0           -> subnormal
+        //   R_EXP in [1, 0xFE]   -> normal, round
+        //   R_EXP >= 0xFF        -> overflow (signed Inf)
+        // ================================================================
+        "lda " R_EXP_HI "\n"
+        "bmi .L__divsf3_und\n"
+        "bne .L__divsf3_ovf\n"
+        "lda " R_EXP_LO "\n"
+        "beq .L__divsf3_und\n"
+        "cmp #$ff\n"
+        "bcc .L__divsf3_round\n"
+        // fall through: overflow
+
+        ".L__divsf3_ovf:\n"
+        "lda #$ff\n"
+        "sta " A_EXP "\n"
+        "lda #0\n"
+        "sta " A_M0 "\n"
+        "sta " A_M1 "\n"
+        "lda #$80\n"
+        "sta " A_M2 "\n"
+        "jmp .L__divsf3_pack_a\n"
+
+        ".L__divsf3_und:\n"
+        // Subnormal result: shift mantissa right by (1 - R_EXP).
+        //
+        // Rounding through the shift is tricky.  Correct semantics:
+        // per iteration, the OLD round bit becomes part of new sticky
+        // (moves down one position), the shifted-out mantissa bit
+        // becomes the new round bit.  After K shifts, round = pre-shift
+        // mantissa bit (K-1); sticky = OR of pre-shift mantissa bits
+        // (K-2..0) | pre-shift round | pre-shift sticky.
+        "sec\n"
+        "lda #1\n"
+        "sbc " R_EXP_LO "\n"
+        "cmp #32\n"
+        "bcc 9f\n"
+        "jmp .L__divsf3_return_zero\n"
+        "9: sta " CNT "\n"
+
+        ".L__divsf3_und_loop:\n"
+        "lda " CNT "\n"
+        "beq .L__divsf3_und_done\n"
+        // OLD round bit contributes to sticky.
+        "lda " TMP1 "\n"
+        "beq 10f\n"
+        "lda #1\n"
+        "sta " TMP0 "\n"
+        "10:\n"
+        // Shift mantissa right by 1.
+        "lsr " A_M2 "\n"
+        "ror " A_M1 "\n"
+        "ror " A_M0 "\n"
+        // C from ROR A_M0 = bit that just fell off = new round bit.
+        "lda #0\n"
+        "rol a\n"                            // A = 1 if C=1 else 0
+        "sta " TMP1 "\n"
+        "dec " CNT "\n"
+        "jmp .L__divsf3_und_loop\n"
+        ".L__divsf3_und_done:\n"
+        "lda #0\n"
+        "sta " R_EXP_LO "\n"
+        "sta " R_EXP_HI "\n"
+
+        ".L__divsf3_round:\n"
+        // ================================================================
+        // Phase 10 -- ROUND: nearest, ties to even.
+        //
+        //   round bit  = TMP1
+        //   sticky     = TMP0
+        //   LSB        = A_M0 bit 0
+        //
+        // Round up iff round && (sticky || LSB).
+        // ================================================================
+        "lda " TMP1 "\n"
+        "beq .L__divsf3_no_round\n"                   // round bit clear -> no round
+        // round bit set: round up iff (sticky || LSB).
+        "lda " TMP0 "\n"
+        "bne .L__divsf3_do_round\n"                   // sticky set -> round up
+        "lda " A_M0 "\n"
+        "and #1\n"
+        "beq .L__divsf3_no_round\n"                   // LSB even, sticky 0 -> tie to even
+        ".L__divsf3_do_round:\n"
+        "inc " A_M0 "\n"
+        "bne 11f\n"
+        "inc " A_M1 "\n"
+        "bne 11f\n"
+        "inc " A_M2 "\n"
+        "bne 11f\n"
+        // Full carry-out: mantissa wrapped 0xFFFFFF -> 0.  Set bit 7
+        // (implicit) and bump exp.
+        "lda #$80\n"
+        "sta " A_M2 "\n"
+        "inc " R_EXP_LO "\n"
+        "bne 11f\n"
+        "inc " R_EXP_HI "\n"
+        "11:\n"
+        // Re-check overflow.
+        "lda " R_EXP_HI "\n"
+        "bne .L__divsf3_ovf\n"
+        "lda " R_EXP_LO "\n"
+        "cmp #$ff\n"
+        "bcc .L__divsf3_no_round\n"
+        "jmp .L__divsf3_ovf\n"
+
+        ".L__divsf3_no_round:\n"
+        // Subnormal-grew-into-normal fix (only relevant if we came
+        // via the underflow path): if R_EXP == 0 but mantissa bit 23
+        // set, bump R_EXP to 1.
+        "lda " R_EXP_LO "\n"
+        "ora " R_EXP_HI "\n"
+        "bne .L__divsf3_setup_pack\n"
+        "bit " A_M2 "\n"
+        "bpl .L__divsf3_setup_pack\n"
+        "lda #1\n"
+        "sta " R_EXP_LO "\n"
+
+        ".L__divsf3_setup_pack:\n"
+        "lda " R_EXP_LO "\n"
+        "sta " A_EXP "\n"
+        // fall through to .L__divsf3_pack_a
+
+        // ================================================================
+        // Phase 11 -- PACK a into ABI return position.
+        //
+        // Same layout as addsf3/mulsf3 pack.
+        // ================================================================
+        ".L__divsf3_pack_a:\n"
+        "lda " A_EXP "\n"
+        "lsr a\n"
+        "sta " TMP1 "\n"
+        "lda " A_M2 "\n"
+        "and #$7f\n"
+        "bcc 12f\n"
+        "ora #$80\n"
+        "12: sta __rc2\n"
+        "lda " TMP1 "\n"
+        "ora " R_SIGN "\n"
+        "sta __rc3\n"
+        "lda " A_M0 "\n"
+        "ldx " A_M1 "\n"
+        "rts\n"
+
+        // ================================================================
+        // Return signed zero.  R_SIGN was computed in Phase 3; the low
+        // three bytes are 0 and byte 3 is R_SIGN.
+        // ================================================================
+        ".L__divsf3_return_zero:\n"
+        "lda #0\n"
+        "sta __rc2\n"
+        "lda " R_SIGN "\n"
+        "sta __rc3\n"
+        "ldx #0\n"
+        "lda #0\n"
+        "rts\n"
+    );
+}

--- a/compiler-rt/lib/builtins/mos/mulsf3.c
+++ b/compiler-rt/lib/builtins/mos/mulsf3.c
@@ -1,0 +1,833 @@
+//===-- lib/mos/mulsf3.c - Single-precision multiplication (MOS) -*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// __mulsf3(a, b) -- IEEE 754 binary32 multiplication for MOS (6502).
+//
+// Rounding: round-to-nearest-ties-to-even, hardcoded.  No fenv support
+// (see addsf3.c for the rationale).
+//
+// This file follows the same structural pattern as addsf3.c: one naked
+// top-level function containing one big asm volatile block, all state
+// in caller-saved zero-page slots, .L-prefixed local labels, invert-and-
+// jump for out-of-range branches.  See addsf3.c for the reference
+// material on IEEE 754 layout, the MOS ABI, and assembler gotchas that
+// applies verbatim here.
+//
+// ============================================================================
+// REFERENCE: multiplication algorithm outline
+// ============================================================================
+//
+// value(x)  = (-1)^s * 1.m * 2^(e-127)     for normal x
+//           = (-1)^s * 0.m * 2^-126        for subnormal x
+//
+// The product's sign is the XOR of input signs.  For the magnitude, we
+// need a 24-bit x 24-bit unsigned integer multiply of the "significand
+// with implicit 1 restored" -- a value in [2^23, 2^24) for normals.  The
+// full 48-bit product lands in [2^46, 2^48); its top bit distinguishes
+// the two cases:
+//
+//   product bit 47 set:  product in [2^47, 2^48)  ->  quotient in [2,4)
+//                        (exp adjustment +1, no bit shift)
+//   product bit 47 clear (bit 46 set): product in [2^46, 2^47) -> [1,2)
+//                        (no exp change, shift product left by 1)
+//
+// After that shift, bit 47 of the 48-bit product always holds the new
+// implicit-1 bit, so we can pull mantissa/round/guard/sticky out of
+// fixed positions regardless of which case applied.
+//
+// The result exponent is computed in signed 16-bit as
+//
+//   result_exp = eff_a + eff_b - 127
+//
+// where eff_a is a's biased exponent (or, for subnormals renormalized
+// by shifting their significand left by k bits, 1 - k -- which can go
+// as low as -22).  Range is roughly [-171, 381].  The +1 from the bit-47
+// case is applied after the multiply.
+//
+// Subnormal renormalization: while significand bit 23 (M2 bit 7) is 0,
+// shift the 24-bit significand left by 1 and decrement the effective
+// exponent (which starts at 0 for a raw subnormal).  A raw subnormal has
+// at least one bit set (the exp==0 && mantissa==0 case is a true zero
+// handled by the zero-dispatch above), so the loop terminates.
+//
+// ============================================================================
+// REFERENCE: the shift-and-add multiply core
+// ============================================================================
+//
+// Classic 6502 right-shift multiply, extended to 24 x 24 -> 48.  Layout
+// during the loop:
+//
+//   [PH2 : PH1 : PH0 : B_M2 : B_M1 : B_M0]        (48-bit shift register)
+//     ^^^^^^^^^^^^^^^^^                              product high half
+//                       ^^^^^^^^^^^^^^^^^^^         multiplier B; becomes
+//                                                   product low half as
+//                                                   B's bits are consumed
+//
+//   A_M2 : A_M1 : A_M0                             multiplicand A (fixed)
+//
+// Setup: PH2:PH1:PH0 = 0; multiplier already in B_M2:B_M1:B_M0.
+//
+// Pre-shift: LSR B_M2 / ROR B_M1 / ROR B_M0.  This puts B's LSB into C
+// for the first iteration's decide, and shifts the multiplier once so
+// that after 24 iterations the accumulator has traveled the full width.
+//
+// Loop body (repeated 24 times):
+//
+//   BCC skip           ; if the bit we just extracted was 0, no add
+//   CLC
+//   LDA PH0; ADC A_M0; STA PH0
+//   LDA PH1; ADC A_M1; STA PH1
+//   LDA PH2; ADC A_M2; STA PH2
+//   ; C now = carry-out of the 24-bit add (i.e., accumulator bit 24)
+// skip:
+//   ROR PH2            ; incorporate C into bit 7 of PH2, shift right
+//   ROR PH1            ; ripple; each ROR moves its LSB into C for
+//   ROR PH0            ; the next ROR up the chain
+//   ROR B_M2
+//   ROR B_M1
+//   ROR B_M0           ; final C = B_M0's old bit 0 = next multiplier bit
+//   DEY
+//   BNE loop
+//
+// When BCC skips the add, C is still 0 (that's what we branched on), so
+// the ROR chain shifts a 0 into PH2's MSB -- which is correct: no add
+// means no carry into bit 24 of the accumulator.
+//
+// ============================================================================
+// REFERENCE: rounding, packing, and edge cases
+// ============================================================================
+//
+// After the multiply and the bit-47 normalize step, the layout is:
+//
+//   PH2 bit 7 = implicit 1 (mantissa MSB)
+//   PH2..PH0  = 24-bit mantissa (including implicit)
+//   B_M2 bit 7 = round bit (R)
+//   B_M2 bit 6 = guard bit (G)
+//   OR(B_M2 & 0x3F, B_M1, B_M0) = sticky (S)
+//
+// Round up iff R && (G || S || mantissa_LSB).  A rounding overflow
+// (mantissa was 0xFFFFFF and got incremented) is detected by
+// mantissa == 0 after the increment; we restore bit 7 and bump exp.
+//
+// If result_exp <= 0, the result is subnormal (or zero): shift the
+// mantissa right by (1 - result_exp) with sticky, then round, then set
+// exp = 0.  If the shift count would leave nothing (>= 25), return
+// signed zero.
+//
+// If result_exp >= 0xFF (after any exp++ from bit-47 normalize or from
+// round-up wrap), return signed infinity.
+//
+// ============================================================================
+// REFERENCE: zero-page layout
+// ============================================================================
+//
+// Slot assignment is constrained by the ABI: on entry a's bytes 2/3 sit
+// in __rc2/__rc3 and b's four bytes sit in __rc4..__rc7.  Byte 0/1 of a
+// arrive in A/X (registers, not zero page).  We picked the layout so
+// unpack can reuse the input slots in-place without needing extra
+// scratch: A's byte2/byte3 sit at __rc2/__rc3 so A_M2 and A_EXP land
+// there naturally after transformation; B's byte 0/1 need no move at
+// all (they're already at B_M0/B_M1 = __rc4/__rc5), and B_M2/B_EXP
+// overwrite b's byte2/byte3 in place at __rc6/__rc7.  A_M0/A_M1 come
+// from registers A/X so they get fresh slots (__rc8/__rc9).
+//
+//     __rc2  A_M2    a mantissa top byte (implicit 1 in bit 7 for normals)
+//     __rc3  A_EXP   a's biased exponent
+//     __rc4  B_M0    b mantissa byte 0 (untouched from input)
+//     __rc5  B_M1    b mantissa byte 1 (untouched from input)
+//     __rc6  B_M2    b mantissa top byte (implicit 1 in bit 7 for normals)
+//     __rc7  B_EXP   b's biased exponent
+//     __rc8  A_M0    a mantissa byte 0 (from register A)
+//     __rc9  A_M1    a mantissa byte 1 (from register X)
+//     __rc10 A_SIGN  a's sign in bit 7 (0x00 or 0x80)
+//     __rc11 B_SIGN  b's sign in bit 7
+//     __rc12 R_SIGN  result sign in bit 7
+//     __rc13 R_EXP_LO signed 16-bit result exponent, low byte
+//     __rc14 R_EXP_HI  ... high byte
+//     __rc15 PH0     product high accumulator, byte 0
+//     __rc16 PH1
+//     __rc17 PH2     product high, MSB (bit 47 lands here after multiply)
+//     __rc18 CNT     multiply loop counter (24 iterations)
+//     __rc19 TMP     scratch (used by subnormal-result shift and pack)
+//
+// After unpack, __rc2 (A_M2) and __rc3 (A_EXP) hold a's transformed
+// bytes.  The pack phase at the end overwrites those two slots directly
+// with the result byte2/byte3, which is fine because A_M2 and A_EXP
+// aren't needed after we've read them into the packer.
+//
+//===----------------------------------------------------------------------===//
+
+#include "../int_lib.h"
+#include <stdint.h>
+
+#define A_M2     "__rc2"
+#define A_EXP    "__rc3"
+#define B_M0     "__rc4"
+#define B_M1     "__rc5"
+#define B_M2     "__rc6"
+#define B_EXP    "__rc7"
+#define A_M0     "__rc8"
+#define A_M1     "__rc9"
+#define A_SIGN   "__rc10"
+#define B_SIGN   "__rc11"
+#define R_SIGN   "__rc12"
+#define R_EXP_LO "__rc13"
+#define R_EXP_HI "__rc14"
+#define PH0      "__rc15"
+#define PH1      "__rc16"
+#define PH2      "__rc17"
+#define CNT      "__rc18"
+#define TMP      "__rc19"
+
+__attribute__((naked, noinline))
+COMPILER_RT_ABI float __mulsf3(float af, float bf) {
+    asm volatile (
+        // ================================================================
+        // Phase 1 -- UNPACK A.
+        //
+        // Incoming: A = a_byte0, X = a_byte1, __rc2 = a_byte2, __rc3 =
+        // a_byte3.  We move byte0/byte1 out of the registers into
+        // A_M0/A_M1 first (freeing A and X), then transform __rc2 and
+        // __rc3 in place into A_M2 and A_EXP; the sign gets its own
+        // slot (A_SIGN) since it doesn't share a destination.
+        //
+        // Restore the implicit leading 1 in A_M2 bit 7 for normals;
+        // leave it clear for subnormals (renormalize later) and zeros
+        // (handled by dispatch).
+        // ================================================================
+        "sta " A_M0 "\n"                     // A_M0 = byte0 (from A)
+        "stx " A_M1 "\n"                     // A_M1 = byte1 (from X)
+
+        // Sign from byte3
+        "lda __rc3\n"
+        "and #$80\n"
+        "sta " A_SIGN "\n"
+
+        // Exp = (byte3 << 1) | (byte2 >> 7).  Order: LDA __rc2 / ASL A
+        // sets C from byte2 bit 7 without touching byte2 in memory;
+        // then LDA __rc3 preserves C; ROL A produces the biased exp.
+        "lda __rc2\n"
+        "asl a\n"                            // C = byte2 bit 7 = E0
+        "lda __rc3\n"                        // A = byte3, C preserved
+        "rol a\n"                            // A = biased exp
+        "sta " A_EXP "\n"                    // overwrites __rc3 (was byte3)
+
+        // A_M2 = (byte2 & 0x7f) | (exp != 0 ? 0x80 : 0).  __rc2 still
+        // holds byte2 (we only did LDA / ASL A, no store).
+        "lda __rc2\n"
+        "and #$7f\n"
+        "ldx " A_EXP "\n"
+        "beq 1f\n"
+        "ora #$80\n"
+        "1: sta " A_M2 "\n"                  // overwrites __rc2 (was byte2)
+
+        // ================================================================
+        // Phase 2 -- UNPACK B.
+        //
+        // Same shape as A, but no register moves needed: b_byte0 arrives
+        // already at __rc4 = B_M0, and b_byte1 at __rc5 = B_M1.  We only
+        // need to transform __rc6 (byte2 -> B_M2) and __rc7 (byte3 ->
+        // B_EXP) in place, and extract the sign into B_SIGN.
+        // ================================================================
+        "lda __rc7\n"
+        "and #$80\n"
+        "sta " B_SIGN "\n"
+
+        "lda __rc6\n"
+        "asl a\n"
+        "lda __rc7\n"
+        "rol a\n"
+        "sta " B_EXP "\n"                    // overwrites __rc7
+
+        "lda __rc6\n"
+        "and #$7f\n"
+        "ldx " B_EXP "\n"
+        "beq 2f\n"
+        "ora #$80\n"
+        "2: sta " B_M2 "\n"                  // overwrites __rc6
+
+        // ================================================================
+        // Phase 3 -- RESULT SIGN.
+        //
+        // The product sign is the XOR of the input signs.  Since both
+        // A_SIGN and B_SIGN have bit 7 = sign and bits 6..0 = 0, an EOR
+        // gives the right result directly in bit 7.
+        // ================================================================
+        "lda " A_SIGN "\n"
+        "eor " B_SIGN "\n"
+        "sta " R_SIGN "\n"
+
+        // ================================================================
+        // Phase 4 -- INF/NAN dispatch.
+        //
+        // If a's exp is 0xFF, a is either NaN (mantissa != 0) or Inf.
+        // If b's exp is 0xFF, similar.  Special-case combinations:
+        //
+        //   NaN * anything  -> quiet NaN (return a with bit 22 set)
+        //   anything * NaN  -> quiet NaN (return b with bit 22 set)
+        //   Inf * 0         -> qNaN (0x7fc00000)
+        //   0 * Inf         -> qNaN (0x7fc00000)
+        //   Inf * finite    -> signed Inf (result_sign)
+        //   finite * Inf    -> signed Inf (result_sign)
+        //
+        // Note that A_M2's implicit-1 bit was set during unpack because
+        // exp is 0xFF (nonzero), so the "is mantissa zero" check has to
+        // mask off bit 7.
+        // ================================================================
+        "lda " A_EXP "\n"
+        "cmp #$ff\n"
+        "bne .L__mulsf3_chk_b_special\n"
+
+        // a is Inf or NaN.  Distinguish.
+        "lda " A_M2 "\n"
+        "and #$7f\n"
+        "ora " A_M1 "\n"
+        "ora " A_M0 "\n"
+        "beq .L__mulsf3_a_is_inf\n"
+
+        // a is NaN: quiet it and return a.  Setting bit 22 (M2 bit 6)
+        // makes any signalling NaN quiet.  A_M2 already has the implicit
+        // 1 in bit 7; setting bit 6 gives the "quiet" marker.  Also copy
+        // a's original sign back into R_SIGN so pack uses it.
+        "lda " A_M2 "\n"
+        "ora #$40\n"
+        "sta " A_M2 "\n"
+        "lda " A_SIGN "\n"
+        "sta " R_SIGN "\n"
+        "jmp .L__mulsf3_pack_a\n"
+
+        ".L__mulsf3_a_is_inf:\n"
+        // a is Inf.  Check b for NaN or 0.  If b is NaN return b.  If b
+        // is 0 return qNaN.  Otherwise return signed Inf.
+        "lda " B_EXP "\n"
+        "cmp #$ff\n"
+        "beq .L__mulsf3_a_inf_b_infnan\n"
+
+        // b is finite.  If b is 0, this is Inf * 0 -> qNaN.
+        "lda " B_EXP "\n"
+        "ora " B_M0 "\n"
+        "ora " B_M1 "\n"
+        "ora " B_M2 "\n"
+        "beq .L__mulsf3_return_qnan\n"
+        // b is finite and nonzero -> return signed Inf.
+        "jmp .L__mulsf3_return_signed_inf\n"
+
+        ".L__mulsf3_a_inf_b_infnan:\n"
+        // b's exp is 0xFF.  NaN vs Inf?
+        "lda " B_M2 "\n"
+        "and #$7f\n"
+        "ora " B_M1 "\n"
+        "ora " B_M0 "\n"
+        "beq .L__mulsf3_return_signed_inf\n"          // b is Inf -> Inf*Inf = signed Inf
+        // b is NaN -> return quiet(b).
+        "lda " B_M2 "\n"
+        "ora #$40\n"
+        "sta " A_M2 "\n"
+        "lda " B_M1 "\n"
+        "sta " A_M1 "\n"
+        "lda " B_M0 "\n"
+        "sta " A_M0 "\n"
+        "lda " B_EXP "\n"
+        "sta " A_EXP "\n"
+        "lda " B_SIGN "\n"
+        "sta " R_SIGN "\n"
+        "jmp .L__mulsf3_pack_a\n"
+
+        ".L__mulsf3_chk_b_special:\n"
+        // a is not special.  Is b special?
+        "lda " B_EXP "\n"
+        "cmp #$ff\n"
+        "bne .L__mulsf3_chk_zero\n"
+
+        // b is Inf or NaN.
+        "lda " B_M2 "\n"
+        "and #$7f\n"
+        "ora " B_M1 "\n"
+        "ora " B_M0 "\n"
+        "beq .L__mulsf3_b_is_inf\n"
+        // b is NaN -> return quiet(b).
+        "lda " B_M2 "\n"
+        "ora #$40\n"
+        "sta " A_M2 "\n"
+        "lda " B_M1 "\n"
+        "sta " A_M1 "\n"
+        "lda " B_M0 "\n"
+        "sta " A_M0 "\n"
+        "lda " B_EXP "\n"
+        "sta " A_EXP "\n"
+        "lda " B_SIGN "\n"
+        "sta " R_SIGN "\n"
+        "jmp .L__mulsf3_pack_a\n"
+
+        ".L__mulsf3_b_is_inf:\n"
+        // b is Inf, a is finite.  If a is 0, Inf*0 -> qNaN.
+        "lda " A_EXP "\n"
+        "ora " A_M0 "\n"
+        "ora " A_M1 "\n"
+        "ora " A_M2 "\n"                     // a_M2 has bit 7 clear iff
+                                             // subnormal or zero; a is not
+                                             // NaN/Inf here so this OR is
+                                             // 0 only for true zero
+        "beq .L__mulsf3_return_qnan\n"
+        // fall through to return signed Inf.
+
+        ".L__mulsf3_return_signed_inf:\n"
+        "lda #0\n"
+        "sta " A_M0 "\n"
+        "sta " A_M1 "\n"
+        "lda #$80\n"
+        "sta " A_M2 "\n"                     // mantissa 0, exp 0xff
+        "lda #$ff\n"
+        "sta " A_EXP "\n"
+        "jmp .L__mulsf3_pack_a\n"
+
+        ".L__mulsf3_return_qnan:\n"
+        // Canonical qNaN 0x7fc00000: byte3 = 0x7f, byte2 = 0xc0, low = 0.
+        "lda #$c0\n"
+        "sta __rc2\n"
+        "lda #$7f\n"
+        "sta __rc3\n"
+        "ldx #0\n"
+        "lda #0\n"
+        "rts\n"
+
+        // ================================================================
+        // Phase 5 -- ZERO dispatch.
+        //
+        // If either operand is zero, the product is signed zero
+        // (R_SIGN was already computed as a XOR b).
+        //
+        // Test: (exp | m0 | m1 | m2) == 0.  For zero, all four are 0.
+        // For subnormal, at least one mantissa byte is nonzero (implicit
+        // wasn't set for subnormals during unpack).  For normal, exp
+        // is nonzero.
+        // ================================================================
+        ".L__mulsf3_chk_zero:\n"
+        "lda " A_EXP "\n"
+        "ora " A_M0 "\n"
+        "ora " A_M1 "\n"
+        "ora " A_M2 "\n"
+        "beq .L__mulsf3_return_zero\n"
+        "lda " B_EXP "\n"
+        "ora " B_M0 "\n"
+        "ora " B_M1 "\n"
+        "ora " B_M2 "\n"
+        "bne .L__mulsf3_not_zero\n"
+
+        ".L__mulsf3_return_zero:\n"
+        // Return signed zero: byte3 = R_SIGN, byte2 = 0, low = 0.
+        "lda #0\n"
+        "sta __rc2\n"
+        "lda " R_SIGN "\n"
+        "sta __rc3\n"
+        "ldx #0\n"
+        "lda #0\n"
+        "rts\n"
+
+        ".L__mulsf3_not_zero:\n"
+
+        // ================================================================
+        // Phase 6 -- RESULT EXPONENT + SUBNORMAL RENORMALIZATION.
+        //
+        // R_EXP is a signed 16-bit accumulator that ends up as the biased
+        // result exponent (with pre-round adjustments).  We build it in
+        // three steps so we never have to sign-extend an ambiguous byte:
+        //
+        //   (a) R_EXP = A_EXP + B_EXP - 127.  Since A_EXP, B_EXP are
+        //       unsigned 0..254 at this point, the sum is 0..508 (fits
+        //       in 9 bits) and the subtraction can borrow into the high
+        //       byte; result range [-127, 381], all representable.
+        //
+        //   (b) If A was subnormal (raw A_EXP == 0), the sum used 0 for
+        //       A but a's "effective biased exp" is (1 - k) where k is
+        //       the left-shift count needed to normalize a's significand.
+        //       So we add 1 to R_EXP up front, then decrement it once
+        //       for each left shift in the renormalize loop.
+        //
+        //   (c) Same for B.
+        //
+        // A raw subnormal has M2 bit 7 = 0 (unpack skipped the implicit-1
+        // set for exp==0) and at least one mantissa byte nonzero (true
+        // zero was dispatched in phase 5), so the shift loop terminates.
+        // ================================================================
+
+        // R_EXP = A_EXP + B_EXP (unsigned, 9-bit sum captured with carry)
+        "clc\n"
+        "lda " A_EXP "\n"
+        "adc " B_EXP "\n"
+        "sta " R_EXP_LO "\n"
+        "lda #0\n"
+        "adc #0\n"                           // A = carry (0 or 1)
+        "sta " R_EXP_HI "\n"
+
+        // R_EXP -= 127
+        "sec\n"
+        "lda " R_EXP_LO "\n"
+        "sbc #127\n"
+        "sta " R_EXP_LO "\n"
+        "lda " R_EXP_HI "\n"
+        "sbc #0\n"
+        "sta " R_EXP_HI "\n"
+
+        // If a subnormal (A_EXP == 0): R_EXP += 1, then loop left-shift
+        // A's significand until M2 bit 7 is set, decrementing R_EXP per
+        // shift.
+        "lda " A_EXP "\n"
+        "bne .L__mulsf3_renorm_b\n"
+        "inc " R_EXP_LO "\n"
+        "bne 3f\n"
+        "inc " R_EXP_HI "\n"
+        "3:\n"
+        ".L__mulsf3_renorm_a_loop:\n"
+        "bit " A_M2 "\n"
+        "bmi .L__mulsf3_renorm_b\n"
+        "asl " A_M0 "\n"
+        "rol " A_M1 "\n"
+        "rol " A_M2 "\n"
+        // R_EXP -= 1  (16-bit dec)
+        "lda " R_EXP_LO "\n"
+        "bne 4f\n"
+        "dec " R_EXP_HI "\n"
+        "4: dec " R_EXP_LO "\n"
+        "jmp .L__mulsf3_renorm_a_loop\n"
+
+        ".L__mulsf3_renorm_b:\n"
+        // Same for b.
+        "lda " B_EXP "\n"
+        "bne .L__mulsf3_mul_init\n"
+        "inc " R_EXP_LO "\n"
+        "bne 5f\n"
+        "inc " R_EXP_HI "\n"
+        "5:\n"
+        ".L__mulsf3_renorm_b_loop:\n"
+        "bit " B_M2 "\n"
+        "bmi .L__mulsf3_mul_init\n"
+        "asl " B_M0 "\n"
+        "rol " B_M1 "\n"
+        "rol " B_M2 "\n"
+        "lda " R_EXP_LO "\n"
+        "bne 6f\n"
+        "dec " R_EXP_HI "\n"
+        "6: dec " R_EXP_LO "\n"
+        "jmp .L__mulsf3_renorm_b_loop\n"
+
+        ".L__mulsf3_mul_init:\n"
+
+        // ================================================================
+        // Phase 8 -- MULTIPLY: 24 x 24 -> 48-bit unsigned.
+        //
+        // See the "shift-and-add multiply core" reference at the top.
+        // Multiplicand: A_M0..A_M2.  Multiplier and low half of product:
+        // B_M0..B_M2.  High half of product accumulator: PH0..PH2, init 0.
+        // ================================================================
+        "lda #0\n"
+        "sta " PH0 "\n"
+        "sta " PH1 "\n"
+        "sta " PH2 "\n"
+        "lda #24\n"
+        "sta " CNT "\n"
+
+        // Pre-shift: shift multiplier right by 1 to get bit 0 into C.
+        "lsr " B_M2 "\n"
+        "ror " B_M1 "\n"
+        "ror " B_M0 "\n"
+
+        ".L__mulsf3_mul_loop:\n"
+        "bcc .L__mulsf3_mul_noadd\n"
+        "clc\n"
+        "lda " PH0 "\n" "adc " A_M0 "\n" "sta " PH0 "\n"
+        "lda " PH1 "\n" "adc " A_M1 "\n" "sta " PH1 "\n"
+        "lda " PH2 "\n" "adc " A_M2 "\n" "sta " PH2 "\n"
+        ".L__mulsf3_mul_noadd:\n"
+        "ror " PH2 "\n"
+        "ror " PH1 "\n"
+        "ror " PH0 "\n"
+        "ror " B_M2 "\n"
+        "ror " B_M1 "\n"
+        "ror " B_M0 "\n"
+        "dec " CNT "\n"
+        "bne .L__mulsf3_mul_loop\n"
+
+        // ================================================================
+        // Phase 9 -- BIT-47 NORMALIZE.
+        //
+        // Product now in [PH2:PH1:PH0:B_M2:B_M1:B_M0].  Bit 47 = PH2 bit 7.
+        //   set  -> product in [2^47, 2^48); exp += 1, no shift
+        //   clear -> product in [2^46, 2^47) (bit 46 set); shift left 1
+        //
+        // For inputs with both implicit bits set (normals or renormalized
+        // subnormals with M2 bit 7 = 1), the product is guaranteed >=
+        // 2^46, so bit 46 or bit 47 is set.  (We would never reach here
+        // with a zero mantissa product because zero was dispatched.)
+        // ================================================================
+        "bit " PH2 "\n"
+        "bmi .L__mulsf3_norm_47_set\n"
+        // Shift 48-bit product left by 1
+        "asl " B_M0 "\n"
+        "rol " B_M1 "\n"
+        "rol " B_M2 "\n"
+        "rol " PH0 "\n"
+        "rol " PH1 "\n"
+        "rol " PH2 "\n"
+        "jmp .L__mulsf3_chk_ovf\n"
+
+        ".L__mulsf3_norm_47_set:\n"
+        // Bit 47 was already set; exp += 1 (may overflow into hi byte).
+        "inc " R_EXP_LO "\n"
+        "bne .L__mulsf3_chk_ovf\n"
+        "inc " R_EXP_HI "\n"
+
+        ".L__mulsf3_chk_ovf:\n"
+        // ================================================================
+        // Phase 10 -- OVERFLOW / UNDERFLOW dispatch.
+        //
+        //   R_EXP < 0            -> underflow: subnormal or zero
+        //   R_EXP == 0           -> subnormal (biased-0 with mantissa
+        //                           bit 47 set means smaller than the
+        //                           smallest normal; shift right by 1)
+        //   R_EXP in [1, 0xFE]   -> normal, proceed to round
+        //   R_EXP >= 0xFF        -> overflow: signed infinity
+        // ================================================================
+        "lda " R_EXP_HI "\n"
+        "bmi .L__mulsf3_chk_und\n"                    // R_EXP < 0
+        "bne .L__mulsf3_overflow\n"                   // hi > 0 -> definitely overflow
+        "lda " R_EXP_LO "\n"
+        "beq .L__mulsf3_chk_und\n"                    // R_EXP == 0 -> subnormal
+        "cmp #$ff\n"
+        "bcc .L__mulsf3_round\n"                      // R_EXP in [1, 0xFE] -> normal
+        // fall through: R_EXP >= 0xFF -> overflow
+
+        ".L__mulsf3_overflow:\n"
+        "lda #$ff\n"
+        "sta " A_EXP "\n"
+        "lda #0\n"
+        "sta " PH0 "\n"
+        "sta " PH1 "\n"
+        "lda #$80\n"
+        "sta " PH2 "\n"
+        "jmp .L__mulsf3_pack_ph\n"
+
+        ".L__mulsf3_chk_und:\n"
+        // ================================================================
+        // Phase 11 -- UNDERFLOW / SUBNORMAL RESULT.
+        //
+        // R_EXP <= 0 -> result is subnormal (or zero).  We need to shift
+        // the [PH2:PH1:PH0:B_M2:B_M1:B_M0] product right by (1 - R_EXP)
+        // bits, keeping sticky, then round, then set exp = 0.
+        //
+        // If the shift count >= 25, everything except sticky is gone; the
+        // rounded result is either 0 or the smallest subnormal.  For
+        // simplicity we return signed 0 for shift >= 32 and clamp shift
+        // to 25 otherwise.
+        // ================================================================
+        // shift_count = 1 - R_EXP (positive; larger for more-negative
+        // R_EXP).  We compute this as (1 - R_EXP_LO) with borrow, but
+        // since R_EXP is negative (bit 7 of R_EXP_HI set), we know
+        // shift_count = 1 + |R_EXP|.
+        //
+        // Compute: shift = 1 - R_EXP_LO - 256*R_EXP_HI.  Since R_EXP_HI
+        // is 0xFF for small negatives (|R_EXP| < 128), shift =
+        // 1 - R_EXP_LO + 256 which is > 256 iff R_EXP_LO < -255... which
+        // can't happen (R_EXP >= -171).  Just use 1 - R_EXP_LO as byte
+        // arithmetic; if R_EXP_LO is e.g. 0xEA (-22), 1 - 0xEA = 0x17
+        // (as unsigned 8-bit, with borrow).  We want +23; 1 - (-22) = 23.
+        // sec / lda #1 / sbc R_EXP_LO gives 1 - R_EXP_LO in A, which for
+        // R_EXP_LO = 0xEA gives 0x17 = 23.  Perfect.
+
+        "sec\n"
+        "lda #1\n"
+        "sbc " R_EXP_LO "\n"                 // A = 1 - R_EXP_LO (byte)
+
+        // If R_EXP_HI is nonzero-and-not-0xFF (impossible), or if the
+        // shift count is huge (>= 32), just return signed 0.  We treat
+        // shift >= 32 as underflow-to-zero.  .L__mulsf3_return_zero is >128 bytes
+        // back from here, out of short-branch range, so use invert-and-jmp
+        // to avoid silent branch-offset truncation.
+        "cmp #32\n"
+        "bcc 15f\n"                          // shift < 32, continue
+        "jmp .L__mulsf3_return_zero\n"
+        "15:\n"
+
+        // Shift the 48-bit product right by A bits.  Use whole-byte
+        // shifts for count >= 8, then bit loop for residual.  Sticky
+        // accumulates in TMP.
+        "sta " CNT "\n"
+        "lda #0\n"
+        "sta " TMP "\n"                      // sticky accumulator = 0
+
+        ".L__mulsf3_sub_byte:\n"
+        "lda " CNT "\n"
+        "cmp #8\n"
+        "bcc .L__mulsf3_sub_bits\n"
+        // Shift right by 8 = shuffle bytes down.  OR B_M0 into sticky first.
+        "lda " B_M0 "\n"
+        "beq 7f\n"
+        "lda #1\n"
+        "sta " TMP "\n"
+        "7: lda " B_M1 "\n"
+        "sta " B_M0 "\n"
+        "lda " B_M2 "\n"
+        "sta " B_M1 "\n"
+        "lda " PH0 "\n"
+        "sta " B_M2 "\n"
+        "lda " PH1 "\n"
+        "sta " PH0 "\n"
+        "lda " PH2 "\n"
+        "sta " PH1 "\n"
+        "lda #0\n"
+        "sta " PH2 "\n"
+        "lda " CNT "\n"
+        "sec\n"
+        "sbc #8\n"
+        "sta " CNT "\n"
+        "jmp .L__mulsf3_sub_byte\n"
+
+        ".L__mulsf3_sub_bits:\n"
+        "ldy " CNT "\n"
+        "beq .L__mulsf3_sub_done\n"
+        ".L__mulsf3_sub_bit_loop:\n"
+        "lsr " PH2 "\n"
+        "ror " PH1 "\n"
+        "ror " PH0 "\n"
+        "ror " B_M2 "\n"
+        "ror " B_M1 "\n"
+        "ror " B_M0 "\n"
+        "bcc 8f\n"
+        "lda #1\n"
+        "sta " TMP "\n"
+        "8: dey\n"
+        "bne .L__mulsf3_sub_bit_loop\n"
+
+        ".L__mulsf3_sub_done:\n"
+        // OR the accumulated sticky into B_M0's LSB region.  We use B_M0
+        // for sticky by writing 1 to it if TMP is nonzero.  Actually we
+        // want the sticky to be represented in the low bits below the
+        // guard for the round logic below.  Simplest: OR TMP into B_M0.
+        "lda " TMP "\n"
+        "beq 10f\n"
+        "lda " B_M0 "\n"
+        "ora #1\n"
+        "sta " B_M0 "\n"
+        "10:\n"
+        // Set R_EXP = 0 (subnormal marker).  R_EXP_HI already whatever.
+        "lda #0\n"
+        "sta " R_EXP_LO "\n"
+        "sta " R_EXP_HI "\n"
+
+        ".L__mulsf3_round:\n"
+        // ================================================================
+        // Phase 12 -- ROUND: nearest, ties to even.
+        //
+        // R = B_M2 bit 7, G = B_M2 bit 6, S = OR(B_M2 & 0x3F, B_M1, B_M0),
+        // LSB = PH0 bit 0.  Round up iff R && (G || S || LSB).
+        // ================================================================
+        "bit " B_M2 "\n"                     // N = bit 7 (R), V = bit 6 (G)
+        "bpl .L__mulsf3_no_round\n"                   // R clear -> no round
+
+        // R set.  Compute (G || S || LSB).  Start with (B_M2 & 0x7F)
+        // OR B_M1 OR B_M0 OR (PH0 & 1).
+        "lda " B_M2 "\n"
+        "and #$7f\n"                         // strip R, keep G+partial S
+        "ora " B_M1 "\n"
+        "ora " B_M0 "\n"
+        "sta " TMP "\n"
+        "lda " PH0 "\n"
+        "and #1\n"                           // LSB
+        "ora " TMP "\n"
+        "beq .L__mulsf3_no_round\n"                   // exact tie AND LSB even -> no round
+
+        // Round up: ripple increment PH0..PH2.
+        "inc " PH0 "\n"
+        "bne .L__mulsf3_no_round\n"
+        "inc " PH1 "\n"
+        "bne .L__mulsf3_no_round\n"
+        "inc " PH2 "\n"
+        "bne .L__mulsf3_no_round\n"
+        // Full carry-out: mantissa wrapped 0xFFFFFF -> 0x000000.
+        // Restore bit 7 (implicit 1) and bump exp; check overflow.
+        "lda #$80\n"
+        "sta " PH2 "\n"
+        "inc " R_EXP_LO "\n"
+        "bne 11f\n"
+        "inc " R_EXP_HI "\n"
+        "11:\n"
+        // Recheck overflow after round bump.  .L__mulsf3_overflow is > 127 bytes
+        // back from here, out of short-branch range -- the assembler
+        // silently truncates out-of-range branch offsets, so we use
+        // invert-and-jmp for both checks.
+        "lda " R_EXP_HI "\n"
+        "beq 13f\n"                          // hi==0, skip forward
+        "jmp .L__mulsf3_overflow\n"
+        "13: lda " R_EXP_LO "\n"
+        "cmp #$ff\n"
+        "bcc .L__mulsf3_no_round\n"                   // R_EXP <= 0xFE, no overflow
+        "jmp .L__mulsf3_overflow\n"
+
+        ".L__mulsf3_no_round:\n"
+        // Post-round check: if we were subnormal (R_EXP == 0) and the
+        // round caused mantissa to become normal (PH2 bit 7 set), we
+        // need to bump R_EXP to 1 for correct encoding.  If R_EXP was
+        // already nonzero we skip.  If PH2 bit 7 is clear the result
+        // stays subnormal.
+        "lda " R_EXP_LO "\n"
+        "ora " R_EXP_HI "\n"
+        "bne .L__mulsf3_setup_pack\n"                 // not exp 0, skip
+        "bit " PH2 "\n"
+        "bpl .L__mulsf3_setup_pack\n"                 // still subnormal
+        "lda #1\n"
+        "sta " R_EXP_LO "\n"
+
+        ".L__mulsf3_setup_pack:\n"
+        // Move R_EXP into A_EXP for the shared packer below (packer
+        // expects A_EXP as the biased result exponent).
+        "lda " R_EXP_LO "\n"
+        "sta " A_EXP "\n"
+
+        ".L__mulsf3_pack_ph:\n"
+        // ================================================================
+        // Phase 13 -- PACK: reassemble bytes into ABI return slots.
+        //
+        // Same layout as addsf3 pack, but our mantissa lives in
+        // PH0..PH2 instead of A_M1..A_M3.  Copy PH -> A_M then reuse
+        // the pack sequence.
+        //
+        // Layout on entry:
+        //   A_EXP  = biased result exponent (0..0xFF)
+        //   R_SIGN = result sign in bit 7
+        //   PH2    = mantissa MSB (bit 7 = implicit 1 for normals, 0 for
+        //            subnormals or zero)
+        //   PH1    = mantissa mid
+        //   PH0    = mantissa low
+        // ================================================================
+        "lda " PH0 "\n"
+        "sta " A_M0 "\n"
+        "lda " PH1 "\n"
+        "sta " A_M1 "\n"
+        "lda " PH2 "\n"
+        "sta " A_M2 "\n"
+        // fall through to .L__mulsf3_pack_a
+
+        ".L__mulsf3_pack_a:\n"
+        // Byte3 = R_SIGN | (A_EXP >> 1); byte2 = ((A_EXP & 1) << 7) |
+        // (A_M2 & 0x7F); byte1 = A_M1; byte0 = A_M0.
+        "lda " A_EXP "\n"
+        "lsr a\n"                            // A = exp>>1, C = exp bit 0
+        "sta " TMP "\n"
+        "lda " A_M2 "\n"
+        "and #$7f\n"
+        "bcc 12f\n"
+        "ora #$80\n"
+        "12: sta __rc2\n"                    // byte2
+        "lda " TMP "\n"
+        "ora " R_SIGN "\n"
+        "sta __rc3\n"                        // byte3
+        "lda " A_M0 "\n"                     // byte0 -> A
+        "ldx " A_M1 "\n"                     // byte1 -> X
+        "rts\n"
+    );
+}

--- a/compiler-rt/lib/builtins/mos/subsf3.c
+++ b/compiler-rt/lib/builtins/mos/subsf3.c
@@ -1,0 +1,73 @@
+//===-- lib/mos/subsf3.c - Single-precision subtraction (MOS) --*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// __subsf3(a, b) -- IEEE 754 binary32 subtraction for MOS (6502).
+//
+// Implemented entirely in terms of __addsf3: since
+//
+//     a - b  ==  a + (-b)
+//
+// we negate b's sign bit and tail-call __addsf3.  This reuses the
+// full, already-correct-and-tested add machinery (unpack, magnitude
+// compare/swap, inf/nan/zero dispatch, align, add/subtract dispatch,
+// normalize, subnormal fix, overflow, round, pack) unchanged, at the
+// cost of six instructions (11 bytes / ~15 cycles) of wrapper overhead:
+// TAY to stash a's byte 0 (which arrives in A), LDA/EOR/STA to flip b's
+// sign bit in __rc7, TYA to restore A, then a JMP tail-call into
+// __addsf3.  The A-save is required because the 6502's EOR only
+// operates on the accumulator, and __addsf3 expects a's byte 0 in A
+// on entry.  Y is used for the stash because Y is not part of the
+// input ABI (numeric args ride only A/X/__rc2..__rc15).
+//
+// Why this and not a stand-alone hand-asm like __addsf3/__mulsf3?
+// Subtraction introduces no new arithmetic cases -- its only semantic
+// difference from addition is the sign of the second operand.  A
+// duplicated copy of addsf3.c would be ~800 lines of dead-maintenance
+// risk for zero behavioral gain.  The trampoline below is the minimal
+// correct expression of that fact.
+//
+// ============================================================================
+// ABI (identical to __addsf3)
+// ============================================================================
+//
+// float __subsf3(float a, float b) with the standard llvm-mos ABI:
+//
+//   INPUT:  a's bytes in A, X, __rc2, __rc3   (byte 0 in A ... byte 3 in rc3)
+//           b's bytes in __rc4, __rc5, __rc6, __rc7
+//   OUTPUT: result bytes in A, X, __rc2, __rc3
+//
+// __rc7 holds b's byte 3, whose bit 7 is b's sign (per the IEEE 754
+// binary32 little-endian layout documented in addsf3.c).  Flipping that
+// bit negates b, after which __addsf3 performs the subtraction.
+//
+// This function is naked: there is no prologue or epilogue, and the
+// final JMP transfers control permanently to __addsf3, whose own RTS
+// becomes our return.  (The __addsf3 symbol is a non-static global, so
+// the assembler's external reference resolves at link time.)
+//
+//===----------------------------------------------------------------------===//
+
+#include "../int_lib.h"
+
+__attribute__((naked, noinline))
+COMPILER_RT_ABI float __subsf3(float af, float bf) {
+    asm volatile(
+        // A holds a's byte 0 on entry -- stash it in Y before we
+        // clobber A doing the sign flip.  Y is otherwise unused by
+        // the input ABI.
+        "tay\n"
+        // Negate b by flipping its sign bit (bit 7 of byte 3, in __rc7).
+        "lda __rc7\n"
+        "eor #$80\n"
+        "sta __rc7\n"
+        // Restore a's byte 0 into A for __addsf3's entry ABI.
+        "tya\n"
+        // Tail-call __addsf3: computes a + (-b) == a - b.
+        "jmp __addsf3\n"
+    );
+}


### PR DESCRIPTION
## Summary

Adds MOS 6502 hand-tuned implementations of the four single-precision
IEEE 754 soft-float compiler-rt builtins: `__addsf3`, `__subsf3`,
`__mulsf3`, `__divsf3`.  Each is a naked C function containing one big
`asm volatile` block; all state lives in caller-saved zero-page slots
(`__rc2..__rc19`), so there is no callee-save tax and no stack frame.

## Numbers (vs upstream generic, on the existing compiler-rt Unit tests, under mos-sim)

| routine   | vectors    | isolated .text gen -> mos | full-test cycles gen -> mos |
|-----------|------------|---------------------------|------------------------------|
| `__addsf3`  | 25         | 3130 -> **675 B** (-78%)  | 33,774 -> **17,955** (-47%)     |
| `__subsf3`  | 22 (hand)  | -> **11 B** (trampoline)  | -> 19,429                       |
| `__mulsf3`  | 350+       | 2424 -> **681 B** (-72%)  | 2,310,376 -> **967,608** (-58%) |
| `__divsf3`  | 351        | 3305 -> **806 B** (-76%)  | 5,438,847 -> **535,174** (-90%) |

All results bit-exact on every upstream `Unit/*_test.c` vector (including
subnormals, subnormal-boundary rounding, exact-half tie-to-even,
NaN quieting, Inf/0 special cases).  The 10x `__divsf3` speedup is
because the generic path is Newton-Raphson (three iterations, each
needing a 32x32 multiply -- catastrophic on the 6502).  Shift-subtract
long division is a much better algorithmic fit.

`__subsf3` has no `Unit/subsf3_test.c` in compiler-rt; verified against
a 22-vector hand-rolled smoke test covering the IEEE 754 cases where
`a + (-b)` differs subtly from `a - b` (signed zero, NaN sign propagation,
subnormal boundaries).

## End-to-end validation

A 60x25 ASCII Mandelbrot demo (exercises all four routines) produces
**bit-identical output** vs generic softfloat (MD5 verified) at
**3.2x speed** (200M -> 638M cycles under `mos-sim`).

## Design notes

- One naked top-level function per file, one big `asm volatile` block
  inside.  All state in caller-saved zero page (`__rc2..__rc19`).  No
  callee-saved slots touched; no stack frame; LTO can still see the
  C-level signature for ABI/DCE analysis.
- Local labels use a per-function `.L__addsf3_*` / `.L__mulsf3_*` etc.
  prefix.  The `.L` keeps them out of the object symbol table; the
  function-name prefix keeps them unique across the LTO unit.  Without
  the per-function prefix, `.Lpack_a` in two sibling files collides
  during LTO because `.L` scoping is per-assembler-invocation, not
  per-source-file, and the mos-target build codegens the whole link
  into a single `.s`.
- Far branches (>127 bytes) use invert-and-jmp or a shared JMP
  trampoline to work around the LLVM MC assembler's silent 8-bit
  branch-offset truncation.

## Commits

1. `[MOS][compiler-rt] hand-tuned __addsf3 (naked asm, IEEE 754 binary32 add)`
2. `[MOS][compiler-rt] hand-tuned __mulsf3 (naked asm, IEEE 754 binary32 mul)`
3. `[MOS][compiler-rt] add __subsf3 as naked-asm trampoline into __addsf3`
4. `[MOS][compiler-rt] hand-tuned __divsf3 (naked asm, shift-subtract long division)`

## Test plan

- [x] `Unit/addsf3_test.c` (25 vectors) passes bit-exact under `mos-sim`
- [x] `Unit/mulsf3_test.c` (350+ vectors) passes bit-exact under `mos-sim`
- [x] `Unit/divsf3_test.c` (351 vectors) passes bit-exact under `mos-sim`
- [x] Hand-written 22-vector `__subsf3` smoke test passes bit-exact
- [x] `ninja runtimes/install-builtins-mos-unknown-unknown` builds and installs
- [x] Downstream `llvm-mos-sdk` libcrt.a rebuilds cleanly
- [x] End-to-end Mandelbrot via installed archive: bit-identical to generic, 3.2x speed

## Note on AI contribution

Substantial portions of this code contribution were written by Anthropic Claude Opus 4.8.  I have reviewed this code contribution by hand, and believe the quality of the generated code to be equivalent to that which I might have created without this tool.  Any errors or omissions in this code are my responsibility, not that of Claude Opus 4.8.