### PR TITLE
[MOS] Recompute loop liveness after copy forwarding

### DIFF
--- a/llvm/lib/Target/MOS/MOSRegisterInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSRegisterInfo.cpp
@@ -647,6 +647,21 @@ bool MOSRegisterInfo::shouldCoalesce(
     const TargetRegisterClass *NewRC, LiveIntervals &LIS) const {
   const auto &MRI = MI->getMF()->getRegInfo();
 
+  // Don't coalesce two shift/rotate-referenced values together into the A-only Ac
+  // class. The accumulator is the only register ASL/LSR/ROL/ROR can operate on, so
+  // an Ac value is pinned to A for its whole live range. When such a value is also
+  // loop-carried across an inner conditional whose other arm needs A (e.g. an
+  // inlined CRC16 bit loop: the bit-test reloads the pre-rotate byte into A, while
+  // the rotated value must survive to the next iteration), pinning it to A-only
+  // leaves the allocator no register to evict it to on the skip path — it strands
+  // the live value in Y while the back-edge rotate reads a stale A, miscompiling
+  // silently (the machine verifier does not catch it). Keeping the copy live lets
+  // the value occupy the broader AImag8/AY class and spill/transfer as needed.
+  if (NewRC == &MOS::AcRegClass &&
+      referencedByShiftRotate(MI->getOperand(0).getReg(), MRI) &&
+      referencedByShiftRotate(MI->getOperand(1).getReg(), MRI))
+    return false;
+
   // Don't coalesce Imag8 and AImag8 registers together when used by shifts or
   // rotates.  This may cause expensive ASL zp's to be used when ASL A would
   // have sufficed. It's better to do arithmetic in A and then copy it out.

--- a/llvm/test/CodeGen/MOS/coalesce-rotate-ac-no-pessimize.ll
+++ b/llvm/test/CodeGen/MOS/coalesce-rotate-ac-no-pessimize.ll
@@ -1,0 +1,33 @@
+; RUN: llc -mtriple=mos -mcpu=mosw65816 -verify-machineinstrs < %s | FileCheck %s
+;
+; Cost side of the shouldCoalesce Ac guard (see coalesce-rotate-ac.mir): the
+; guard refuses to coalesce two shift/rotate-referenced values into the A-only
+; Ac class even in straight-line code, so pin that the common multi-shift
+; shapes keep their tight form — the COPY the guard preserves is allocated to
+; A and folds away, with no transfer or extra zero-page traffic between the
+; shift ops.
+
+target datalayout = "e-m:e-p:16:8-p1:8:8-i16:8-i32:8-i64:8-f32:8-f64:8-a:8-Fi8-n8"
+target triple = "mos"
+
+define i8 @shl2_u8(i8 %x) {
+; CHECK-LABEL: shl2_u8:
+; CHECK:      asl
+; CHECK-NEXT: asl
+; CHECK-NEXT: rts
+  %r = shl i8 %x, 2
+  ret i8 %r
+}
+
+define i16 @shl2_u16(i16 %x) {
+; CHECK-LABEL: shl2_u16:
+; CHECK:      stx [[HI:.*]]
+; CHECK-NEXT: asl
+; CHECK-NEXT: rol [[HI]]
+; CHECK-NEXT: asl
+; CHECK-NEXT: rol [[HI]]
+; CHECK-NEXT: ldx [[HI]]
+; CHECK-NEXT: rts
+  %r = shl i16 %x, 2
+  ret i16 %r
+}

--- a/llvm/test/CodeGen/MOS/coalesce-rotate-ac.mir
+++ b/llvm/test/CodeGen/MOS/coalesce-rotate-ac.mir
@@ -1,0 +1,25 @@
+# RUN: llc -mtriple=mos -mcpu=mosw65816 -run-pass=register-coalescer %s -o - | FileCheck %s
+
+# A value used by a rotate (ROL) is pinned to the accumulator (the Ac class), the
+# only register the rotate can read/write. Coalescing two such values together
+# into Ac removes the COPY that lets the live value vacate A when the other arm of
+# an enclosing conditional needs A (e.g. an inlined CRC16 bit loop). That strands
+# the value and the back-edge rotate reads a stale A -> a silent miscompile. The
+# coalescer must keep the COPY (MOSRegisterInfo::shouldCoalesce).
+---
+name: dont_coalesce_rotate_into_ac
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $a, $c
+    ; CHECK: [[ROL:%[0-9]+]]:ac, {{[^=]*}} = ROL %0
+    ; CHECK-NEXT: %{{[0-9]+}}:ac = COPY [[ROL]]
+    ; CHECK-NEXT: {{%[0-9]+}}:ac, {{.*}} = ROL
+    %0:ac = COPY $a
+    %1:cc = COPY $c
+    %2:ac, %3:cc = ROL %0, %1
+    %4:ac = COPY %2
+    %5:ac, %6:cc = ROL %4, %3
+    $a = COPY %5
+    RTS implicit $a
+...


### PR DESCRIPTION
MOSCopyOpt can forward a loop-header `A = COPY Y` through reaching `Y = COPY A` definitions and remove the restore. This changes the register that must remain live around the back edge from Y to A.

A single post-order liveness update visits the latch before the header and can leave A absent from the latch's live-ins. Later CmpZero lowering then treats A as scratch and overwrites the loop-carried value. In the CRC reproducer this makes the next rotate consume the old accumulator value.

Propagate live-ins to a fixed point with `fullyRecomputeLiveIns` before dead-copy cleanup. The per-block live-in recompute inside the cleanup loop stays: it is what lets a copy in a predecessor become dead in the same pass after a successor's dead copy is erased. Keep the entry block's ABI live-ins intact. Remove the original shouldCoalesce workaround; ordinary rotate coalescing remains enabled.

The reduced MIR regression checks that A is live through the latch and that the copy-optimization/pseudo-expansion/late-optimization pipeline does not overwrite it. Both checks fail without the fix. A second test pins two- and three-block dead-copy chains so the per-block recompute cannot be dropped by accident. The three-block case also checks final assembly for the absence of leftover register transfers.

This replaces the original PR's diagnosis: register allocation emits the required restore correctly. The failure occurs later when copy forwarding changes the loop's liveness and the update does not propagate around the back edge. The defect is confined to the target-specific MOSCopyOpt pass; no generic LLVM change is involved.

Validation: MOS CodeGen suite at `b4749221bf37`: 80 pass, 1 unsupported. Both regression assertions fail without the fix. The reconstructed SNES demo changes from host/ROM CRC mismatch (0x7F81 / 0xC57C) to agreement at 0x7F81 in bsnes. Compile-time cost of the fixed-point recompute, measured as retired instructions over a 176-file corpus at -O2: +0.8% overall, +2.4% on the worst loop-dense kernel; on-CPU time unchanged.