### PR TITLE
[MOS] Accept an optional BRK signature operand

### DIFF
--- a/llvm/lib/Target/MOS/MOSInstrInfo.td
+++ b/llvm/lib/Target/MOS/MOSInstrInfo.td
@@ -192,6 +192,10 @@ def BEQ_Relative : ConditionalBranch<"beq", 0b11, 0b1>;
 /// 8A  9A  AA  BA  CA  EA
 
 def BRK_Implied: InstLow0<"brk", 0b0000>, InstUnconditionalBranch;
+def BRK_Immediate: Inst16<"brk", Opcode<0x00>, Immediate>,
+    InstUnconditionalBranch {
+  let isAsmParserOnly = true;
+}
 /// JSR is the only instruction that does not follow the current pattern.
 def JSR_Absolute: Inst24<"jsr", Opcode<0x20>, Absolute>, InstCall;
 def RTI_Implied: InstLow0<"rti", 0b0100>, InstReturn;

--- a/llvm/test/MC/MOS/brk-signature.s
+++ b/llvm/test/MC/MOS/brk-signature.s
@@ -1,0 +1,4 @@
+; RUN: llvm-mc -triple mos -show-encoding < %s | FileCheck %s
+
+	brk     ; CHECK: encoding: [0x00]
+	brk #66 ; CHECK: encoding: [0x00,0x42]


### PR DESCRIPTION
Accept `brk #imm` as assembler syntax for the BRK opcode followed by a signature byte. Bare `brk` continues to emit one byte.

The signature form is assembler-only. Disassembly always decodes BRK as an operandless, one-byte instruction and treats the following byte independently.

Prior art: ca65 documents an optional BRK signature byte (`brk`, `brk $34`, `brk #$34`) and emits one byte when it is omitted ([ca65 manual, section 4](https://cc65.github.io/doc/ca65.html#ss4.1)). This change accepts only the `#imm` spelling.

Tests cover encoding, object disassembly on MOS6502 and W65816, and disassemble/reassemble round trips. The signature byte in the round-trip test is the NOP opcode, so consuming it as part of BRK would fail the test.

Validation: all 40 MOS MC tests pass (Linux, assertions enabled).