### PR TITLE
[MOS] Add 32-bit imaginary register foundation

### DIFF
--- a/llvm/lib/Target/MOS/MOSAsmPrinter.cpp
+++ b/llvm/lib/Target/MOS/MOSAsmPrinter.cpp
@@ -178,7 +178,8 @@ bool MOSAsmPrinter::PrintAsmOperand(const MachineInstr *MI, unsigned OpNo,
       break;
     }
 
-    if (MOS::Imag16RegClass.contains(Reg) || MOS::Imag8RegClass.contains(Reg))
+    if (MOS::Imag32RegClass.contains(Reg) ||
+        MOS::Imag16RegClass.contains(Reg) || MOS::Imag8RegClass.contains(Reg))
       OS << TRI.getImag8SymbolName(Reg);
     else
       OS << TRI.getRegAsmName(Reg);

--- a/llvm/lib/Target/MOS/MOSAsmPrinter.cpp
+++ b/llvm/lib/Target/MOS/MOSAsmPrinter.cpp
@@ -174,7 +174,7 @@ bool MOSAsmPrinter::PrintAsmOperand(const MachineInstr *MI, unsigned OpNo,
       size_t Offset = It->second;
       if (Offset)
         OS << '+' << Offset;
-      OS << ")\n";
+      OS << ')';
       break;
     }
 

--- a/llvm/lib/Target/MOS/MOSCopyOpt.cpp
+++ b/llvm/lib/Target/MOS/MOSCopyOpt.cpp
@@ -229,7 +229,8 @@ bool MOSCopyOpt::runOnMachineFunction(MachineFunction &MF) {
       auto [Dst, Src] = MI.getFirst2Regs();
       auto LdImmCostVal = MOSInstrCost(2, 2).value(CostMode);
 
-      if (!MOS::Imag16RegClass.contains(Dst) && Dst != MOS::C &&
+      if (!MOS::Imag32RegClass.contains(Dst) &&
+          !MOS::Imag16RegClass.contains(Dst) && Dst != MOS::C &&
           Dst != MOS::V &&
           TRI.copyCost(Dst, Src, STI).value(CostMode) <= LdImmCostVal)
         continue;

--- a/llvm/lib/Target/MOS/MOSInstrInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSInstrInfo.cpp
@@ -670,6 +670,12 @@ void MOSInstrInfo::copyPhysRegImpl(MachineIRBuilder &Builder, Register DestReg,
                     TRI.getSubReg(SrcReg, MOS::sublo));
     copyPhysRegImpl(Builder, TRI.getSubReg(DestReg, MOS::subhi),
                     TRI.getSubReg(SrcReg, MOS::subhi));
+  } else if (AreClasses(MOS::Imag32RegClass, MOS::Imag32RegClass)) {
+    assert(SrcReg.isPhysical() && DestReg.isPhysical());
+    copyPhysRegImpl(Builder, TRI.getSubReg(DestReg, MOS::sublo16),
+                    TRI.getSubReg(SrcReg, MOS::sublo16));
+    copyPhysRegImpl(Builder, TRI.getSubReg(DestReg, MOS::subhi16),
+                    TRI.getSubReg(SrcReg, MOS::subhi16));
   } else if (AreClasses(MOS::Anyi1RegClass, MOS::Anyi1RegClass)) {
     assert(SrcReg.isPhysical() && DestReg.isPhysical());
     Register SrcReg8 =

--- a/llvm/lib/Target/MOS/MOSMCInstLower.cpp
+++ b/llvm/lib/Target/MOS/MOSMCInstLower.cpp
@@ -862,7 +862,8 @@ bool MOSMCInstLower::lowerOperand(const MachineOperand &MO, MCOperand &MCOp) {
       break;
     }
 
-    if (MOS::Imag16RegClass.contains(Reg) || MOS::Imag8RegClass.contains(Reg)) {
+    if (MOS::Imag32RegClass.contains(Reg) ||
+        MOS::Imag16RegClass.contains(Reg) || MOS::Imag8RegClass.contains(Reg)) {
       const MCExpr *Expr = MCSymbolRefExpr::create(
           Ctx.getOrCreateSymbol(TRI.getImag8SymbolName(Reg)), Ctx);
       MCOp = MCOperand::createExpr(Expr);

--- a/llvm/lib/Target/MOS/MOSRegisterInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSRegisterInfo.cpp
@@ -52,6 +52,8 @@ MOSRegisterInfo::MOSRegisterInfo()
     // Pointers are referred to by their low byte in the addressing modes that
     // use them.
     unsigned R = Reg;
+    if (MOS::Imag32RegClass.contains(R))
+      R = getSubReg(R, MOS::sublo16);
     if (MOS::Imag16RegClass.contains(R))
       R = getSubReg(R, MOS::sublo);
     if (!MOS::Imag8RegClass.contains(R))
@@ -994,6 +996,9 @@ MOSInstrCost MOSRegisterInfo::copyCost(Register DestReg, Register SrcReg,
   }
   if (AreClasses(MOS::Imag16RegClass, MOS::Imag16RegClass)) {
     return copyCost(MOS::RC0, MOS::RC1, STI) * 2;
+  }
+  if (AreClasses(MOS::Imag32RegClass, MOS::Imag32RegClass)) {
+    return copyCost(MOS::RC0, MOS::RC1, STI) * 4;
   }
   if (AreClasses(MOS::Anyi1RegClass, MOS::Anyi1RegClass)) {
     Register SrcReg8 =

--- a/llvm/lib/Target/MOS/MOSRegisterInfo.td
+++ b/llvm/lib/Target/MOS/MOSRegisterInfo.td
@@ -20,6 +20,10 @@ def sublo : MOSSubRegIndex<8>;
 // High byte of a 16-bit imaginary pointer register.
 def subhi : MOSSubRegIndex<8, 8>;
 
+// Low and high words of a 32-bit imaginary register.
+def sublo16 : MOSSubRegIndex<16>;
+def subhi16 : MOSSubRegIndex<16, 16>;
+
 // Carry bit of the 8-bit processor status register.
 def subcarry : MOSSubRegIndex<1>;
 
@@ -125,6 +129,14 @@ class MOSImagReg16<bits<16> num, string name, list<Register> subregs>
   let CoveredBySubRegs = 1;
 }
 
+// 32-bit imaginary registers composed of pairs of 16-bit registers.
+class MOSImagReg32<bits<16> num, string name, list<Register> subregs>
+    : MOSReg<num, name> {
+  let SubRegs = subregs;
+  let SubRegIndices = [sublo16, subhi16];
+  let CoveredBySubRegs = 1;
+}
+
 defvar MaxImag8Regs = 256;
 // The starting DWARF number for the imaginary registers.
 defvar Imag8RegsOffset = 0x10;
@@ -132,19 +144,30 @@ defvar Imag8RegsOffset = 0x10;
 defvar MaxImag16Regs = !sra(MaxImag8Regs, 1);
 defvar Imag16RegsOffset = !add(Imag8RegsOffset, !shl(MaxImag8Regs,1));
 
+defvar MaxImag32Regs = !sra(MaxImag16Regs, 1);
+defvar Imag32RegsOffset = !add(Imag16RegsOffset, MaxImag16Regs);
+
 // Now we enumerate the imaginary registers.
-// Imaginary 8-bit registers, starting with the prefix rc
+// Imaginary 8-bit registers, starting with the prefix rc (c = "char")
 foreach I = 0...!add(MaxImag8Regs, -1) in {
   // There exist MaxImag8Regs rcXX registers...
   defm RC#I: MOSImagReg8<!add(!shl(I,1), Imag8RegsOffset), "rc"#!cast<string>(I)>;
 }
 
-// Imaginary 16-bit registers, starting with the prefix rs
+// Imaginary 16-bit registers, starting with the prefix rs (s = "short")
 foreach I = 0...!add(MaxImag16Regs, -1) in {
   // There exist MaxImag16Regs rsXX registers...
   def RS#I: MOSImagReg16<!add(I, Imag16RegsOffset), "rs"#!cast<string>(I),
       [!cast<Register>("RC"#!shl(I, 1)),
        !cast<Register>("RC"#!add(!shl(I,1),1))]>;
+}
+
+// Imaginary 32-bit registers, starting with the prefix rl (l = "long")
+foreach I = 0...!add(MaxImag32Regs, -1) in {
+  // There exist MaxImag32Regs rlXX registers...
+  def RL#I: MOSImagReg32<!add(I, Imag32RegsOffset), "rl"#!cast<string>(I),
+      [!cast<Register>("RS"#!shl(I, 1)),
+       !cast<Register>("RS"#!add(!shl(I,1),1))]>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -160,6 +183,7 @@ class MOSReg1Class<dag RegList>: MOSRegClass<[i1], 8, RegList> {
 }
 class MOSReg8Class<dag RegList>: MOSRegClass<[i8], 8, RegList>;
 class MOSReg16Class<dag RegList>: MOSRegClass<[i16], 8, RegList>;
+class MOSReg32Class<dag RegList>: MOSRegClass<[i32], 8, RegList>;
 
 // Single register classes.
 let isPressureFineGrained = true in {
@@ -179,6 +203,10 @@ let isPressureFineGrained = true in {
 }
 def Imag8 : MOSReg8Class<(sequence "RC%u", 0, !add(MaxImag8Regs, -1))>;
 def Imag16 : MOSReg16Class<(sequence "RS%u", 0, !add(MaxImag16Regs, -1))>;
+// Linker scripts may place adjacent RS registers apart, so RL cannot be
+// allocated safely.
+let isAllocatable = false in
+def Imag32 : MOSReg32Class<(sequence "RL%u", 0, !add(MaxImag32Regs, -1))>;
 
 // Instruction-specific register classes.
 def AImag8 : MOSReg8Class<(add Imag8, A)>;

--- a/llvm/lib/Target/MOS/MOSZeroPageAlloc.cpp
+++ b/llvm/lib/Target/MOS/MOSZeroPageAlloc.cpp
@@ -385,10 +385,20 @@ bool MOSZeroPageAlloc::runOnModule(Module &M) {
         DenseMap<Register, size_t> &CSRZPOffsets =
             MF.getInfo<MOSFunctionInfo>()->CSRZPOffsets;
         const TargetRegisterInfo &TRI = *MF.getSubtarget().getRegisterInfo();
-        if (MOS::Imag16RegClass.contains(Cand->CSR)) {
-          CSRZPOffsets[Cand->CSR] =
-              CSRZPOffsets[TRI.getSubReg(Cand->CSR, MOS::sublo)] = Offset++;
-          CSRZPOffsets[TRI.getSubReg(Cand->CSR, MOS::subhi)] = Offset++;
+        // Later stages may refer to any alias of an assigned composite CSR.
+        auto AssignImag16 = [&](Register Reg) {
+          CSRZPOffsets[Reg] =
+              CSRZPOffsets[TRI.getSubReg(Reg, MOS::sublo)] = Offset++;
+          CSRZPOffsets[TRI.getSubReg(Reg, MOS::subhi)] = Offset++;
+        };
+        if (MOS::Imag32RegClass.contains(Cand->CSR)) {
+          Register Lo = TRI.getSubReg(Cand->CSR, MOS::sublo16);
+          Register Hi = TRI.getSubReg(Cand->CSR, MOS::subhi16);
+          CSRZPOffsets[Cand->CSR] = Offset;
+          AssignImag16(Lo);
+          AssignImag16(Hi);
+        } else if (MOS::Imag16RegClass.contains(Cand->CSR)) {
+          AssignImag16(Cand->CSR);
         } else {
           CSRZPOffsets[Cand->CSR] = Offset++;
         }
@@ -558,6 +568,8 @@ void MOSZeroPageAlloc::collectCandidates(
   TFL.determineCalleeSaves(MF, SavedRegs, /*RS=*/nullptr);
   unsigned Idx = 0;
   DenseSet<Register> Imag16Regs;
+  DenseSet<Register> Imag32Regs;
+  const TargetRegisterInfo &TRI = *MF.getSubtarget().getRegisterInfo();
   for (Register Reg : SavedRegs.set_bits()) {
     if (!MOS::Imag8RegClass.contains(Reg))
       continue;
@@ -578,13 +590,38 @@ void MOSZeroPageAlloc::collectCandidates(
       Benefit += 12 * RestoreFreq; // LDA ABS,STA ZP
     }
 
-    // If the CSR is used as a 16-bit pointer, then the two halves cannot be
-    // assigned independently. Thus, instead of two size-1 candidates, one
-    // size-2 candidate is used.
+    // Composite imaginary registers must be assigned as one candidate.
+    // RC has both RS and RL super-registers, so select each layer explicitly.
     Register Imag16 =
-        *MF.getSubtarget().getRegisterInfo()->superregs(Reg).begin();
+        TRI.getMatchingSuperReg(Reg, MOS::sublo, &MOS::Imag16RegClass);
+    if (!Imag16)
+      Imag16 =
+          TRI.getMatchingSuperReg(Reg, MOS::subhi, &MOS::Imag16RegClass);
     assert(MOS::Imag16RegClass.contains(Imag16));
-    if (!MF.getRegInfo().reg_nodbg_empty(Imag16)) {
+    Register Imag32 =
+        TRI.getMatchingSuperReg(Imag16, MOS::sublo16, &MOS::Imag32RegClass);
+    if (!Imag32)
+      Imag32 = TRI.getMatchingSuperReg(Imag16, MOS::subhi16,
+                                       &MOS::Imag32RegClass);
+    if (Imag32 && !MF.getRegInfo().reg_nodbg_empty(Imag32)) {
+      if (Imag32Regs.contains(Imag32))
+        continue;
+
+      Reg = Imag32;
+      Imag32Regs.insert(Reg);
+
+      for (unsigned I = 1; I != 4; ++I) {
+        if (Idx++ < 4) {
+          Benefit += 9 * SaveFreq;
+          Benefit += 10 * RestoreFreq;
+        } else {
+          Benefit += 12 * SaveFreq;
+          Benefit += 12 * RestoreFreq;
+        }
+        ++Size;
+      }
+      Benefit /= Size;
+    } else if (!MF.getRegInfo().reg_nodbg_empty(Imag16)) {
       // Don't create the Imag16 candidate twice.
       if (Imag16Regs.contains(Imag16))
         continue;

--- a/llvm/lib/Target/MOS/MOSZeroPageAlloc.cpp
+++ b/llvm/lib/Target/MOS/MOSZeroPageAlloc.cpp
@@ -594,10 +594,10 @@ void MOSZeroPageAlloc::collectCandidates(
 
       // Account for the second byte.
       if (Idx++ < 4) {
-        Benefit = 9 * SaveFreq;      // LDA ZP,PHA
+        Benefit += 9 * SaveFreq;     // LDA ZP,PHA
         Benefit += 10 * RestoreFreq; // PLA,STA ZP
       } else {
-        Benefit = 12 * SaveFreq;     // LDA ZP,STA ABS
+        Benefit += 12 * SaveFreq;    // LDA ZP,STA ABS
         Benefit += 12 * RestoreFreq; // LDA ABS,STA ZP
       }
       ++Size;

--- a/llvm/test/CodeGen/MOS/asm-printer-45gs02.mir
+++ b/llvm/test/CodeGen/MOS/asm-printer-45gs02.mir
@@ -1,0 +1,16 @@
+# RUN: llc -mtriple=mos -mcpu=mos45gs02 -start-after=machine-opt-remark-emitter \
+# RUN:   -verify-machineinstrs -o - %s | FileCheck %s
+
+# Physical RL operands are currently reachable only from MIR.
+
+---
+name: imag32_memory_operand
+body: |
+  bb.0.entry:
+    INLINEASM &"lda [$0],z", 9 /* sideeffect mayload attdialect */, 196622 /* mem:m */, $rl1
+    INLINEASM &"lda [$0],z", 9 /* sideeffect mayload attdialect */, 196622 /* mem:m */, $rl7
+    ; CHECK-LABEL: imag32_memory_operand
+    ; CHECK: lda [__rc4],z
+    ; CHECK: lda [__rc28],z
+    RTS
+...

--- a/llvm/test/CodeGen/MOS/copy-phys-reg.mir
+++ b/llvm/test/CodeGen/MOS/copy-phys-reg.mir
@@ -192,6 +192,25 @@ body: |
     $rs1 = COPY $rs0
 ...
 ---
+name: imag32_to_imag32
+tracksRegLiveness: true
+body: |
+  bb.0.entry:
+    liveins: $rl1
+    ; CHECK-LABEL: name: imag32_to_imag32
+    ; CHECK: liveins: $rl1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[LD0:%[0-9]+]]:gpr = LDImag8 $rc4
+    ; CHECK-NEXT: $rc8 = STImag8 [[LD0]]
+    ; CHECK-NEXT: [[LD1:%[0-9]+]]:gpr = LDImag8 $rc5
+    ; CHECK-NEXT: $rc9 = STImag8 [[LD1]]
+    ; CHECK-NEXT: [[LD2:%[0-9]+]]:gpr = LDImag8 $rc6
+    ; CHECK-NEXT: $rc10 = STImag8 [[LD2]]
+    ; CHECK-NEXT: [[LD3:%[0-9]+]]:gpr = LDImag8 $rc7
+    ; CHECK-NEXT: $rc11 = STImag8 [[LD3]]
+    $rl2 = COPY $rl1
+...
+---
 name: lsb_to_lsb
 tracksRegLiveness: true
 body: |

--- a/llvm/test/CodeGen/MOS/imag32-copy.mir
+++ b/llvm/test/CodeGen/MOS/imag32-copy.mir
@@ -1,0 +1,14 @@
+# RUN: llc -mtriple=mos -O2 -start-before=mos-copy-opt -verify-machineinstrs \
+# RUN:   -o - %s | FileCheck %s
+
+---
+name: imag32_copy
+tracksRegLiveness: true
+body: |
+  bb.0.entry:
+    liveins: $rl1
+    ; CHECK-LABEL: imag32_copy:
+    ; CHECK: rts
+    $rl2 = COPY $rl1
+    RTS
+...

--- a/llvm/test/CodeGen/MOS/imag32-nonalloc.mir
+++ b/llvm/test/CodeGen/MOS/imag32-nonalloc.mir
@@ -1,0 +1,17 @@
+# RUN: not llc -mtriple=mos -run-pass=none -verify-machineinstrs -o - %s \
+# RUN:   2>&1 | FileCheck %s
+
+# The MIR parser rejects virtual registers from nonallocatable classes.
+# CHECK: Cannot use non-allocatable class 'Imag32'
+
+---
+name: imag32_not_allocatable
+legalized: true
+regBankSelected: true
+tracksRegLiveness: true
+body: |
+  bb.0.entry:
+    %0:imag32 = IMPLICIT_DEF
+    KILL %0
+    RTS
+...

--- a/llvm/test/CodeGen/MOS/imag32-registers.mir
+++ b/llvm/test/CodeGen/MOS/imag32-registers.mir
@@ -1,0 +1,27 @@
+# RUN: llc -mtriple=mos -run-pass=none -verify-machineinstrs -o - %s | FileCheck %s
+
+---
+name: imag32_register
+tracksRegLiveness: true
+body: |
+  bb.0.entry:
+    liveins: $rl1
+    ; CHECK-LABEL: name: imag32_register
+    ; CHECK: liveins: $rl1
+    ; CHECK: $rl1 = IMPLICIT_DEF
+    $rl1 = IMPLICIT_DEF
+    RTS
+...
+---
+name: imag32_word_subregisters
+tracksRegLiveness: true
+body: |
+  bb.0.entry:
+    liveins: $rl1
+    ; CHECK-LABEL: name: imag32_word_subregisters
+    ; CHECK: $rs4 = EXTRACT_SUBREG $rl1, %subreg.sublo16
+    ; CHECK: $rs5 = EXTRACT_SUBREG $rl1, %subreg.subhi16
+    $rs4 = EXTRACT_SUBREG $rl1, %subreg.sublo16
+    $rs5 = EXTRACT_SUBREG $rl1, %subreg.subhi16
+    RTS
+...

--- a/llvm/test/CodeGen/MOS/imag32-zp-alloc.mir
+++ b/llvm/test/CodeGen/MOS/imag32-zp-alloc.mir
@@ -1,0 +1,26 @@
+# RUN: llc -mtriple=mos -mcpu=mos45gs02 -O2 -zp-avail=224 \
+# RUN:   -start-before=mos-zero-page-alloc -verify-machineinstrs -o - %s \
+# RUN:   | FileCheck %s
+
+--- |
+  target triple = "mos"
+
+  define void @imag32_zp() #0 {
+  entry:
+    ret void
+  }
+
+  attributes #0 = { "nonreentrant" }
+...
+---
+name: imag32_zp
+tracksRegLiveness: true
+body: |
+  bb.0.entry:
+    $rl5 = IMPLICIT_DEF
+    INLINEASM &"lda [$0],z", 9 /* sideeffect mayload attdialect */, 196622 /* mem:m */, $rl5
+    ; CHECK-LABEL: imag32_zp:
+    ; CHECK: lda [mos8(.Limag32_zp_zp_stk)],z
+    ; CHECK: .size .Limag32_zp_zp_stk, 4
+    RTS
+...

--- a/llvm/test/CodeGen/MOS/inline-asm-zp-csr.ll
+++ b/llvm/test/CodeGen/MOS/inline-asm-zp-csr.ll
@@ -16,9 +16,7 @@ define void @inline_asm_zp_csr(i8 %c) "nonreentrant" {
 ; CHECK-NEXT:    sta mos8(.Linline_asm_zp_csr_zp_stk+1)
 ; CHECK-NEXT:    ;APP
 ; CHECK-NEXT:    lda mos8(.Linline_asm_zp_csr_zp_stk)
-; CHECK-EMPTY:
 ; CHECK-NEXT:    lda mos8(.Linline_asm_zp_csr_zp_stk+1)
-; CHECK-EMPTY:
 ; CHECK-NEXT:    ;NO_APP
 ; CHECK-NEXT:    rts
 entry:

--- a/llvm/test/CodeGen/MOS/zp-alloc-composite-benefit.mir
+++ b/llvm/test/CodeGen/MOS/zp-alloc-composite-benefit.mir
@@ -1,0 +1,26 @@
+# REQUIRES: asserts
+# RUN: llc -mtriple=mos -O2 -zp-avail=224 \
+# RUN:   -start-before=mos-zero-page-alloc \
+# RUN:   -debug-only=mos-zero-page-alloc -o /dev/null %s 2>&1 \
+# RUN:   | FileCheck %s
+
+# CHECK: CSR $rs10, Size 2, Benefit 1.900000e+01
+
+--- |
+  target triple = "mos"
+
+  define void @imag16_zp_benefit() #0 {
+  entry:
+    ret void
+  }
+
+  attributes #0 = { "nonreentrant" }
+...
+---
+name: imag16_zp_benefit
+tracksRegLiveness: true
+body: |
+  bb.0.entry:
+    $rs10 = IMPLICIT_DEF
+    RTS
+...


### PR DESCRIPTION
Adds nonallocatable 32-bit imaginary registers composed of two 16-bit imaginary registers.

This prepares the backend for future 32-bit pointer and code-generation support, including 45GS02 Q-register operations and related 65CE02-family work. It doesn't change the ABI or expose 32-bit registers to allocation.

Also fixes inline-asm operand printing and composite zero-page CSR costing; stand-along and may be cherry picked.

This is step 1 of a likely long process and I'll leave this in draft state for the time being. Any comments are very welcome so I don't walk the wrong path. I do think this was briefly discussed in a GH thread back in Feb 2026, but I cant't find exactly where (ping @mysterymath). Update, found it - see below.

### future work

This adds only the nonallocatable Imag32. Next:

1. add SDK linker contract identifying platforms with safe contiguous four-byte imaginary registers (llvm-mos-sdk). Working branch: https://github.com/mlund/llvm-mos-sdk/tree/imag32-contract

2. then add allocation, spilling, and i32 inline-asm support on top of that (llvm-mos). Working branch: https://github.com/mlund/llvm-mos/tree/imag32-inline-asm-v2

Far-pointer address spaces and instruction selection is later work. First target is MEGA65 via `lda/sta [ptr],z`, extending the assembler and SDK support used by today’s `lpeek/lpoke` functions into wide pointers. CX16 VRAM may reuse the pointers with VERA-specific lowering and replace `vpeek/vpoke`.

In accord with LLVM guidelines, this PR was generated with assistance of OpenAI GPT 5.6 and humanly reviewed and tested by @mlund. I have tried to minimize any side effects to the best of my knowledge. The LLM found several issues that is now remedied and covered by tests.
