### PR TITLE
[65CE02] Legalize arithmetic right shifts

### DIFF
--- a/llvm/lib/Target/MOS/MOSCombine.td
+++ b/llvm/lib/Target/MOS/MOSCombine.td
@@ -72,13 +72,13 @@ def fold_sbc : GICombineRule<
 
 def fold_shift : GICombineRule<
   (defs root:$root, build_fn_matchinfo:$matchinfo),
-  (match (wip_match_opcode G_SHLE, G_LSHRE):$root,
+  (match (wip_match_opcode G_SHLE, G_LSHRE, G_ASHRE):$root,
           [{ return matchFoldShift(*${root}, ${matchinfo}); }]),
   (apply [{ Helper.applyBuildFn(*${root}, ${matchinfo}); }])>;
 
 def shift_unused_carry_in : GICombineRule<
   (defs root:$root, build_fn_matchinfo:$matchinfo),
-  (match (wip_match_opcode G_SHLE, G_LSHRE):$root,
+  (match (wip_match_opcode G_SHLE, G_LSHRE, G_ASHRE):$root,
           [{ return matchShiftUnusedCarryIn(*${root}, ${matchinfo}); }]),
   (apply [{ Helper.applyBuildFnNoErase(*${root}, ${matchinfo}); }])>;
 

--- a/llvm/lib/Target/MOS/MOSCombiner.cpp
+++ b/llvm/lib/Target/MOS/MOSCombiner.cpp
@@ -685,14 +685,20 @@ APInt MOSCombinerImpl::getDemandedBits(Register R,
       DemandedBits |= ~Ones;
       break;
     }
-    case MOS::G_LSHRE: {
+    case MOS::G_LSHRE:
+    case MOS::G_ASHRE: {
       APInt DstDemandedBits = getDemandedBits(MI.getOperand(0).getReg(), Cache);
       if (Use.getOperandNo() == 2) {
         APInt CarryOutDemanded =
             getDemandedBits(MI.getOperand(1).getReg(), Cache);
-        DemandedBits |= DstDemandedBits << 1 | CarryOutDemanded.zext(8);
+        DemandedBits |= DstDemandedBits << 1 |
+                        CarryOutDemanded.zext(DstDemandedBits.getBitWidth());
+        if (MI.getOpcode() == MOS::G_ASHRE)
+          DemandedBits |= DstDemandedBits &
+                          APInt::getSignMask(DstDemandedBits.getBitWidth());
       } else {
         assert(Use.getOperandNo() == 3);
+        // The G_ASHRE LSR/ROR fallback uses carry-in for bit 7.
         DemandedBits |= DstDemandedBits.lshr(7).trunc(1);
       }
       break;

--- a/llvm/lib/Target/MOS/MOSCombiner.cpp
+++ b/llvm/lib/Target/MOS/MOSCombiner.cpp
@@ -538,6 +538,9 @@ bool MOSCombinerImpl::matchFoldShift(MachineInstr &MI,
   if (MI.getOpcode() == MOS::G_LSHRE) {
     CarryOut = (Val->Value & 1).getBoolValue();
     Result = Val->Value.lshr(1) | CarryIn->Value.zext(8).shl(7);
+  } else if (MI.getOpcode() == MOS::G_ASHRE) {
+    CarryOut = (Val->Value & 1).getBoolValue();
+    Result = Val->Value.ashr(1);
   } else {
     CarryOut = (Val->Value & 0x80).getBoolValue();
     Result = Val->Value.shl(1) | CarryIn->Value.zext(8);
@@ -561,7 +564,7 @@ bool MOSCombinerImpl::matchShiftUnusedCarryIn(MachineInstr &MI,
 
   APInt DemandedBits = getDemandedBits(MI.getOperand(0).getReg());
   assert(DemandedBits.getBitWidth() == 8);
-  if (MI.getOpcode() == MOS::G_LSHRE) {
+  if (MI.getOpcode() != MOS::G_SHLE) {
     if ((DemandedBits & 0x80).getBoolValue())
       return false;
   } else {

--- a/llvm/lib/Target/MOS/MOSInsertCopies.cpp
+++ b/llvm/lib/Target/MOS/MOSInsertCopies.cpp
@@ -64,6 +64,7 @@ bool MOSInsertCopies::runOnMachineFunction(MachineFunction &MF) {
         continue;
       case MOS::ASL:
       case MOS::LSR:
+      case MOS::ASR:
       case MOS::ROL:
       case MOS::ROR:
         WideRC = &MOS::AImag8RegClass;

--- a/llvm/lib/Target/MOS/MOSInstrGISel.td
+++ b/llvm/lib/Target/MOS/MOSInstrGISel.td
@@ -157,6 +157,13 @@ def G_LSHRE : MOSGenericInstruction {
   let InOperandList = (ins type0:$src, type1:$carry_in);
 }
 
+// Arithmetically shift an 8-bit value right one bit. $carry_in must be the
+// source sign bit; it permits a logical-shift fallback when $dst is dead.
+def G_ASHRE : MOSGenericInstruction {
+  let OutOperandList = (outs type0:$dst, type1:$carry_out);
+  let InOperandList = (ins type0:$src, type1:$carry_in);
+}
+
 // These opcodes represent multi-byte increment and decrement operations. Each
 // use operand is one byte; either a register or an absolute address. The def
 // operands correspond to only the register use operands, and they must be tied

--- a/llvm/lib/Target/MOS/MOSInstrLogical.td
+++ b/llvm/lib/Target/MOS/MOSInstrLogical.td
@@ -228,6 +228,10 @@ class MOSRotateRMW : MOSShiftRotateRMW {
 def ASL : MOSShift;
 def LSR : MOSShift;
 
+let Predicates = [Has65CE02] in {
+  def ASR : MOSShift;
+}
+
 def ASLAbs : MOSShiftRMW, PseudoInstExpansion<(ASL_ZeroPage addr8:$addr)> {
   dag InOperandList = (ins addr16:$addr);
 }

--- a/llvm/lib/Target/MOS/MOSInstructionSelector.cpp
+++ b/llvm/lib/Target/MOS/MOSInstructionSelector.cpp
@@ -227,6 +227,7 @@ bool MOSInstructionSelector::select(MachineInstr &MI) {
   case MOS::G_STORE_ABS_IDX:
     return selectStore(MI);
   case MOS::G_LSHRE:
+  case MOS::G_ASHRE:
   case MOS::G_SHLE:
     return selectLshrShlE(MI);
   case MOS::G_MERGE_VALUES:
@@ -1346,6 +1347,8 @@ template <typename ADDR_P, typename CARRYIN_P> struct GLshrE_match {
   bool match(const MachineRegisterInfo &MRI, Register Reg) {
     const MachineInstr *GLshrE = getOpcodeDef(MOS::G_LSHRE, Reg, MRI);
     if (!GLshrE)
+      GLshrE = getOpcodeDef(MOS::G_ASHRE, Reg, MRI);
+    if (!GLshrE)
       return false;
     CarryOut = GLshrE->getOperand(1).getReg();
     return Addr.match(MRI, GLshrE->getOperand(2).getReg()) &&
@@ -1687,6 +1690,8 @@ bool MOSInstructionSelector::selectMergeValues(MachineInstr &MI) {
 
 bool MOSInstructionSelector::selectLshrShlE(MachineInstr &MI) {
   auto [Dst, CarryOut, Src, CarryIn] = MI.getFirst4Regs();
+  MachineIRBuilder Builder(MI);
+  const auto &MRI = *Builder.getMRI();
 
   unsigned ShiftOpcode, RotateOpcode;
   switch (MI.getOpcode()) {
@@ -1700,10 +1705,21 @@ bool MOSInstructionSelector::selectLshrShlE(MachineInstr &MI) {
     ShiftOpcode = MOS::LSR;
     RotateOpcode = MOS::ROR;
     break;
+  case MOS::G_ASHRE:
+    // Store folding can consume Dst with ROR RMW, in which case CarryIn
+    // provides the sign bit without introducing register pressure.
+    if (STI.has65CE02() && !MRI.use_nodbg_empty(Dst)) {
+      auto Asr = Builder.buildInstr(MOS::ASR, {Dst, CarryOut}, {Src});
+      constrainSelectedInstRegOperands(*Asr, TII, TRI, RBI);
+      MI.eraseFromParent();
+      return true;
+    }
+    ShiftOpcode = MOS::LSR;
+    RotateOpcode = MOS::ROR;
+    break;
   }
 
-  MachineIRBuilder Builder(MI);
-  if (mi_match(CarryIn, *Builder.getMRI(), m_SpecificICst(0))) {
+  if (mi_match(CarryIn, MRI, m_SpecificICst(0))) {
     auto Asl = Builder.buildInstr(ShiftOpcode, {Dst, CarryOut}, {Src});
     constrainSelectedInstRegOperands(*Asl, TII, TRI, RBI);
   } else {

--- a/llvm/lib/Target/MOS/MOSLegalizerInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSLegalizerInfo.cpp
@@ -1021,9 +1021,11 @@ bool MOSLegalizerInfo::legalizeShiftRotate(
       Opcode = MOS::G_SHLE;
       break;
     case G_LSHR:
-    case G_ASHR:
     case G_ROTR:
       Opcode = MOS::G_LSHRE;
+      break;
+    case G_ASHR:
+      Opcode = MOS::G_ASHRE;
       break;
     }
     auto Even = Builder.buildInstr(Opcode, {Ty, S1}, {Src, CarryIn});
@@ -1059,7 +1061,8 @@ bool MOSLegalizerInfo::legalizeLshrEShlE(LegalizerHelper &Helper,
   for (MachineOperand &SrcPart : unmergeDefs(Unmerge))
     Defs.push_back(SrcPart.getReg());
 
-  if (MI.getOpcode() == MOS::G_LSHRE)
+  const bool IsRightShift = MI.getOpcode() != MOS::G_SHLE;
+  if (IsRightShift)
     std::reverse(Defs.begin(), Defs.end());
 
   Register Carry = CarryIn;
@@ -1068,12 +1071,14 @@ bool MOSLegalizerInfo::legalizeLshrEShlE(LegalizerHelper &Helper,
     Register NewCarry = I.index() == Defs.size() - 1
                             ? CarryOut
                             : MRI.createGenericVirtualRegister(S1);
-    Builder.buildInstr(MI.getOpcode(), {Parts.back(), NewCarry},
-                       {I.value(), Carry});
+    unsigned Opcode = MI.getOpcode() == MOS::G_ASHRE && I.index() == 0
+                          ? MOS::G_ASHRE
+                          : (IsRightShift ? MOS::G_LSHRE : MOS::G_SHLE);
+    Builder.buildInstr(Opcode, {Parts.back(), NewCarry}, {I.value(), Carry});
     Carry = NewCarry;
   }
 
-  if (MI.getOpcode() == MOS::G_LSHRE)
+  if (IsRightShift)
     std::reverse(Parts.begin(), Parts.end());
 
   Builder.buildMergeValues(Dst, Parts).getReg(0);

--- a/llvm/lib/Target/MOS/MOSMCInstLower.cpp
+++ b/llvm/lib/Target/MOS/MOSMCInstLower.cpp
@@ -189,6 +189,7 @@ void MOSMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI) {
   }
   case MOS::ASL:
   case MOS::LSR:
+  case MOS::ASR:
   case MOS::ROL:
   case MOS::ROR:
     switch (MI->getOperand(0).getReg()) {
@@ -200,6 +201,9 @@ void MOSMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI) {
         break;
       case MOS::LSR:
         OutMI.setOpcode(MOS::LSR_ZeroPage);
+        break;
+      case MOS::ASR:
+        OutMI.setOpcode(MOS::ASR_ZeroPage);
         break;
       case MOS::ROL:
         OutMI.setOpcode(MOS::ROL_ZeroPage);
@@ -223,6 +227,9 @@ void MOSMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI) {
         return;
       case MOS::LSR:
         OutMI.setOpcode(MOS::LSR_Accumulator);
+        return;
+      case MOS::ASR:
+        OutMI.setOpcode(MOS::ASR_Implied);
         return;
       case MOS::ROL:
         OutMI.setOpcode(MOS::ROL_Accumulator);

--- a/llvm/lib/Target/MOS/MOSRegisterInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSRegisterInfo.cpp
@@ -554,6 +554,7 @@ bool referencedByShiftRotate(Register Reg, const MachineRegisterInfo &MRI) {
       break;
     case MOS::ASL:
     case MOS::LSR:
+    case MOS::ASR:
     case MOS::ROL:
     case MOS::ROR:
       return true;
@@ -607,6 +608,7 @@ bool isRmwPattern(Register Reg, const MachineRegisterInfo &MRI) {
       break;
     case MOS::ASL:
     case MOS::LSR:
+    case MOS::ASR:
     case MOS::ROL:
     case MOS::ROR:
     case MOS::IncMB:
@@ -765,6 +767,7 @@ bool MOSRegisterInfo::getRegAllocationHints(Register VirtReg,
     }
     case MOS::ASL:
     case MOS::LSR:
+    case MOS::ASR:
     case MOS::ROR:
     case MOS::ROL:
       if (is_contained(Order, MOS::A))

--- a/llvm/lib/Target/MOS/MOSTargetMachine.cpp
+++ b/llvm/lib/Target/MOS/MOSTargetMachine.cpp
@@ -334,6 +334,7 @@ bool MOSCSEConfigFull::shouldCSEOpc(unsigned Opc) {
     return CSEConfigFull::shouldCSEOpc(Opc);
   case MOS::G_DEC:
   case MOS::G_INC:
+  case MOS::G_ASHRE:
   case MOS::G_LSHRE:
   case MOS::G_SBC:
   case MOS::G_SHLE:

--- a/llvm/test/CodeGen/MOS/asr-65ce02.ll
+++ b/llvm/test/CodeGen/MOS/asr-65ce02.ll
@@ -1,0 +1,223 @@
+; RUN: llc -mcpu=mos65ce02 -verify-machineinstrs < %s | FileCheck %s
+; RUN: llc -mcpu=mos45gs02 -verify-machineinstrs < %s | FileCheck %s
+; RUN: llc -mcpu=mos6502 -verify-machineinstrs < %s | FileCheck %s --check-prefix=NOASR
+
+target datalayout = "e-m:e-p:16:8-p1:8:8-i16:8-i32:8-i64:8-f32:8-f64:8-a:8-Fi8-n8"
+target triple = "mos"
+
+define i8 @ashr_i8_1(i8 %a) {
+; CHECK-LABEL: ashr_i8_1:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    asr
+; CHECK-NEXT:    rts
+;
+; NOASR-LABEL: ashr_i8_1:
+; NOASR:       ; %bb.0: ; %entry
+; NOASR-NEXT:    cmp #128
+; NOASR-NEXT:    ror
+; NOASR-NEXT:    rts
+entry:
+  %0 = ashr i8 %a, 1
+  ret i8 %0
+}
+
+define i8 @ashr_i8_2(i8 %a) {
+; CHECK-LABEL: ashr_i8_2:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    asr
+; CHECK-NEXT:    asr
+; CHECK-NEXT:    rts
+;
+; NOASR-LABEL: ashr_i8_2:
+; NOASR:       ; %bb.0: ; %entry
+; NOASR-NEXT:    cmp #128
+; NOASR-NEXT:    ror
+; NOASR-NEXT:    cmp #128
+; NOASR-NEXT:    ror
+; NOASR-NEXT:    rts
+entry:
+  %0 = ashr i8 %a, 2
+  ret i8 %0
+}
+
+; Only the highest byte needs sign preservation; lower bytes propagate carry.
+define i16 @ashr_i16_1(i16 %a) {
+; CHECK-LABEL: ashr_i16_1:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    stx __rc2
+; CHECK-NEXT:    asr __rc2
+; CHECK-NEXT:    ror
+; CHECK-NEXT:    ldx __rc2
+; CHECK-NEXT:    rts
+;
+; NOASR-LABEL: ashr_i16_1:
+; NOASR:       ; %bb.0: ; %entry
+; NOASR-NEXT:    sta __rc2
+; NOASR-NEXT:    txa
+; NOASR-NEXT:    cpx #128
+; NOASR-NEXT:    ror
+; NOASR-NEXT:    ror __rc2
+; NOASR-NEXT:    tax
+; NOASR-NEXT:    lda __rc2
+; NOASR-NEXT:    rts
+entry:
+  %0 = ashr i16 %a, 1
+  ret i16 %0
+}
+
+define i16 @ashr_i16_2(i16 %a) {
+; CHECK-LABEL: ashr_i16_2:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    stx __rc2
+; CHECK-NEXT:    asr __rc2
+; CHECK-NEXT:    ror
+; CHECK-NEXT:    asr __rc2
+; CHECK-NEXT:    ror
+; CHECK-NEXT:    ldx __rc2
+; CHECK-NEXT:    rts
+;
+; NOASR-LABEL: ashr_i16_2:
+; NOASR:       ; %bb.0: ; %entry
+; NOASR-NEXT:    sta __rc2
+; NOASR-NEXT:    txa
+; NOASR-NEXT:    cpx #128
+; NOASR-NEXT:    ror
+; NOASR-NEXT:    ror __rc2
+; NOASR-NEXT:    cmp #128
+; NOASR-NEXT:    ror
+; NOASR-NEXT:    ror __rc2
+; NOASR-NEXT:    tax
+; NOASR-NEXT:    lda __rc2
+; NOASR-NEXT:    rts
+entry:
+  %0 = ashr i16 %a, 2
+  ret i16 %0
+}
+
+define i32 @ashr_i32_1(i32 %a) {
+; CHECK-LABEL: ashr_i32_1:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    stx __rc4
+; CHECK-NEXT:    asr __rc3
+; CHECK-NEXT:    ror __rc2
+; CHECK-NEXT:    ror __rc4
+; CHECK-NEXT:    ror
+; CHECK-NEXT:    ldx __rc4
+; CHECK-NEXT:    rts
+;
+; NOASR-LABEL: ashr_i32_1:
+; NOASR:       ; %bb.0: ; %entry
+; NOASR-NEXT:    sta __rc4
+; NOASR-NEXT:    stx __rc5
+; NOASR-NEXT:    lda __rc3
+; NOASR-NEXT:    cmp #128
+; NOASR-NEXT:    ror
+; NOASR-NEXT:    ror __rc2
+; NOASR-NEXT:    ror __rc5
+; NOASR-NEXT:    ror __rc4
+; NOASR-NEXT:    sta __rc3
+; NOASR-NEXT:    ldx __rc5
+; NOASR-NEXT:    lda __rc4
+; NOASR-NEXT:    rts
+entry:
+  %0 = ashr i32 %a, 1
+  ret i32 %0
+}
+
+; Each shift-by-1 iteration must independently preserve the sign bit.
+define i8 @ashr_i8_3(i8 %a) {
+; CHECK-LABEL: ashr_i8_3:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    asr
+; CHECK-NEXT:    asr
+; CHECK-NEXT:    asr
+; CHECK-NEXT:    rts
+;
+; NOASR-LABEL: ashr_i8_3:
+; NOASR:       ; %bb.0: ; %entry
+; NOASR-NEXT:    cmp #128
+; NOASR-NEXT:    ror
+; NOASR-NEXT:    cmp #128
+; NOASR-NEXT:    ror
+; NOASR-NEXT:    cmp #128
+; NOASR-NEXT:    ror
+; NOASR-NEXT:    rts
+entry:
+  %0 = ashr i8 %a, 3
+  ret i8 %0
+}
+
+; Unsigned shifts must use LSR, not ASR (ASR would incorrectly preserve sign).
+define i8 @lshr_i8_1(i8 %a) {
+; CHECK-LABEL: lshr_i8_1:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    lsr
+; CHECK-NEXT:    rts
+entry:
+  %0 = lshr i8 %a, 1
+  ret i8 %0
+}
+
+; Multi-byte unsigned: high byte must use LSR to zero-extend, not ASR.
+define i16 @lshr_i16_1(i16 %a) {
+; CHECK-LABEL: lshr_i16_1:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    stx __rc2
+; CHECK-NEXT:    lsr __rc2
+; CHECK-NEXT:    ror
+; CHECK-NEXT:    ldx __rc2
+; CHECK-NEXT:    rts
+entry:
+  %0 = lshr i16 %a, 1
+  ret i16 %0
+}
+
+; Left shifts must not be affected by the ASR pattern match.
+define i16 @shl_i16_1(i16 %a) {
+; CHECK-LABEL: shl_i16_1:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    stx __rc2
+; CHECK-NEXT:    asl
+; CHECK-NEXT:    rol __rc2
+; CHECK-NEXT:    ldx __rc2
+; CHECK-NEXT:    rts
+entry:
+  %0 = shl i16 %a, 1
+  ret i16 %0
+}
+
+; Store-folded RMW: the shift result is consumed by RORAbs, leaving ASR's data
+; output dead. Selecting ASR here would only add register pressure.
+@g16 = global i16 0
+define void @ashr_global_i16() {
+; CHECK-LABEL: ashr_global_i16:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NOT:     asr
+; CHECK:         ror{{$}}
+; CHECK-NOT:     asr
+; CHECK:         ror g16
+; CHECK-NOT:     asr
+; CHECK:         ror g16+1
+; CHECK-NOT:     asr
+; CHECK:         rts
+;
+; NOASR-LABEL: ashr_global_i16:
+; NOASR:       ; %bb.0: ; %entry
+; NOASR-NEXT:    lda g16+1
+; NOASR-NEXT:    cmp #128
+; NOASR-NEXT:    ldx #1
+; NOASR-NEXT:    bcs .LBB[[#]]_2
+; NOASR:       ; %bb.1: ; %entry
+; NOASR-NEXT:    ldx #0
+; NOASR:       .LBB[[#]]_2: ; %entry
+; NOASR-NEXT:    ror{{$}}
+; NOASR-NEXT:    ror g16
+; NOASR-NEXT:    cpx #1
+; NOASR-NEXT:    ror g16+1
+; NOASR-NEXT:    rts
+entry:
+  %v = load i16, ptr @g16
+  %s = ashr i16 %v, 1
+  store i16 %s, ptr @g16
+  ret void
+}

--- a/llvm/test/CodeGen/MOS/combiner.mir
+++ b/llvm/test/CodeGen/MOS/combiner.mir
@@ -94,6 +94,26 @@
       ret void
   }
 
+  define void @arithmetic_shift_unused_carry_in_chain() {
+    entry:
+      ret void
+  }
+
+  define void @arithmetic_shift_used_carry_in_chain() {
+    entry:
+      ret void
+  }
+
+  define void @ashre_carry_out_demands_source_bit_0() {
+    entry:
+      ret void
+  }
+
+  define void @ashre_carry_in_demand_reaches_producer() {
+    entry:
+      ret void
+  }
+
   define void @mul_to_shift() {
     entry:
       ret void
@@ -579,6 +599,83 @@ body: |
     ; Bit 7 is demanded, so this carry-in must survive.
     %26:_(s8), %27:_(s1) = G_ASHRE %0, %1
     G_STORE_ABS %26, 1234
+...
+---
+name: arithmetic_shift_unused_carry_in_chain
+legalized: true
+body: |
+  bb.0.entry:
+    ; CHECK-LABEL: name: arithmetic_shift_unused_carry_in_chain
+    ; CHECK: [[SRC:%[0-9]+]]:_(s8) = G_LOAD_ABS 1234
+    ; CHECK-NEXT: [[SIGN:%[0-9]+]]:_(s1) = G_LOAD_ABS 1234
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s1) = G_CONSTANT i1 false
+    ; CHECK-NEXT: [[FIRST:%[0-9]+]]:_(s8), [[FIRST_C:%[0-9]+]]:_(s1) = G_ASHRE [[SRC]], [[C]]
+    ; CHECK-NEXT: [[SECOND:%[0-9]+]]:_(s8), {{%[0-9]+}}:_(s1) = G_ASHRE [[FIRST]], [[C]]
+    ; CHECK-NEXT: [[MASK:%[0-9]+]]:_(s8) = G_CONSTANT i8 63
+    ; CHECK-NEXT: [[RESULT:%[0-9]+]]:_(s8) = G_AND [[SECOND]], [[MASK]]
+    ; CHECK-NEXT: G_STORE_ABS [[RESULT]](s8), 1234
+    %0:_(s8) = G_LOAD_ABS 1234
+    %1:_(s1) = G_LOAD_ABS 1234
+    %2:_(s8), %3:_(s1) = G_ASHRE %0, %1
+    %4:_(s8), %5:_(s1) = G_ASHRE %2, %3
+    %6:_(s8) = G_CONSTANT i8 63
+    %7:_(s8) = G_AND %4, %6
+    G_STORE_ABS %7, 1234
+...
+---
+name: arithmetic_shift_used_carry_in_chain
+legalized: true
+body: |
+  bb.0.entry:
+    ; CHECK-LABEL: name: arithmetic_shift_used_carry_in_chain
+    ; CHECK: [[SRC:%[0-9]+]]:_(s8) = G_LOAD_ABS 1234
+    ; CHECK-NEXT: [[SIGN:%[0-9]+]]:_(s1) = G_LOAD_ABS 1234
+    ; CHECK-NEXT: [[FIRST:%[0-9]+]]:_(s8), [[FIRST_C:%[0-9]+]]:_(s1) = G_ASHRE [[SRC]], [[SIGN]]
+    ; CHECK-NEXT: [[SECOND:%[0-9]+]]:_(s8), {{%[0-9]+}}:_(s1) = G_ASHRE [[FIRST]], [[FIRST_C]]
+    ; CHECK-NEXT: [[MASK:%[0-9]+]]:_(s8) = G_CONSTANT i8 -128
+    ; CHECK-NEXT: [[RESULT:%[0-9]+]]:_(s8) = G_AND [[SECOND]], [[MASK]]
+    ; CHECK-NEXT: G_STORE_ABS [[RESULT]](s8), 1234
+    %0:_(s8) = G_LOAD_ABS 1234
+    %1:_(s1) = G_LOAD_ABS 1234
+    %2:_(s8), %3:_(s1) = G_ASHRE %0, %1
+    %4:_(s8), %5:_(s1) = G_ASHRE %2, %3
+    %6:_(s8) = G_CONSTANT i8 128
+    %7:_(s8) = G_AND %4, %6
+    G_STORE_ABS %7, 1234
+...
+---
+name: ashre_carry_out_demands_source_bit_0
+legalized: true
+body: |
+  bb.0.entry:
+    ; CHECK-LABEL: name: ashre_carry_out_demands_source_bit_0
+    ; CHECK: [[SRC:%[0-9]+]]:_(s8) = G_LOAD_ABS 1234
+    ; CHECK-NEXT: [[CIN:%[0-9]+]]:_(s1) = G_LOAD_ABS 1234
+    ; CHECK-NEXT: {{%[0-9]+}}:_(s8), {{%[0-9]+}}:_(s1) = G_SHLE [[SRC]], [[CIN]]
+    %0:_(s8) = G_LOAD_ABS 1234
+    %1:_(s1) = G_LOAD_ABS 1234
+    %2:_(s8), %3:_(s1) = G_SHLE %0, %1
+    %4:_(s1) = G_CONSTANT i1 false
+    %5:_(s8), %6:_(s1) = G_ASHRE %2, %4
+    RTS implicit %6
+...
+---
+name: ashre_carry_in_demand_reaches_producer
+legalized: true
+body: |
+  bb.0.entry:
+    ; CHECK-LABEL: name: ashre_carry_in_demand_reaches_producer
+    ; CHECK: [[SRC:%[0-9]+]]:_(s8) = G_LOAD_ABS 1234
+    ; CHECK-NEXT: [[SIGN:%[0-9]+]]:_(s1) = G_LOAD_ABS 1234
+    ; CHECK-NEXT: {{%[0-9]+}}:_(s8), {{%[0-9]+}}:_(s1) = G_ASHRE [[SRC]], [[SIGN]]
+    %0:_(s8) = G_LOAD_ABS 1234
+    %1:_(s1) = G_LOAD_ABS 1234
+    %2:_(s8), %3:_(s1) = G_ASHRE %0, %1
+    %4:_(s1) = G_CONSTANT i1 false
+    %5:_(s8), %6:_(s1) = G_SHLE %2, %4
+    %7:_(s8) = G_LOAD_ABS 5678
+    %8:_(s8), %9:_(s1) = G_ASHRE %7, %6
+    RTS implicit %8
 ...
 ---
 name: mul_to_shift

--- a/llvm/test/CodeGen/MOS/combiner.mir
+++ b/llvm/test/CodeGen/MOS/combiner.mir
@@ -444,20 +444,29 @@ legalized: true
 body: |
   bb.0.entry:
     ; CHECK-LABEL: name: fold_shift
-    ; CHECK: [[C:%[0-9]+]]:_(s1) = G_CONSTANT i1 true
-    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s8) = G_CONSTANT i8 1
-    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s1) = G_CONSTANT i1 false
-    ; CHECK-NEXT: G_STORE_ABS [[C1]](s8), 1234
-    ; CHECK-NEXT: G_STORE_ABS [[C2]](s1), 1234
-    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s8) = G_CONSTANT i8 -2
+    ; CHECK: [[C:%[0-9]+]]:_(s8) = G_CONSTANT i8 -1
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s1) = G_CONSTANT i1 false
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s1) = G_CONSTANT i1 true
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s8) = G_CONSTANT i8 1
     ; CHECK-NEXT: G_STORE_ABS [[C3]](s8), 1234
-    ; CHECK-NEXT: G_STORE_ABS [[C]](s1), 1234
-    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(s8) = G_CONSTANT i8 -128
+    ; CHECK-NEXT: G_STORE_ABS [[C1]](s1), 1234
+    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(s8) = G_CONSTANT i8 -2
     ; CHECK-NEXT: G_STORE_ABS [[C4]](s8), 1234
     ; CHECK-NEXT: G_STORE_ABS [[C2]](s1), 1234
-    ; CHECK-NEXT: [[C5:%[0-9]+]]:_(s8) = G_CONSTANT i8 127
+    ; CHECK-NEXT: [[C5:%[0-9]+]]:_(s8) = G_CONSTANT i8 -128
     ; CHECK-NEXT: G_STORE_ABS [[C5]](s8), 1234
-    ; CHECK-NEXT: G_STORE_ABS [[C]](s1), 1234
+    ; CHECK-NEXT: G_STORE_ABS [[C1]](s1), 1234
+    ; CHECK-NEXT: [[C6:%[0-9]+]]:_(s8) = G_CONSTANT i8 127
+    ; CHECK-NEXT: G_STORE_ABS [[C6]](s8), 1234
+    ; CHECK-NEXT: G_STORE_ABS [[C2]](s1), 1234
+    ; CHECK-NEXT: [[C7:%[0-9]+]]:_(s8) = G_CONSTANT i8 -64
+    ; CHECK-NEXT: G_STORE_ABS [[C7]](s8), 1234
+    ; CHECK-NEXT: G_STORE_ABS [[C1]](s1), 1234
+    ; CHECK-NEXT: G_STORE_ABS [[C]](s8), 1234
+    ; CHECK-NEXT: G_STORE_ABS [[C2]](s1), 1234
+    ; CHECK-NEXT: [[C8:%[0-9]+]]:_(s8) = G_CONSTANT i8 63
+    ; CHECK-NEXT: G_STORE_ABS [[C8]](s8), 1234
+    ; CHECK-NEXT: G_STORE_ABS [[C2]](s1), 1234
     %0:_(s8) = G_CONSTANT i8 0
     %1:_(s8) = G_CONSTANT i8 255
     %2:_(s1) = G_CONSTANT i1 0
@@ -478,6 +487,24 @@ body: |
     %10:_(s8), %11:_(s1) = G_LSHRE %1, %0
     G_STORE_ABS %10, 1234
     G_STORE_ABS %11, 1234
+
+    ; G_ASHRE requires its carry-in to be the sign bit of its source, so each
+    ; case below pairs a source with the matching carry-in. 128 distinguishes
+    ; an arithmetic fold from a logical one: 128 >>a 1 is 192, not 64.
+    %12:_(s8) = G_CONSTANT i8 128
+    %13:_(s8) = G_CONSTANT i8 127
+
+    %14:_(s8), %15:_(s1) = G_ASHRE %12, %3
+    G_STORE_ABS %14, 1234
+    G_STORE_ABS %15, 1234
+
+    %16:_(s8), %17:_(s1) = G_ASHRE %1, %3
+    G_STORE_ABS %16, 1234
+    G_STORE_ABS %17, 1234
+
+    %18:_(s8), %19:_(s1) = G_ASHRE %13, %2
+    G_STORE_ABS %18, 1234
+    G_STORE_ABS %19, 1234
 ...
 ---
 name: shift_unused_carry_in
@@ -508,6 +535,12 @@ body: |
     ; CHECK-NEXT: [[C5:%[0-9]+]]:_(s8) = G_CONSTANT i8 63
     ; CHECK-NEXT: [[AND3:%[0-9]+]]:_(s8) = G_AND [[SHLE2]], [[C5]]
     ; CHECK-NEXT: G_STORE_ABS [[AND3]](s8), 1234
+    ; CHECK-NEXT: [[ASHRE:%[0-9]+]]:_(s8), [[ASHRE1:%[0-9]+]]:_(s1) = G_ASHRE [[LOAD_ABS]], [[C]]
+    ; CHECK-NEXT: [[C6:%[0-9]+]]:_(s8) = G_CONSTANT i8 127
+    ; CHECK-NEXT: [[AND4:%[0-9]+]]:_(s8) = G_AND [[ASHRE]], [[C6]]
+    ; CHECK-NEXT: G_STORE_ABS [[AND4]](s8), 1234
+    ; CHECK-NEXT: [[ASHRE2:%[0-9]+]]:_(s8), [[ASHRE3:%[0-9]+]]:_(s1) = G_ASHRE [[LOAD_ABS]], [[LOAD_ABS1]]
+    ; CHECK-NEXT: G_STORE_ABS [[ASHRE2]](s8), 1234
     %0:_(s8) = G_LOAD_ABS 1234
     %1:_(s1) = G_LOAD_ABS 1234
 
@@ -535,6 +568,17 @@ body: |
     %20:_(s8) = G_CONSTANT i8 63
     %21:_(s8) = G_AND %18, %20
     G_STORE_ABS %21, 1234
+
+    ; Bit 7 of an arithmetic shift is the replicated sign bit, so masking it off
+    ; makes the carry-in dead here too, just as for G_LSHRE.
+    %22:_(s8), %23:_(s1) = G_ASHRE %0, %1
+    %24:_(s8) = G_CONSTANT i8 127
+    %25:_(s8) = G_AND %22, %24
+    G_STORE_ABS %25, 1234
+
+    ; Bit 7 is demanded, so this carry-in must survive.
+    %26:_(s8), %27:_(s1) = G_ASHRE %0, %1
+    G_STORE_ABS %26, 1234
 ...
 ---
 name: mul_to_shift

--- a/llvm/test/CodeGen/MOS/legalizer.mir
+++ b/llvm/test/CodeGen/MOS/legalizer.mir
@@ -1284,13 +1284,65 @@ body: |
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s1) = G_CONSTANT i1 true
     ; CHECK-NEXT: [[SBC:%[0-9]+]]:_(s8), [[SBC1:%[0-9]+]]:_(s1), [[SBC2:%[0-9]+]]:_, [[SBC3:%[0-9]+]]:_, [[SBC4:%[0-9]+]]:_ = G_SBC [[COPY]], [[C]], [[C1]]
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s1) = COPY [[SBC1]](s1)
-    ; CHECK-NEXT: [[LSHRE:%[0-9]+]]:_(s8), [[LSHRE1:%[0-9]+]]:_(s1) = G_LSHRE [[COPY]], [[COPY1]]
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s8) = COPY [[LSHRE]](s8)
+    ; CHECK-NEXT: [[ASHRE:%[0-9]+]]:_(s8), [[ASHRE1:%[0-9]+]]:_(s1) = G_ASHRE [[COPY]], [[COPY1]]
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s8) = COPY [[ASHRE]](s8)
     ; CHECK-NEXT: RTS implicit [[COPY2]](s8)
     %0:_(s8) = COPY $a
     %1:_(s8) = G_CONSTANT i8 1
     %2:_(s8) = G_ASHR %0, %1
     RTS implicit %2
+...
+---
+# Only the most significant byte preserves the sign; the remaining bytes shift
+# in the carry from the byte above, so they stay G_LSHRE.
+name: ashr_i16_1
+body: |
+  bb.0.entry:
+    ; CHECK-LABEL: name: ashr_i16_1
+    ; CHECK: [[COPY:%[0-9]+]]:_(s8) = COPY $a
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s8) = COPY $x
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s8) = G_CONSTANT i8 -128
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s1) = G_CONSTANT i1 true
+    ; CHECK-NEXT: [[SBC:%[0-9]+]]:_(s8), [[SBC1:%[0-9]+]]:_(s1), [[SBC2:%[0-9]+]]:_, [[SBC3:%[0-9]+]]:_, [[SBC4:%[0-9]+]]:_ = G_SBC [[COPY1]], [[C]], [[C1]]
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s1) = COPY [[SBC1]](s1)
+    ; CHECK-NEXT: [[ASHRE:%[0-9]+]]:_(s8), [[ASHRE1:%[0-9]+]]:_(s1) = G_ASHRE [[COPY1]], [[COPY2]]
+    ; CHECK-NEXT: [[LSHRE:%[0-9]+]]:_(s8), [[LSHRE1:%[0-9]+]]:_(s1) = G_LSHRE [[COPY]], [[ASHRE1]]
+    ; CHECK-NEXT: RTS implicit [[LSHRE]](s8), implicit [[ASHRE]](s8)
+    %0:_(s8) = COPY $a
+    %1:_(s8) = COPY $x
+    %2:_(s16) = G_MERGE_VALUES %0, %1
+    %3:_(s32) = G_CONSTANT i32 1
+    %4:_(s16) = G_ASHR %2, %3
+    %5:_(s8), %6:_(s8) = G_UNMERGE_VALUES %4
+    RTS implicit %5, implicit %6
+...
+---
+name: ashr_i32_1
+body: |
+  bb.0.entry:
+    ; CHECK-LABEL: name: ashr_i32_1
+    ; CHECK: [[COPY:%[0-9]+]]:_(s8) = COPY $a
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s8) = COPY $x
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s8) = COPY $y
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s8) = COPY $rc0
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s8) = G_CONSTANT i8 -128
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s1) = G_CONSTANT i1 true
+    ; CHECK-NEXT: [[SBC:%[0-9]+]]:_(s8), [[SBC1:%[0-9]+]]:_(s1), [[SBC2:%[0-9]+]]:_, [[SBC3:%[0-9]+]]:_, [[SBC4:%[0-9]+]]:_ = G_SBC [[COPY3]], [[C]], [[C1]]
+    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(s1) = COPY [[SBC1]](s1)
+    ; CHECK-NEXT: [[ASHRE:%[0-9]+]]:_(s8), [[ASHRE1:%[0-9]+]]:_(s1) = G_ASHRE [[COPY3]], [[COPY4]]
+    ; CHECK-NEXT: [[LSHRE:%[0-9]+]]:_(s8), [[LSHRE1:%[0-9]+]]:_(s1) = G_LSHRE [[COPY2]], [[ASHRE1]]
+    ; CHECK-NEXT: [[LSHRE2:%[0-9]+]]:_(s8), [[LSHRE3:%[0-9]+]]:_(s1) = G_LSHRE [[COPY1]], [[LSHRE1]]
+    ; CHECK-NEXT: [[LSHRE4:%[0-9]+]]:_(s8), [[LSHRE5:%[0-9]+]]:_(s1) = G_LSHRE [[COPY]], [[LSHRE3]]
+    ; CHECK-NEXT: RTS implicit [[LSHRE4]](s8), implicit [[LSHRE2]](s8), implicit [[LSHRE]](s8), implicit [[ASHRE]](s8)
+    %0:_(s8) = COPY $a
+    %1:_(s8) = COPY $x
+    %2:_(s8) = COPY $y
+    %3:_(s8) = COPY $rc0
+    %4:_(s32) = G_MERGE_VALUES %0, %1, %2, %3
+    %5:_(s32) = G_CONSTANT i32 1
+    %6:_(s32) = G_ASHR %4, %5
+    %7:_(s8), %8:_(s8), %9:_(s8), %10:_(s8) = G_UNMERGE_VALUES %6
+    RTS implicit %7, implicit %8, implicit %9, implicit %10
 ...
 ---
 name: ashr_7


### PR DESCRIPTION
Represent one-bit arithmetic right shifts as G_ASHRE during legalization, rather than recovering the sign-carry idiom in instruction selection. On 65CE02, a live result selects native ASR. When store folding makes the result dead, selection retains the existing ROR RMW path using the explicit sign carry. Other CPUs retain the existing CMP #128 + ROR lowering.

Supersedes #552.

#### Byte and cycle impact

| C operation | bytes before | bytes after | Δ | cycles before | cycles after | Δ |
|---|---:|---:|---:|---:|---:|---:|
| `int8_t x = x >> 1` | 4 | 2 | −2 | 10 | 7 | −3 |
| `int8_t x = x >> 2` | 7 | 3 | −4 | 14 | 8 | −6 |
| `int8_t x = x >> 3` | 10 | 4 | −6 | 18 | 9 | −9 |
| `int16_t x = x >> 1` | 12 | 8 | −4 | 25 | 19 | −6 |
| `int16_t x = x >> 2` | 17 | 11 | −6 | 34 | 26 | −8 |
| `int32_t x = x >> 1` | 20 | 12 | −8 | 43 | 29 | −14 |
| `uint8_t x = x >> 1` | 2 | 2 | · | 8 | 8 | · |
| `int16_t g; g >>= 1` (store-folded global) | unchanged | unchanged | · | unchanged | unchanged | · |

Assumes MEGA65 at 40 MHz, 6502 timings for existing instructions, and includes `rts`.

This PR was aided by LLM agent _OpenAI gpt-5.6-terra_ and humanly reviewed in accordance with LLVM guidelines.

**Update**: Using a [patched SDK simulator with 65CE02 opcodes](https://github.com/mlund/llvm-mos-sdk/tree/sim-65ce02), this PR passes the complete [llvm-test-suite](https://github.com/llvm-mos/llvm-test-suite) and all tests in [mega65-freezer](https://github.com/mlund/mega65-freezer) a ~10k line C23 port of the original cc65 code.