### PR TITLE
[MOS] Legalize G_SCMP/G_UCMP via lowerThreewayCompare

### DIFF
--- a/llvm/lib/Target/MOS/MOSLegalizerInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSLegalizerInfo.cpp
@@ -217,6 +217,13 @@ MOSLegalizerInfo::MOSLegalizerInfo(const MOSSubtarget &STI) {
 
   getActionDefinitionsBuilder({G_SMIN, G_SMAX, G_UMIN, G_UMAX}).lower();
 
+  // Three-way compares (llvm.scmp/ucmp — the C `(a>b)-(a<b)` spaceship idiom and libc-style
+  // comparators) have no native form on the 6502/65816; lower them to icmp+select primitives the
+  // backend already legalizes (LegalizerHelper::lowerThreewayCompare). Without this the backend
+  // aborts with "unable to legalize G_SCMP" on any qsort-style comparator. Not accum-specific —
+  // it fires at every width and in default/+mos-a16/+mos-xy16 alike.
+  getActionDefinitionsBuilder({G_SCMP, G_UCMP}).lower();
+
   getActionDefinitionsBuilder(G_ABS).custom();
 
   // Odd operations are handled via even ones: 6502 has only ADC/SBC.

--- a/llvm/test/CodeGen/MOS/scmp-ucmp.ll
+++ b/llvm/test/CodeGen/MOS/scmp-ucmp.ll
@@ -1,0 +1,71 @@
+; RUN: llc -verify-machineinstrs < %s | FileCheck %s
+;
+; The C three-way-compare ("spaceship") idiom `(a > b) - (a < b)` is
+; canonicalized by clang/instcombine to the generic llvm.scmp/llvm.ucmp
+; intrinsics (G_SCMP/G_UCMP in GlobalISel). The MOS legalizer had no rule for
+; them, so any program qsort-ing with such a comparator aborted with
+; "unable to legalize instruction: ... = G_SCMP ...". These now lower via
+; LegalizerHelper::lowerThreewayCompare (icmp + select expansion the backend
+; already legalizes). The checks pin each function's successful lowering to a
+; return and that the expansion stays inline (CHECK-NOT: jsr) — a regression
+; to either an abort or a libcall fails; the exact expansion is icmp/select
+; codegen owned elsewhere.
+
+target datalayout = "e-m:e-p:16:8-p1:8:8-i16:8-i32:8-i64:8-f32:8-f64:8-a:8-Fi8-n8"
+target triple = "mos"
+
+; CHECK-LABEL: scmp_i8:
+; CHECK-NOT: jsr
+; CHECK: rts
+define i8 @scmp_i8(i8 %a, i8 %b) {
+  %r = call i8 @llvm.scmp.i8.i8(i8 %a, i8 %b)
+  ret i8 %r
+}
+
+; CHECK-LABEL: ucmp_i8:
+; CHECK-NOT: jsr
+; CHECK: rts
+define i8 @ucmp_i8(i8 %a, i8 %b) {
+  %r = call i8 @llvm.ucmp.i8.i8(i8 %a, i8 %b)
+  ret i8 %r
+}
+
+; CHECK-LABEL: scmp_i16:
+; CHECK-NOT: jsr
+; CHECK: rts
+define i16 @scmp_i16(i16 %a, i16 %b) {
+  %r = call i16 @llvm.scmp.i16.i16(i16 %a, i16 %b)
+  ret i16 %r
+}
+
+; CHECK-LABEL: ucmp_i16:
+; CHECK-NOT: jsr
+; CHECK: rts
+define i16 @ucmp_i16(i16 %a, i16 %b) {
+  %r = call i16 @llvm.ucmp.i16.i16(i16 %a, i16 %b)
+  ret i16 %r
+}
+
+; CHECK-LABEL: scmp_i16_i32:
+; CHECK-NOT: jsr
+; CHECK: rts
+define i16 @scmp_i16_i32(i32 %a, i32 %b) {
+  %r = call i16 @llvm.scmp.i16.i32(i32 %a, i32 %b)
+  ret i16 %r
+}
+
+; CHECK-LABEL: ucmp_i16_i64:
+; CHECK-NOT: jsr
+; CHECK: rts
+define i16 @ucmp_i16_i64(i64 %a, i64 %b) {
+  %r = call i16 @llvm.ucmp.i16.i64(i64 %a, i64 %b)
+  ret i16 %r
+}
+
+; CHECK-LABEL: scmp_i32_i16:
+; CHECK-NOT: jsr
+; CHECK: rts
+define i32 @scmp_i32_i16(i16 %a, i16 %b) {
+  %r = call i32 @llvm.scmp.i32.i16(i16 %a, i16 %b)
+  ret i32 %r
+}


### PR DESCRIPTION
`MOSLegalizerInfo` had no rule for `G_SCMP`/`G_UCMP`, so the C three-way-compare idiom
`(a > b) - (a < b)` — which clang/instcombine canonicalize to `llvm.scmp`/`llvm.ucmp` — aborted the
backend (`unable to legalize instruction: ... = G_SCMP ...`) at every integer width, every `-O`
level, with and without LTO. Any `qsort` spaceship comparator fails to build for MOS.

The fix is one line, placed next to the analogous min/max lowering:

```cpp
getActionDefinitionsBuilder({G_SCMP, G_UCMP}).lower();
```

routing both opcodes through LLVM's existing `LegalizerHelper::lowerThreewayCompare` (an
icmp+select expansion the backend already legalizes end to end). No generic-LLVM change, no new
pseudo, no effect on any currently-compiling code (the opcodes previously always aborted).

Includes `llvm/test/CodeGen/MOS/scmp-ucmp.ll`: `llc -verify-machineinstrs` over signed and unsigned
three-way compares with s8/s16/s32 results and s8/s16/s32/s64 operands — every case aborts without
the fix and compiles verifier-clean with it. Each function also pins that the expansion stays
inline (`CHECK-NOT: jsr` between its label and its `rts`): no width falls back to a libcall.

Testing beyond the lit test: the identical change has been soak-tested in our 65816 development
fork, where five qsort-based SNES demos are differentially verified — host-computed result ==
on-console result on two independent emulators (MAME + bsnes-jg), `-verify-machineinstrs` clean —
and are **playable in-browser** (bsnes-jg WASM, each page's "Verify fidelity" button re-runs the
WRAM self-check live):

- [qsortviz](https://biohack.net/snes/qsortviz/) — the demo that found the crash (libc `qsort`,
  spaceship comparator)
- [spaceship](https://biohack.net/snes/spaceship/) — signed comparators at int8/16/32/64 keys
- [ucmprank](https://biohack.net/snes/ucmprank/) — the unsigned half (`G_UCMP` at u16/u32/u64)
- [trimerge](https://biohack.net/snes/trimerge/) — the scmp result consumed as control flow
- [keycmp64](https://biohack.net/snes/keycmp64/) — chained 64-bit tie-break (`G_SCMP s64` ×2/call)

Fixes #576.
