### PR TITLE
[MOS] Add the COP mnemonic with a mandatory signature operand

### DIFF
--- a/llvm/lib/Target/MOS/MOSInstrInfo.td
+++ b/llvm/lib/Target/MOS/MOSInstrInfo.td
@@ -785,6 +785,14 @@ def TDC_Implied : InstLowB<"tdc", 0b0111>;
 def TSC_Implied : InstLowB<"tsc", 0b0011>;
 
 def WDM_Immediate : Inst16<"wdm", Opcode<0x42>, Immediate>;
+
+/// COP invokes the co-processor software interrupt. Like BRK, it advances the
+/// PC by two, so the byte following the opcode is a "signature" the handler
+/// can read via the pushed return address; the hardware makes no direct use
+/// of it. Unlike BRK, WDC's own assembly syntax requires this operand, so it
+/// is mandatory here rather than optional. W65816-only: on the 65EL02,
+/// opcode $02 is NXT (a different instruction), not COP.
+def COP_Immediate : Inst16<"cop", Opcode<0x02>, Immediate>, InstUnconditionalBranch;
 }
 
 } // Predicates = [HasW65816]

--- a/llvm/test/MC/MOS/all-65816-opcodes.s
+++ b/llvm/test/MC/MOS/all-65816-opcodes.s
@@ -105,3 +105,5 @@
 	xce                             ; CHECK: encoding: [0xfb]
 
 	wdm #$ea                        ; CHECK: encoding: [0x42,0xea]
+
+	cop #$ea                        ; CHECK: encoding: [0x02,0xea]

--- a/llvm/test/MC/MOS/asm-errors.s
+++ b/llvm/test/MC/MOS/asm-errors.s
@@ -24,3 +24,11 @@ rep #$30
 
 ; CHECK: [[#@LINE+1]]:1: error: instruction requires: FeatureW65816Or65EL02
 sep #$30
+
+; CHECK: [[#@LINE+1]]:1: error: instruction requires: FeatureW65816
+cop #90
+
+; cop has no zero-operand form at all outside FeatureW65816, so a bare
+; mnemonic with no matching variant is simply unrecognized here.
+; CHECK: [[#@LINE+1]]:1: error: invalid instruction
+cop

--- a/llvm/test/MC/MOS/cop-signature.s
+++ b/llvm/test/MC/MOS/cop-signature.s
@@ -1,0 +1,22 @@
+; RUN: llvm-mc -triple mos -mcpu=mosw65816 -motorola-integers --filetype=obj -o=%t.obj %s
+; RUN: llvm-objdump -d --mcpu=mosw65816 %t.obj | FileCheck %s
+
+; RUN: not llvm-mc -triple mos -mcpu=mos65el02 -motorola-integers %s 2>&1 | FileCheck --check-prefix=EL02 %s
+
+; COP is W65816-only: opcode $02 is NXT on the 65EL02 (a different
+; instruction that happens to share the encoding), so every `cop` below must
+; be rejected there even though it assembles cleanly under mosw65816. No
+; existing test pinned this -- asm-errors.s only runs at -mcpu=mos6502, so a
+; refactor onto the shared FeatureW65816Or65EL02 predicate used by COP's
+; neighbours would otherwise pass the whole suite.
+
+; cop's signature operand accepts arbitrary expressions, not just literal
+; immediates.
+sig = $5a
+; EL02: [[#@LINE+1]]:2: error: instruction requires: FeatureW65816
+	cop #sig                        ; CHECK: 02 5a cop #$5a
+
+; WDC reserves $80-$ff for internal use and recommends confining user
+; signature bytes to $00-$7f; $7f is the top of that range.
+; EL02: [[#@LINE+1]]:2: error: instruction requires: FeatureW65816
+	cop #$7f                        ; CHECK: 02 7f cop #$7f


### PR DESCRIPTION
Add the W65816 COP instruction with a mandatory signature operand, following WDC assembly syntax. COP encodes as opcode $02 followed by the signature byte and disassembles as a two-byte instruction.

Tests cover expression and literal operands, instruction encoding and disassembly, rejection on an unsupported CPU, and rejection of a missing operand. Comments describe the operand requirement without repeating instruction semantics.

Validation: all 40 MOS MC tests pass (Linux, assertions enabled).
