### PR TITLE
[compiler-rt] MOS hand-tuned single-precision softfloat (2nd attempt)

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -938,7 +938,13 @@ set(mips64_SOURCES ${GENERIC_TF_SOURCES}
 set(mips64el_SOURCES ${GENERIC_TF_SOURCES}
                      ${mips_SOURCES})
 
-set(mos_SOURCES ${GENERIC_SOURCES})
+set(mos_SOURCES
+  mos/addsf3.S
+  mos/divsf3.S
+  mos/mulsf3.S
+  mos/subsf3.S
+  ${GENERIC_SOURCES}
+)
 # MOS SDK implementations are already smaller and faster.
 list(REMOVE_ITEM mos_SOURCES
   ashldi3.c

--- a/compiler-rt/lib/builtins/mos/addsf3.S
+++ b/compiler-rt/lib/builtins/mos/addsf3.S
@@ -1,0 +1,922 @@
+//===-- lib/mos/addsf3.S - Single-precision addition (MOS 6502) --*- Asm -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// __addsf3(a, b) -- IEEE 754 binary32 addition for MOS (6502).
+//
+// Rounding: round-to-nearest-ties-to-even, hardcoded.  There is no
+// support for fenv (no dynamic rounding mode, no inexact flag).  This
+// is a deliberate choice: MOS programs almost never manipulate the
+// floating-point environment, and the generic compiler-rt fenv
+// machinery (__fe_getround, __fe_raise_inexact) is ~30x more expensive
+// per call than the arithmetic it wraps.
+//
+// This file also provides the __subsf3 code path indirectly: the
+// separate subsf3.S is a 6-instruction trampoline that flips b's sign
+// bit and JMPs here.  Anything that fixes __addsf3 fixes __subsf3.
+//
+// ============================================================================
+// REFERENCE: IEEE 754 binary32 memory layout (little-endian)
+// ============================================================================
+//
+//   byte 3  : [S | EEEEEEE ]     S     = sign bit
+//   byte 2  : [E | MMMMMMM ]     EEEEE = 8-bit biased exponent, split
+//   byte 1  : [MMMMMMMM    ]     M     = 23-bit stored mantissa
+//   byte 0  : [MMMMMMMM    ]     (implicit leading 1 for normals)
+//
+// The 8-bit biased exponent spans byte3's low 7 bits AND byte2's high
+// bit.  To extract, shift bit 7 of byte2 into carry with ASL, then
+// load byte3 and ROL through carry:
+//
+//     LDA byte2 ; ASL A    -- C = byte2[7] = E0 (low bit of exp)
+//     LDA byte3 ; ROL A    -- A = (byte3 << 1) | C = biased exp
+//
+// Number semantics by exponent field:
+//   exp == 0xFF, mantissa != 0 -- NaN (quiet if bit 22 (m3 bit 6) set)
+//   exp == 0xFF, mantissa == 0 -- +/- infinity
+//   exp == 0x00, mantissa != 0 -- subnormal (value = M * 2^-149)
+//   exp == 0x00, mantissa == 0 -- +/- zero (sign preserved)
+//   exp in [1,254]             -- normal (value = 1.M * 2^(exp-127))
+//
+// For arithmetic we restore the implicit leading 1 for normal operands
+// so the mantissa is 24 bits [1.MMMMMMMMMMMMMMMMMMMMMMM].  We store it
+// in the top three bytes of a 4-byte tuple [m3:m2:m1:m0] where m0 is a
+// sub-LSB byte holding round + guard bits shifted down during
+// alignment.  A separate `stk` byte accumulates a running sticky OR of
+// bits that fall off the bottom of m0.
+//
+// ============================================================================
+// REFERENCE: MOS calling convention for this function
+// ============================================================================
+//
+// float __addsf3(float a, float b) with the standard llvm-mos ABI:
+//
+//   INPUT:  a's bytes in A, X, __rc2, __rc3  (byte 0 in A ... byte 3 in rc3)
+//           b's bytes in __rc4, __rc5, __rc6, __rc7
+//   OUTPUT: result bytes in A, X, __rc2, __rc3
+//
+//   Caller-saved:  A, X, Y, flags, __rc2..__rc19 (RS1..RS9)
+//   Callee-saved:  __rc0/__rc1 (RS0 = soft SP), __rc20..__rc31 (RS10..RS15)
+//
+// We confine all state to caller-saved slots, so there is no prologue
+// or epilogue and no zero-page save/restore cost.
+//
+// ============================================================================
+// REFERENCE: zero-page layout during arithmetic
+// ============================================================================
+//
+//   __rc2    B_M0    b's sub-LSB byte (0 on entry, holds R/G bits)
+//   __rc3    B_M1    b's low mantissa byte  (was b_byte0 on entry)
+//   __rc4    B_M2    b's mid mantissa byte  (was b_byte1 on entry)
+//   __rc5    B_M3    b's high mantissa byte (implicit 1 in bit 7 for normal)
+//   __rc6    B_EXP   b's biased exponent
+//   __rc7    B_SIGN  b's sign in bit 7 (0x00 or 0x80)
+//   __rc8    B_STK   b's sticky bit (0 or nonzero)
+//   __rc9    TMP     scratch used in align/pack/round
+//   __rc10   A_M0    a's sub-LSB byte
+//   __rc11   A_M1    a's low mantissa byte
+//   __rc12   A_M2    a's mid mantissa byte
+//   __rc13   A_M3    a's high mantissa byte
+//   __rc14   A_EXP   a's biased exponent
+//   __rc15   A_SIGN  a's sign in bit 7
+//   __rc16   A_STK   a's sticky bit
+//
+// After the magnitude-compare swap, `a` always holds the operand with
+// the larger absolute value.
+//
+// ============================================================================
+// REFERENCE: MOS assembler gotchas
+// ============================================================================
+//
+// 1. Local labels use the ".L" prefix.  Since this is a stand-alone .S
+//    file (one assembler invocation), ".L" labels are truly file-local
+//    and cannot collide with sibling .S files.  Numeric labels
+//    (1:, 2:, ..., 32:) also work; each `Nf` refers to the next `N:`
+//    forward.  Do not reuse the same numeric label multiple times in
+//    the same function.
+//
+// 2. Out-of-range branch offsets are silently TRUNCATED to 8 bits.
+//    A BEQ/BNE/BCC/BCS whose target is more than +127/-128 bytes away
+//    will wrap to a totally different address and execute garbage.
+//    For any conditional branch that reaches a far label we use the
+//    invert-and-jump pattern:
+//        bne .Lskip ; jmp .Lfar_target ; .Lskip:
+//    OR, when several far branches share a common target, we place a
+//    small trampoline (jmp .Lfar_target) within byte range of all of
+//    them and branch to the trampoline.  See .L__addsf3_tramp_pack_a.
+//
+// 3. Even-numbered __rcN slots are declared with PROVIDE() in the
+//    linker script, so a platform can reorder them.  The only
+//    guaranteed-contiguous groups are pointer pairs: (rc0,rc1),
+//    (rc2,rc3), (rc4,rc5), ....  We therefore access every named slot
+//    by name and never use zp,x indexed addressing over the __rcN range.
+//
+// ============================================================================
+// REFERENCE: algorithm phases
+// ============================================================================
+//
+//   1. UNPACK A: split A/X/rc2/rc3 into sign/exp/mantissa/sticky in
+//      __rc10..__rc16.  Restore implicit-1 bit in m3 for normals.
+//   2. UNPACK B: same for b's bytes in rc4..rc7, target __rc2..__rc8.
+//   3. COMPARE + SWAP: compare |a| vs |b|; if a < b, swap the five
+//      unpacked fields so a becomes the larger.
+//   4. INF/NAN DISPATCH: classify special values.
+//   5. ZERO DISPATCH: signed-zero rule for a == 0 (implies b == 0).
+//   6. ALIGN: shift b's mantissa right by (a.exp - b.exp).  Whole-byte
+//      fast path for shifts >= 8, bit loop for residual.  Accumulate
+//      sticky in B_STK.
+//   7. ADD or SUBTRACT: same-sign -> ADC chain; opposite-sign -> SBC
+//      chain (borrow cannot propagate out of m3 because |a| >= |b|).
+//      On the subtract path, when B_STK is set we ripple-decrement the
+//      tuple by 1 and force A_STK=1 to get the correct sticky sign.
+//   8. NORMALIZE (subtract only): shift left until bit 7 of m3 is set;
+//      stop AT exp==1 (crossing into subnormal without shifting)
+//      because subnormals share the same reference scale as the
+//      smallest normal.  Not stopping there silently doubles subnormal
+//      results.
+//   9. SUBNORMAL FIX (add path only): if arithmetic produced m3 bit 7
+//      set with exp==0 (two subnormals added to a normal), bump exp
+//      to 1.
+//  10. OVERFLOW: exp >= 0xFF -> signed infinity.
+//  11. ROUND: nearest-ties-to-even using round/guard/sticky in m0/stk;
+//      ripple-increment m1..m3; bump exp on all-1s wrap; overflow to
+//      infinity if that pushes exp past 0xFE.
+//  12. PACK: reassemble result bytes back into A, X, __rc2, __rc3.
+//
+//===----------------------------------------------------------------------===//
+
+#include "imag-regs-zp.inc"
+
+#define B_M0  __rc2
+#define B_M1  __rc3
+#define B_M2  __rc4
+#define B_M3  __rc5
+#define B_EXP  __rc6
+#define B_SIGN  __rc7
+#define B_STK  __rc8
+#define A_M0  __rc10
+#define A_M1  __rc11
+#define A_M2  __rc12
+#define A_M3  __rc13
+#define A_EXP  __rc14
+#define A_SIGN  __rc15
+#define A_STK  __rc16
+; __rc17..__rc18 are free; align scratch reuses __rc9 (TMP).
+#define TMP  __rc9
+
+
+.text
+.globl __addsf3
+.type __addsf3, @function
+__addsf3:
+        ; ================================================================
+        ; Phase 1 -- UNPACK A: A/X/__rc2/__rc3 (a's incoming bytes) into
+        ; our working slots __rc10..__rc16.  See the "IEEE 754 binary32
+        ; memory layout" reference at top of file.
+
+        ; On entry: A = a_byte0 (low mantissa), X = a_byte1,
+        ; __rc2 = a_byte2 (E0|MMMMMMM), __rc3 = a_byte3 (S|EEEEEEE)
+
+        ; A_M1 and A_M2 come straight from A and X.
+        ; A_EXP uses the ASL/ROL trick: ASL __rc2 puts byte2's bit 7 (E0)
+        ; in C, then ROL A on byte3 gives (byte3<<1)|C = 8-bit biased exp.
+        ; A_SIGN is byte3's bit 7 preserved as 0x00 or 0x80.
+        ; A_M3 is byte2's low 7 mantissa bits, with the implicit leading 1
+        ; restored (bit 7 set) iff we're normal (exp != 0).
+        ; A_M0 and A_STK start at 0 (no sub-LSB bits, no sticky yet).
+        ; ================================================================
+        sta A_M1   ; A_M1 = byte0
+        stx A_M2   ; A_M2 = byte1
+
+        ; Extract biased exponent from (byte3<<1)|(byte2>>7)
+        lda __rc2   ; A = byte2
+        asl a   ; C = byte2[7] = E0
+        lda __rc3   ; A = byte3, C preserved
+        rol a   ; A = (byte3<<1)|C = biased exp
+        sta A_EXP
+
+        ; Extract sign bit (byte3 & 0x80)
+        lda __rc3
+        and #$80
+        sta A_SIGN
+
+        ; Restore mantissa MSB with implicit leading 1 for normals:
+        ; A_M3 = (byte2 & 0x7f) | (exp!=0 ? 0x80 : 0)
+        lda __rc2
+        and #$7f   ; strip E0
+        ldy A_EXP   ; check exp
+        beq 1f   ; exp==0 -> subnormal, no bit 7
+        ora #$80   ; exp!=0 -> set implicit 1
+        1: sta A_M3
+
+        ; Initialise sub-LSB byte and sticky.
+        lda #0
+        sta A_M0
+        sta A_STK
+
+        ; ================================================================
+        ; Phase 2 -- UNPACK B: __rc4..__rc7 (b's incoming bytes) into
+        ; __rc2..__rc8.  Same shape as unpack A.  We can safely overwrite
+        ; __rc2/__rc3 now because a's data has been fully extracted.
+
+        ; Order matters: we read __rc4/__rc5 (b_byte0/1) before writing
+        ; to B_M1 (=__rc3), which happens to be safe because we're
+        ; writing to __rc3 and reading from __rc4/__rc5 which are
+        ; preserved.
+        ; ================================================================
+        lda __rc4   ; b_byte0
+        sta B_M1
+        lda __rc5   ; b_byte1
+        sta B_M2
+
+        ; Biased exp via the ASL/ROL trick, stashed in Y temporarily
+        ; so we can consult it while computing B_M3.
+        lda __rc6
+        asl a
+        lda __rc7
+        rol a
+        tay   ; Y = b_exp
+
+        lda __rc6
+        and #$7f
+        cpy #0
+        beq 2f
+        ora #$80
+        2: sta B_M3
+        sty B_EXP
+
+        lda __rc7
+        and #$80
+        sta B_SIGN
+
+        lda #0
+        sta B_M0
+        sta B_STK
+
+        ; ================================================================
+        ; COMPARE |a| vs |b|; swap if |a| < |b|
+        ; ================================================================
+        ; ================================================================
+        ; Phase 3 -- MAGNITUDE COMPARE and SWAP.
+
+        ; We want |a| >= |b| after this phase, so the arithmetic can
+        ; freely assume a is the "larger" operand (align always shifts
+        ; b, subtract never underflows a, special-case dispatch only
+        ; checks a's classification).
+
+        ; Since sign is stored separately, |a| = a's exp:m3:m2:m1 as an
+        ; unsigned tuple.  IEEE 754's clever bit layout makes this a
+        ; straight byte-wise lexicographic compare from high (exp) to
+        ; low (m1) -- m0 and stk are both 0 for both operands at this
+        ; point so we can ignore them.
+
+        ; BCC/BNE cascade: at each level, BCC on "a<b at this byte"
+        ; jumps to swap; BNE on "a>b at this byte" jumps past swap.
+        ; Only equality falls through to the next-lower byte.
+        ; ================================================================
+        lda A_EXP
+        cmp B_EXP
+        bcc .L__addsf3_do_swap
+        bne .L__addsf3_no_swap
+        lda A_M3
+        cmp B_M3
+        bcc .L__addsf3_do_swap
+        bne .L__addsf3_no_swap
+        lda A_M2
+        cmp B_M2
+        bcc .L__addsf3_do_swap
+        bne .L__addsf3_no_swap
+        lda A_M1
+        cmp B_M1
+        bcs .L__addsf3_no_swap
+
+        .L__addsf3_do_swap:
+        ; Swap 5 fields (m1, m2, m3, exp, sign).  MUST be unrolled --
+        ; we cannot use zp,x indexed addressing over the __rcN range
+        ; because only pair members rc(2N)/rc(2N+1) are guaranteed
+        ; contiguous; the platform's imag-regs.ld may reorder even-rc
+        ; slots between pairs.  See llvm-mos-sdk .../lib/imag-regs.ld.
+        ; m0 and stk are known 0 for both operands here, so no need to
+        ; swap them.
+        ldx A_M1
+        lda B_M1
+        sta A_M1
+        stx B_M1
+        ldx A_M2
+        lda B_M2
+        sta A_M2
+        stx B_M2
+        ldx A_M3
+        lda B_M3
+        sta A_M3
+        stx B_M3
+        ldx A_EXP
+        lda B_EXP
+        sta A_EXP
+        stx B_EXP
+        ldx A_SIGN
+        lda B_SIGN
+        sta A_SIGN
+        stx B_SIGN
+
+        .L__addsf3_no_swap:
+
+        ; ================================================================
+        ; Phase 4 -- INF/NAN dispatch.
+
+        ; Exp == 0xFF marks a special value.  Since |a| >= |b|, we only
+        ; need to check a first; b's classification only matters in
+        ; sub-cases (b is also NaN, or inf+inf with opposite signs).
+
+        ; Distinguishing NaN vs inf: mantissa != 0 -> NaN, mantissa == 0
+        ; -> inf.  We inline the (m3&0x7f)|m2|m1 OR check at each site
+        ; rather than precomputing it globally, because common-path
+        ; inputs (exp in [1,254]) never need it.
+
+        ; IEEE 754 propagates NaN: NaN + anything = NaN.  We "quiet" the
+        ; NaN by setting bit 22 (which is bit 6 of m3, or 0x40 in
+        ; "high byte + implicit 1 restored" form).
+        ; ================================================================
+        lda A_EXP
+        cmp #$ff
+        bne .L__addsf3_not_infnan
+
+        ; a_exp == 0xff.  Is a a NaN or an inf?
+        lda A_M3
+        and #$7f
+        ora A_M2
+        ora A_M1
+        beq .L__addsf3_a_is_inf
+        ; a is NaN -> quiet and return a
+        lda A_M3
+        ora #$40
+        sta A_M3
+        jmp .L__addsf3_pack_a
+
+        .L__addsf3_a_is_inf:
+        ; a is +/- inf.  If b is finite, result is a.
+        lda B_EXP
+        cmp #$ff
+        ; .L__addsf3_pack_a is > 127 bytes away and the assembler silently
+        ; truncates out-of-range branch offsets, so instead of a bare
+        ; "bne .L__addsf3_pack_a" we branch to the .L__addsf3_tramp_pack_a trampoline
+        ; placed just a few instructions below (in byte range).
+        bne .L__addsf3_tramp_pack_a
+        ; b is also inf or NaN -- classify with an inline OR check.
+        lda B_M3
+        and #$7f
+        ora B_M2
+        ora B_M1
+        beq .L__addsf3_both_inf
+        ; b is NaN -> quiet b and return b.  The result flows through
+        ; the pack_b_to_a prologue which copies b's fields into a's
+        ; slots then falls into the shared pack_a exit.
+        lda B_M3
+        ora #$40
+        sta B_M3
+        jmp .L__addsf3_pack_b_to_a
+
+        ; Shared trampoline: both .L__addsf3_a_is_inf and .L__addsf3_both_inf branch here
+        ; to reach .L__addsf3_pack_a (which is >127 bytes below, past all the
+        ; arithmetic phases).  Position matters -- it must be within
+        ; byte range of every branch that targets it.  Both callers
+        ; above are within ~20 bytes, so this location is fine.
+        .L__addsf3_tramp_pack_a:
+        jmp .L__addsf3_pack_a
+
+        .L__addsf3_both_inf:
+        ; Both operands are +/- inf.  Same sign -> return that inf.
+        ; Different signs -> +inf + -inf is IEEE-undefined and returns
+        ; a qNaN (canonical 0x7fc00000).
+        lda A_SIGN
+        cmp B_SIGN
+        beq .L__addsf3_tramp_pack_a   ; same sign -> return a
+        ; Different signs: build 0x7fc00000 directly into the ABI return
+        ; slots and RTS.  byte0=0 (in A), byte1=0 (in X), byte2=0xc0
+        ; (in __rc2), byte3=0x7f (in __rc3).
+        lda #$7f
+        sta __rc3
+        lda #$c0
+        sta __rc2
+        ldx #0
+        lda #0
+        rts
+
+        .L__addsf3_not_infnan:
+        ; ================================================================
+        ; Phase 5 -- ZERO dispatch.
+
+        ; Since |a| >= |b|, if a is zero then b must also be zero.
+        ; IEEE 754 signed-zero rule for addition:
+        ; +0 + +0 = +0        -0 + -0 = -0
+        ; +0 + -0 = +0        -0 + +0 = +0
+        ; Equivalently: result sign = a_sign AND b_sign (bit 7 semantic).
+
+        ; If a has exp==0 with a nonzero mantissa, it's a subnormal
+        ; (not zero), and we fall through to the normal arithmetic path.
+        ; ================================================================
+        lda A_EXP
+        bne .L__addsf3_not_zero
+        ; a_exp == 0 -- is it a zero (all mantissa bits 0) or subnormal?
+        lda A_M3
+        and #$7f
+        ora A_M2
+        ora A_M1
+        bne .L__addsf3_not_zero   ; subnormal -> normal path
+        ; a is +/- 0.  b is also +/- 0.  Apply signed-zero rule to b's
+        ; sign in place, then dispatch through pack_b_to_a.
+        lda B_SIGN
+        and A_SIGN
+        sta B_SIGN
+        jmp .L__addsf3_pack_b_to_a
+
+        .L__addsf3_not_zero:
+        ; ================================================================
+        ; Phase 6 -- ALIGN b's mantissa to a's exponent.
+
+        ; Shift count = a_effective_exp - b_effective_exp, where the
+        ; "effective exp" of a subnormal (biased exp = 0) is 1 (since
+        ; the smallest normal has biased exp 1 and represents 2^-126,
+        ; and a subnormal represents the same power range with the
+        ; implicit-1 removed).
+
+        ; Cases:
+        ; both normal:                shift = a_exp - b_exp
+        ; a normal, b subnormal:      shift = a_exp - 1
+        ; both subnormal (a_exp==0):  shift = 0  (early exit)
+        ; a subnormal, b normal:      impossible after swap (|a|>=|b|)
+
+        ; Do the a_exp-first check to skip everything for the "both
+        ; subnormal" case (no shift needed).  Otherwise SBC on B_EXP
+        ; gives a_exp - b_exp; the correction "-1 more if b was 0" is a
+        ; single SBC #1 whose C-input is still set from the previous
+        ; SBC (which cannot have borrowed because a >= b).
+        ; ================================================================
+        lda A_EXP
+        beq .L__addsf3_align_done   ; both subnormal, no shift
+        sec
+        sbc B_EXP   ; A = a_exp - b_exp
+        ; If b_exp was 0, we need one more decrement (want a_exp - 1).
+        ; C is still set from the SBC above (a>=b -> no borrow).
+        ldy B_EXP
+        bne 7f
+        sbc #1
+        7: beq .L__addsf3_align_done   ; shift == 0, no work
+
+        ; If shift count is >= 32, b's entire 4-byte mantissa is discarded
+        ; in one shot -- much cheaper than iterating the bit loop 32+ times.
+        ; Sticky bit reflects whether any bit was truncated: 1 iff b's
+        ; pre-shift mantissa was nonzero, 0 if b was exactly 0.  (The
+        ; zero-dispatch above only checks a; it is legal for b to be 0
+        ; here.  See the subtract-path sticky ripple below -- it MUST
+        ; NOT fire when no bits were actually truncated, because
+        ; ripple-decrementing a's tuple in that case corrupts an
+        ; otherwise-exact result.)
+        cmp #32
+        bcc .L__addsf3_align_byte_check
+        lda B_M3
+        ora B_M2
+        ora B_M1
+        ora B_M0
+        sta TMP                              ; TMP = "b was nonzero" flag
+        lda #0
+        sta B_M0
+        sta B_M1
+        sta B_M2
+        sta B_M3
+        sta B_STK                            ; default: no bits truncated
+        lda TMP
+        beq .L__addsf3_align_done            ; b was 0, STK stays 0
+        lda #1
+        sta B_STK
+        jmp .L__addsf3_align_done
+
+        ; Whole-byte fast path: while count >= 8, shift the tuple down by
+        ; 8 bits with a byte-shuffle (m0 <- m1, m1 <- m2, m2 <- m3, m3 <- 0)
+        ; and decrement count by 8.  Anything that would have shifted out
+        ; of m0 becomes sticky (we OR in the old m0's whole byte because
+        ; sticky is "any bit was 1 anywhere below the LSB" -- exact value
+        ; doesn't matter, only nonzero-ness).
+
+        ; Count is parked in Y across the shuffle (which needs A for the
+        ; byte moves).  Y is dead here -- the align entry test finished
+        ; with it, and the bit loop below reloads it via TAY.
+        .L__addsf3_align_byte_check:
+        cmp #8
+        bcc .L__addsf3_align_bit_setup
+        sec
+        sbc #8
+        tay   ; park residual count
+        lda B_M0
+        beq 11f
+        sta B_STK   ; any nonzero suffices for sticky
+        11: lda B_M1
+        sta B_M0
+        lda B_M2
+        sta B_M1
+        lda B_M3
+        sta B_M2
+        lda #0
+        sta B_M3
+        tya
+        jmp .L__addsf3_align_byte_check
+
+        ; Bit loop for the residual 1..7 shifts.  After the LSR/ROR chain,
+        ; C holds the bit that just fell off m0's LSB -- if set, mark
+        ; sticky.  Y is the loop counter (DEY sets Z, BNE loops).
+        .L__addsf3_align_bit_setup:
+        tay
+        beq .L__addsf3_align_done   ; residual == 0, done
+        .L__addsf3_align_bit_loop:
+        lsr B_M3
+        ror B_M2
+        ror B_M1
+        ror B_M0
+        bcc 12f   ; C = bit that fell off m0[0]
+        lda #1
+        sta B_STK
+        12: dey
+        bne .L__addsf3_align_bit_loop
+
+        .L__addsf3_align_done:
+
+        ; ================================================================
+        ; Phase 7 -- ADD or SUBTRACT the aligned mantissas.
+
+        ; Same-sign path is a straight 4-byte ADC chain over the
+        ; [m3:m2:m1:m0] tuple.  A carry out of m3 means the sum grew
+        ; past 2.0; we shift the whole tuple right by 1 and increment
+        ; the exponent to keep the mantissa in [1.0, 2.0) form.
+
+        ; Opposite-sign path is a 4-byte SBC chain; since a is the
+        ; larger operand (post-swap), no borrow can propagate out of
+        ; m3.  A result of exactly zero means exact cancellation -> +0.
+        ; Otherwise we normalize (shift left until m3 bit 7 is set) to
+        ; restore the leading-1 form.
+
+        ; In both paths we OR b's sticky bit into a's sticky.
+        ; ================================================================
+        lda A_SIGN
+        cmp B_SIGN
+        bne .L__addsf3_do_subtract
+
+        ; ---- SAME-SIGN ADD ----
+        ; Straight ADC chain, byte-by-byte, low to high.
+        clc
+        lda A_M0
+        adc B_M0
+        sta A_M0
+        lda A_M1
+        adc B_M1
+        sta A_M1
+        lda A_M2
+        adc B_M2
+        sta A_M2
+        lda A_M3
+        adc B_M3
+        sta A_M3
+        bcc .L__addsf3_add_no_carry
+        ; Carry out of the top: the sum has exceeded 24-bit mantissa
+        ; space (there's now a virtual bit 24 = the carry).  Shift the
+        ; whole tuple right by 1 to bring bit 24 back to bit 23, then
+        ; OR in the implicit-1 marker (bit 7 of m3), and bump exp.
+        ; C after the LSR/ROR chain is the bit that fell off m0 -- OR
+        ; into sticky.
+        lsr A_M3
+        ror A_M2
+        ror A_M1
+        ror A_M0
+        bcc 13f
+        lda #1
+        sta A_STK
+        13: lda A_M3
+        ora #$80
+        sta A_M3
+        inc A_EXP
+        .L__addsf3_add_no_carry:
+        ; Merge b's sticky into a's sticky (as a plain OR: any nonzero
+        ; b-stk makes a-stk nonzero).
+        lda B_STK
+        beq .L__addsf3_skip_stk_or
+        lda #1
+        sta A_STK
+        .L__addsf3_skip_stk_or:
+        jmp .L__addsf3_after_arith
+
+        .L__addsf3_do_subtract:
+        ; ---- OPPOSITE-SIGN SUBTRACT ----
+        ; Straight SBC chain low-to-high.  Since |a|>=|b| post-swap,
+        ; borrow cannot propagate out of m3.  Result sign is a's sign.
+        sec
+        lda A_M0
+        sbc B_M0
+        sta A_M0
+        lda A_M1
+        sbc B_M1
+        sta A_M1
+        lda A_M2
+        sbc B_M2
+        sta A_M2
+        lda A_M3
+        sbc B_M3
+        sta A_M3
+        ; Bug fix: on the SUBTRACT path, a nonzero B_STK means b's true
+        ; value is slightly larger than the truncated bytes we subtracted,
+        ; so the computed difference is slightly TOO LARGE by an amount
+        ; strictly less than one ULP.  Correct rounding requires biasing
+        ; DOWN -- the mirror image of the add-path convention where a
+        ; nonzero sticky biases up.  We encode that here by ripple-
+        ; decrementing the [A_M3:A_M2:A_M1:A_M0] tuple by 1 and setting
+        ; A_STK unconditionally, so the true value is representable as
+        ; "(computed - 1 ULP) plus a strictly-positive inexact remainder"
+        ; -- which is exactly what the standard add-path rounding logic
+        ; below wants to see.
+        ;
+        ; The ripple decrement cannot underflow an all-zero tuple:
+        ; whenever B_STK is set, alignment shifted b (logical right
+        ; shift zero-fills), so B_M3 bit 7 is provably 0 post-shift;
+        ; and A had exp != 0 (else the zero-dispatch above fired), so
+        ; A_M3 bit 7 is provably 1 pre-sub.  Therefore the raw SBC
+        ; result has bit 7 set (or the sub required a borrow-in that
+        ; already reduced the higher byte), so the tuple is >= 1 before
+        ; decrement.
+        lda B_STK
+        beq .L__addsf3_sub_stk_done
+        dec A_M0
+        lda A_M0
+        cmp #$ff
+        bne .L__addsf3_sub_stk_set
+        dec A_M1
+        lda A_M1
+        cmp #$ff
+        bne .L__addsf3_sub_stk_set
+        dec A_M2
+        lda A_M2
+        cmp #$ff
+        bne .L__addsf3_sub_stk_set
+        dec A_M3
+        .L__addsf3_sub_stk_set:
+        lda #1
+        sta A_STK
+        .L__addsf3_sub_stk_done:
+
+        ; Exact cancellation (whole tuple + sticky all zero) -> +0.
+        ; Per IEEE 754, "correctly-rounded x - x" returns +0 for any
+        ; finite x under round-to-nearest.
+        lda A_M3
+        ora A_M2
+        ora A_M1
+        ora A_M0
+        ora A_STK
+        bne .L__addsf3_do_normalize
+        lda #0
+        sta __rc2
+        sta __rc3
+        ldx #0
+        lda #0
+        rts
+
+        .L__addsf3_do_normalize:
+        ; ================================================================
+        ; Phase 8 -- NORMALIZE (subtract path only).
+
+        ; After cancellation, m3's bit 7 may no longer be set.  Shift
+        ; the tuple left until it is, decrementing exp accordingly.  If
+        ; exp reaches 0 first, the result is subnormal (or exact
+        ; cancellation, already handled).
+
+        ; Whole-byte fast path is taken when m3 == 0 (all bits) AND exp
+        ; is high enough to afford an 8-bit shift.  Each iteration
+        ; shifts everything up by a byte and decrements exp by 8.  When
+        ; m3 has any bit set we bail to the bit loop (which will take
+        ; at most 7 iterations to place bit 7).
+        ; ================================================================
+        .L__addsf3_norm_byte_check:
+        bit A_M3   ; N flag <- bit 7 of A_M3
+        bmi .L__addsf3_norm_done   ; bit 7 set -> normalized
+        lda A_EXP
+        cmp #9
+        bcc .L__addsf3_norm_bit_loop   ; exp < 9: byte-shift would
+                                             ; drop exp below 1; use bits
+        lda A_M3
+        bne .L__addsf3_norm_bit_loop   ; m3 has bits (below bit 7):
+                                             ; bit shift will finish faster
+        ; Whole-byte shift left:
+        ; m3 <- m2, m2 <- m1, m1 <- m0, m0 <- (stk ? 0x80 : 0)
+        ; The sticky-bit-becomes-new-m0-bit-7 rule is because sticky
+        ; represents "some non-zero bit was below m0"; when we shift
+        ; that region up into m0, it collapses to a single bit at the
+        ; topmost position (bit 7).
+        lda A_M2
+        sta A_M3
+        lda A_M1
+        sta A_M2
+        lda A_M0
+        sta A_M1
+        lda A_STK
+        beq 14f
+        lda #$80
+        14: sta A_M0
+        lda #0
+        sta A_STK
+        ; exp -= 8
+        lda A_EXP
+        sec
+        sbc #8
+        sta A_EXP
+        jmp .L__addsf3_norm_byte_check
+
+        ; Bit loop: shift left 1 per iteration, folding sticky bit into
+        ; the new m0 LSB via LSR of stk into C, then ROL through the
+        ; tuple.  After the ROL chain, stk is fully consumed (set to 0).
+        .L__addsf3_norm_bit_loop:
+        bit A_M3
+        bmi .L__addsf3_norm_done
+        lda A_EXP
+        beq .L__addsf3_norm_done   ; already subnormal -- stop
+        ; Bug fix: exp==1 is the transition into subnormal representation,
+        ; not one more normal-to-normal renormalization step.  Normal
+        ; exponents E and E-1 (both >=1) share a "shift mantissa left 1,
+        ; decrement exp" invariant that preserves value; that invariant
+        ; does NOT extend to E=1 -> E=0, because IEEE 754 subnormals
+        ; (biased exp field 0) reuse the SAME reference scale as the
+        ; smallest normal (biased exp field 1) -- they just drop the
+        ; implicit leading 1.  So at exp==1 with bit 7 still clear, the
+        ; CURRENT (unshifted) mantissa is already the correct subnormal
+        ; encoding: relabel exp to 0 and stop, without shifting.
+        ; Shifting here as if crossing a normal exponent boundary
+        ; silently doubles the result.
+        cmp #1
+        beq .L__addsf3_norm_to_subnormal
+        lda A_STK
+        lsr a   ; C <- stk bit 0
+        rol A_M0   ; shift with sticky into new m0[0]
+        rol A_M1
+        rol A_M2
+        rol A_M3
+        lda #0
+        sta A_STK
+        dec A_EXP
+        jmp .L__addsf3_norm_bit_loop
+
+        .L__addsf3_norm_to_subnormal:
+        lda #0
+        sta A_EXP
+        ; fall through
+
+        .L__addsf3_norm_done:
+        ; (The old "NORMALIZE OVERSHOOT CORRECTION" block that sat here
+        ; is unreachable now that the bit-loop exits cleanly at exp==1
+        ; via .L__addsf3_norm_to_subnormal without a final shift, so
+        ; "exp==0 AND m3 bit 7 set" cannot arise on the subtract path.
+        ; Fall straight into the shared after-arith path.)
+
+        .L__addsf3_after_arith:
+        ; ================================================================
+        ; Phase 9 -- SUBNORMAL-GREW-INTO-NORMAL FIX (add path only).
+
+        ; Two subnormal operands can add to a value >= 2^-126 (smallest
+        ; normal); the mantissa's implicit-1 bit (m3 bit 7) is set but
+        ; exp is still 0.  IEEE 754 requires that be encoded with exp=1.
+        ; Pack expects exp>=1 when m3 bit 7 is set, so bump exp here.
+
+        ; The subtract path can't reach this state: its overshoot
+        ; correction above shifts the tuple such that m3 bit 7 is
+        ; guaranteed clear when exp is 0.
+        ; ================================================================
+        lda A_EXP
+        bne .L__addsf3_skip_subnorm_fix   ; exp != 0, nothing to do
+        bit A_M3
+        bpl .L__addsf3_skip_subnorm_fix   ; m3 bit 7 clear -> true subnormal
+        lda #1
+        sta A_EXP
+        .L__addsf3_skip_subnorm_fix:
+
+        ; ================================================================
+        ; Phase 10 -- OVERFLOW -> signed infinity.
+
+        ; exp >= 0xFF means we've saturated.  Return +/- inf with a's
+        ; sign.  Encoding: byte3 = sign|0x7F, byte2 = 0x80, low bytes 0.
+        ; ================================================================
+        lda A_EXP
+        cmp #$ff
+        bcc .L__addsf3_do_round
+
+        .L__addsf3_return_inf:
+        lda #$80
+        sta __rc2
+        lda A_SIGN
+        ora #$7f
+        sta __rc3
+        ldx #0
+        lda #0
+        rts
+
+        .L__addsf3_do_round:
+        ; ================================================================
+        ; Phase 11 -- ROUND to nearest, ties to even.
+
+        ; Our round + guard + sticky bits are packed in m0 and stk:
+        ; R = m0 bit 7      (round bit; nearest tie boundary)
+        ; G = m0 bit 6      (guard; disambiguates > half from == half)
+        ; S = (m0 & 0x3f) != 0  ||  stk != 0
+        ; LSB = m1 bit 0    (destination LSB; for ties-to-even)
+
+        ; Round-up condition: R && (G || S || LSB).
+        ; - R=0: below half, round down (no increment).
+        ; - R=1, G|S=1: strictly above half, round up.
+        ; - R=1, G=0, S=0: exactly half, tie to even -> round up iff
+        ; LSB is odd (would make it even after +1).
+        ; ================================================================
+        bit A_M0
+        bpl .L__addsf3_pack_a   ; R bit clear -> no round
+
+        ; Compute (G | S | LSB) via ORs; branch to pack_a if all zero
+        ; (exact tie with even LSB -> no round).
+        lda A_M0
+        and #$7f   ; G bit + partial sticky bits
+        ora A_STK   ; fold in accumulated sticky
+        sta TMP
+        lda A_M1
+        and #1   ; LSB for tie-to-even
+        ora TMP
+        beq .L__addsf3_pack_a   ; exact tie, LSB even -> no round
+
+        ; Round up: ripple-increment the 24-bit mantissa.  If it wraps
+        ; all the way to zero, that means m1..m3 were 0xFFFFFF and the
+        ; rounded value is exactly 2^(exp+1) -- restore m3 bit 7 and
+        ; bump exp (which may overflow to infinity).
+        inc A_M1
+        bne .L__addsf3_pack_a
+        inc A_M2
+        bne .L__addsf3_pack_a
+        inc A_M3
+        bne .L__addsf3_pack_a
+        lda #$80
+        sta A_M3
+        inc A_EXP
+        lda A_EXP
+        cmp #$ff
+        bcs .L__addsf3_return_inf
+        jmp .L__addsf3_pack_a                     ; skip pack_b_to_a fall-through
+
+        ; ================================================================
+        ; Phase 12a -- PACK B_TO_A prologue.
+
+        ; The "b is NaN quiet" and "both zero" paths want to return b's
+        ; value.  Rather than maintain a duplicate packer for b's slots,
+        ; copy b's five fields into a's slots and fall through into the
+        ; single shared .L__addsf3_pack_a exit.  Costs 5 load/store pairs (~30
+        ; cycles on rare paths) in exchange for ~35 bytes of code we'd
+        ; otherwise emit twice.
+        ; ================================================================
+        .L__addsf3_pack_b_to_a:
+        lda B_M1
+        sta A_M1
+        lda B_M2
+        sta A_M2
+        lda B_M3
+        sta A_M3
+        lda B_EXP
+        sta A_EXP
+        lda B_SIGN
+        sta A_SIGN
+        ; fall through
+
+        ; ================================================================
+        ; Phase 12b -- PACK a into the ABI return position.
+
+        ; Return convention: byte0 in A, byte1 in X, byte2 in __rc2,
+        ; byte3 in __rc3.  We reconstruct the IEEE 754 layout by
+        ; splitting the biased exponent between byte3's low 7 bits and
+        ; byte2's high bit, and dropping the implicit-1 marker from m3.
+
+        ; byte3 = sign | (exp >> 1)          (S | E7..E1)
+        ; byte2 = (m3 & 0x7f) | ((exp & 1) << 7)  (E0 | M22..M16)
+        ; byte1 = m2                          (M15..M8)
+        ; byte0 = m1                          (M7..M0)
+
+        ; Trick: LSR of exp puts the low bit in C.  That C is preserved
+        ; through LDA/AND (which don't touch C), so we can BCC/BCS on
+        ; it after loading m3 and ANDing to strip its bit 7.
+        ; ================================================================
+        .L__addsf3_pack_a:
+        lda A_EXP
+        lsr a   ; A = exp>>1, C = exp bit 0 (E0)
+        sta TMP   ; stash exp>>1 for byte3
+        lda A_M3
+        and #$7f   ; strip implicit-1 marker
+        bcc .L__addsf3_pack_no_bit7   ; if E0 was 0, no bit 7
+        ora #$80   ; if E0 was 1, set bit 7
+        .L__addsf3_pack_no_bit7:
+        sta __rc2   ; byte2 = E0|(m3&0x7f)
+        lda TMP
+        ora A_SIGN
+        sta __rc3   ; byte3 = sign|(exp>>1)
+        lda A_M1   ; byte0 -> A
+        ldx A_M2   ; byte1 -> X
+        rts

--- a/compiler-rt/lib/builtins/mos/divsf3.S
+++ b/compiler-rt/lib/builtins/mos/divsf3.S
@@ -1,0 +1,858 @@
+//===-- lib/mos/divsf3.S - Single-precision division (MOS 6502) -*- Asm -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+//
+// __divsf3(a, b) -- IEEE 754 binary32 division for MOS (6502).
+//
+// Rounding: round-to-nearest-ties-to-even, hardcoded.  No fenv support.
+//
+// Same overall shape as addsf3.c and mulsf3.c: one naked top-level
+// function with all state in caller-saved zero-page (__rc2..__rc19),
+// .L-prefixed local labels, invert-and-jmp for far branches.  See
+// addsf3.c for the reference material on IEEE 754 layout and the
+// assembler gotchas that applies unchanged here.
+//
+// ============================================================================
+// REFERENCE: division algorithm outline
+// ============================================================================
+//
+// value(a/b) = (-1)^(sa^sb) * (Ma/Mb) * 2^((ea-eb))     for normal a,b
+//
+// Sign of result is the XOR of input signs.  Magnitude is a 24 x 24 ->
+// 25-bit mantissa division plus an exponent subtract.  Since both input
+// mantissas are in [2^23, 2^24) (implicit-1 restored), the mantissa
+// ratio Ma/Mb is in (0.5, 2.0).  Two cases fall out:
+//
+// Case A (Ma >= Mb, ratio in [1, 2)):  the true (Ma * 2^24) / Mb
+// quotient is a 25-bit value with bit 24 = 1.  The result mantissa
+// (with implicit-1) is the top 24 bits of that quotient.
+// Case B (Ma < Mb, ratio in [0.5, 1)):  quotient is a 24-bit value
+// in [2^23, 2^24).  The result mantissa is those 24 bits directly,
+// and the result exponent is decremented by 1 (to compensate for
+// the [0.5, 1) → [1, 2) normalization).
+//
+// Which case applies is determined by a pre-loop 24-bit compare of
+// Ma and Mb; the flag is stored in Q_HI (1 for case A, 0 for case B).
+//
+// The divide loop is a standard 6502 shift-subtract long division.
+// Init: R = Ma; Q = 0.  For case A, we also pre-subtract D once from
+// R (matching the "would-be first quotient bit = 1" of the 25-bit
+// quotient) to establish the loop invariant "R < D".  Case B needs no
+// pre-subtract because Ma < Mb already satisfies it.
+//
+// Then 24 iterations of:
+//
+// 1. Shift [R:Q] left by 1.  The bit that falls off R2's MSB
+// (captured in the C flag as C_out) reflects whether pre-shift R
+// had bit 23 set -- i.e. whether the "true" 25-bit post-shift R
+// was >= 2^24 > D.
+// 2. If C_out = 1:  force subtract D from the 24-bit R.  The 24-bit
+// SBC's borrow "consumes" the 2^24 bit that shifted out, so the
+// stored 24-bit R correctly reflects the 25-bit R minus D.
+// 3. Else:  compare R with D (high byte first, early-out) and
+// subtract in place only if R >= D.
+// 4. If we subtracted (in either branch), set Q bit 0 = 1.
+//
+// A post-loop cleanup handles the exact-division boundary: if R >= D
+// after 24 iterations, subtract D once more and increment Q.  (Without
+// this, exact-divisible cases like Ma == Mb would end with R = D and
+// Q one short.)
+//
+// After the loop, Q holds the 24-bit low bits of the true quotient
+// (which is 24-bit in case B or the low 24 bits of a 25-bit value in
+// case A):
+//
+// Case A: mantissa = 0x800000 | (Q >> 1); round bit = Q bit 0.
+// Case B: mantissa = Q; round bit computed from a "virtual 25th
+// iteration" (shift R left, compare/sub with D, round bit = 1 iff
+// the virtual subtract commits).
+//
+// Sticky = (R != 0) after all shifts and the virtual iteration.
+//
+// Underflow (R_EXP <= 0) triggers a shift-right of the mantissa with
+// careful round/sticky tracking:  the old round bit becomes part of
+// the new sticky before each shift, and the bit that falls off each
+// shift becomes the new round bit.  After (1 - R_EXP) shifts, the
+// mantissa is in subnormal-encoding form and R_EXP is set to 0.
+//
+// ============================================================================
+// REFERENCE: result exponent
+// ============================================================================
+//
+// R_EXP = a_exp + (127 - b_exp)
+// = (a_exp - b_exp) + 127
+//
+// For normal inputs (a_exp, b_exp in [1, 254]) this is in
+// [1-254+127, 254-1+127] = [-126, 380].  Fits in signed 16-bit.
+// Subnormals renormalize like in mulsf3 -- shift the significand left
+// until bit 23 is set, adjust the effective exponent one per shift.
+//
+// After the divide loop's mantissa case-B branch (ratio < 1), R_EXP
+// gets one more decrement.
+//
+// ============================================================================
+// REFERENCE: special cases
+// ============================================================================
+//
+// NaN / anything = quiet(a)
+// anything / NaN = quiet(b)
+// Inf / Inf      = qNaN
+// Inf / finite   = signed Inf
+// finite / Inf   = signed 0
+// x / 0 (x != 0) = signed Inf     (IEEE 754 "divide by zero" -- we
+// don't raise a flag, we just return)
+// 0 / x (x != 0) = signed 0
+// 0 / 0          = qNaN
+//
+// Sign of Inf and 0 in x/0 and 0/x follows the XOR of the operand signs.
+//
+// ============================================================================
+// REFERENCE: zero-page layout
+// ============================================================================
+//
+// Same input constraints as addsf3/mulsf3 (a in A/X/__rc2/__rc3;
+// b in __rc4..__rc7).  Unpack transforms in place where possible.
+//
+// __rc2   A_M2      a mantissa top (implicit 1 in bit 7 for normals)
+// __rc3   A_EXP     a's biased exponent
+// __rc4   D0        b mantissa byte 0 (unchanged from input)
+// __rc5   D1        b mantissa byte 1 (unchanged from input)
+// __rc6   D2        b mantissa top (implicit 1 restored)
+// __rc7   B_EXP     b's biased exponent
+// __rc8   A_M0      a mantissa byte 0 (from register A)
+// __rc9   A_M1      a mantissa byte 1 (from register X)
+// __rc10  A_SIGN -> Q_HI     a's sign in bit 7; after dispatch reused
+// as bit 24 of the quotient
+// __rc11  B_SIGN -> TMP0     b's sign; after the divide loop reused as
+// the sticky flag
+// __rc12  R_SIGN            result sign in bit 7
+// __rc13  R_EXP_LO          signed 16-bit result exponent, low byte
+// __rc14  R_EXP_HI          ... high byte
+// __rc15  R0                remainder byte 0
+// __rc16  R1
+// __rc17  R2
+// __rc18  CNT               shift counter for the subnormal-result
+//                           shift (the divide loop counts down in Y)
+// __rc19  TMP1              round bit / pack scratch
+//
+// A_M0/A_M1/A_M2 double as Q0/Q1/Q2 during the divide loop (numerator
+// is consumed as quotient bits shift up from below).
+//
+// ===----------------------------------------------------------------------===//
+
+
+#include "imag-regs-zp.inc"
+
+#define A_M2  __rc2
+#define A_EXP  __rc3
+#define D0  __rc4
+#define D1  __rc5
+#define D2  __rc6
+#define B_EXP  __rc7
+#define A_M0  __rc8
+#define A_M1  __rc9
+#define A_SIGN  __rc10
+#define Q_HI  __rc10
+#define B_SIGN  __rc11
+#define TMP0  __rc11
+#define R_SIGN  __rc12
+#define R_EXP_LO  __rc13
+#define R_EXP_HI  __rc14
+#define R0  __rc15
+#define R1  __rc16
+#define R2  __rc17
+#define CNT  __rc18
+#define TMP1  __rc19
+
+
+.text
+.globl __divsf3
+.type __divsf3, @function
+__divsf3:
+        // ================================================================
+        // Phase 1 -- UNPACK A (identical to mulsf3's unpack A).
+        // ================================================================
+        sta A_M0
+        stx A_M1
+
+        lda __rc3
+        and #$80
+        sta A_SIGN
+
+        lda __rc2
+        asl a
+        lda __rc3
+        rol a
+        sta A_EXP
+
+        lda __rc2
+        and #$7f
+        ldx A_EXP
+        beq 1f
+        ora #$80
+        1: sta A_M2
+
+        // ================================================================
+        // Phase 2 -- UNPACK B.
+        // ================================================================
+        lda __rc7
+        and #$80
+        sta B_SIGN
+
+        lda __rc6
+        asl a
+        lda __rc7
+        rol a
+        sta B_EXP
+
+        lda __rc6
+        and #$7f
+        ldx B_EXP
+        beq 2f
+        ora #$80
+        2: sta D2
+
+        // ================================================================
+        // Phase 3 -- RESULT SIGN (XOR of input signs, in bit 7).
+        // ================================================================
+        lda A_SIGN
+        eor B_SIGN
+        sta R_SIGN
+
+        // ================================================================
+        // Phase 4 -- INF/NAN dispatch.
+
+        // NaN / anything -> quiet(a) with a's sign
+        // anything / NaN -> quiet(b) with b's sign
+        // Inf / Inf      -> qNaN
+        // Inf / finite   -> signed Inf
+        // finite / Inf   -> signed 0
+        // ================================================================
+        lda A_EXP
+        cmp #$ff
+        bne .L__divsf3_chk_b_special
+
+        // a's exp is 0xFF.  NaN or Inf?
+        lda A_M2
+        and #$7f
+        ora A_M1
+        ora A_M0
+        beq .L__divsf3_a_is_inf
+
+        // a is NaN -> quiet a, use a's sign.
+        lda A_M2
+        ora #$40
+        sta A_M2
+        lda A_SIGN
+        sta R_SIGN
+        jmp .L__divsf3_pack_a
+
+        .L__divsf3_a_is_inf:
+        // a is Inf.  Check b.
+        lda B_EXP
+        cmp #$ff
+        beq .L__divsf3_a_inf_b_infnan
+        // b is finite -> return signed Inf.
+        jmp .L__divsf3_return_signed_inf
+
+        .L__divsf3_a_inf_b_infnan:
+        // b's exp is 0xFF.  NaN or Inf?
+        lda D2
+        and #$7f
+        ora D1
+        ora D0
+        beq .L__divsf3_return_qnan   // Inf / Inf = qNaN
+        // b is NaN -> return quiet(b).
+        jmp .L__divsf3_return_quiet_b
+
+        .L__divsf3_chk_b_special:
+        // a is not special.  Is b special?
+        lda B_EXP
+        cmp #$ff
+        bne .L__divsf3_chk_zero
+
+        // b is Inf or NaN.
+        lda D2
+        and #$7f
+        ora D1
+        ora D0
+        beq .L__divsf3_b_is_inf
+        // b is NaN -> return quiet(b).
+        .L__divsf3_return_quiet_b:
+        lda D2
+        ora #$40
+        sta A_M2
+        lda D1
+        sta A_M1
+        lda D0
+        sta A_M0
+        lda B_EXP
+        sta A_EXP
+        lda B_SIGN
+        sta R_SIGN
+        jmp .L__divsf3_pack_a
+
+        .L__divsf3_b_is_inf:
+        // b is Inf, a is finite.  Return signed 0.
+        jmp .L__divsf3_return_zero
+
+        .L__divsf3_return_signed_inf:
+        lda #0
+        sta A_M0
+        sta A_M1
+        lda #$80
+        sta A_M2
+        lda #$ff
+        sta A_EXP
+        jmp .L__divsf3_pack_a
+
+        .L__divsf3_return_qnan:
+        // Canonical qNaN 0x7fc00000.
+        lda #$c0
+        sta __rc2
+        lda #$7f
+        sta __rc3
+        ldx #0
+        lda #0
+        rts
+
+        // ================================================================
+        // Phase 5 -- ZERO dispatch.
+
+        // 0 / 0            -> qNaN
+        // 0 / nonzero      -> signed 0
+        // nonzero / 0      -> signed Inf
+        // nonzero / nonzero -> normal path
+        // ================================================================
+        .L__divsf3_chk_zero:
+        // Test a for zero: exp | m0 | m1 | m2 == 0.
+        lda A_EXP
+        ora A_M0
+        ora A_M1
+        ora A_M2
+        sta TMP0   // TMP0 = 0 iff a is zero
+        lda B_EXP
+        ora D0
+        ora D1
+        ora D2
+        sta TMP1   // TMP1 = 0 iff b is zero
+        // Dispatch:
+        lda TMP0
+        bne .L__divsf3_a_nonzero
+        // a is zero.
+        lda TMP1
+        beq .L__divsf3_return_qnan   // 0 / 0
+        jmp .L__divsf3_return_zero   // 0 / nonzero
+
+        .L__divsf3_a_nonzero:
+        lda TMP1
+        beq .L__divsf3_return_signed_inf   // nonzero / 0
+        // Both nonzero, proceed to renormalize.
+
+        // ================================================================
+        // Phase 6 -- COMPUTE R_EXP AND RENORMALIZE SUBNORMALS.
+
+        // R_EXP = a_exp - b_exp + 127  (16-bit signed).  For subnormals,
+        // fold the "effective exp is 1-k where k is shift count" via
+        // pre-decrement + one dec per shift, just like mulsf3.
+        // ================================================================
+
+        // R_EXP = a_exp + 127 (as unsigned 8-bit + high 0).
+        clc
+        lda A_EXP
+        adc #127
+        sta R_EXP_LO
+        lda #0
+        adc #0
+        sta R_EXP_HI
+
+        // R_EXP -= b_exp.
+        sec
+        lda R_EXP_LO
+        sbc B_EXP
+        sta R_EXP_LO
+        lda R_EXP_HI
+        sbc #0
+        sta R_EXP_HI
+
+        // If a subnormal (a_exp == 0): R_EXP += 1, then shift A_M left
+        // until A_M2 bit 7 set, decrementing R_EXP per shift.
+        lda A_EXP
+        bne .L__divsf3_renorm_b
+        inc R_EXP_LO
+        bne 3f
+        inc R_EXP_HI
+        3:
+        .L__divsf3_renorm_a_loop:
+        bit A_M2
+        bmi .L__divsf3_renorm_b
+        asl A_M0
+        rol A_M1
+        rol A_M2
+        lda R_EXP_LO
+        bne 4f
+        dec R_EXP_HI
+        4: dec R_EXP_LO
+        jmp .L__divsf3_renorm_a_loop
+
+        .L__divsf3_renorm_b:
+        // If b subnormal: R_EXP -= 1 (subtract 1 from effective b_exp),
+        // then shift D left, INCREMENTING R_EXP per shift (because
+        // R_EXP has b_exp SUBTRACTED, and shifting b's mantissa left
+        // means b's effective exponent decreases, so R_EXP increases).
+        lda B_EXP
+        bne .L__divsf3_div_init
+        // Subnormal b's effective exp is (1 - k), so R_EXP was computed
+        // with too much subtracted (b_exp = 0 was used, should be
+        // 1 - k).  Adjust: R_EXP -= 1 initially (so we're at
+        // R_EXP - (-1 + k) = R_EXP + 1 - k conceptually), then INC per
+        // shift.  Actually: subtracting b_exp=0 vs b_eff=1-k means
+        // R_EXP is too HIGH by (1-k) - 0 = 1 - k.  Correct by decrementing
+        // by (1-k) = 1 - k, i.e. R_EXP -= 1 then INC per shift.
+        lda R_EXP_LO
+        bne 5f
+        dec R_EXP_HI
+        5: dec R_EXP_LO
+        .L__divsf3_renorm_b_loop:
+        bit D2
+        bmi .L__divsf3_div_init
+        asl D0
+        rol D1
+        rol D2
+        inc R_EXP_LO
+        bne 6f
+        inc R_EXP_HI
+        6:
+        jmp .L__divsf3_renorm_b_loop
+
+        // ================================================================
+        // Phase 7a -- DIVIDE LOOP INIT.
+
+        // Init R = M_A (numerator in the "high half" of a 48-bit
+        // dividend [R:Q] = M_A * 2^24), Q = 0.
+
+        // 24 iterations of shift-subtract-with-force will produce the
+        // 24-bit quotient in Q (low 24 bits of the true 24- or 25-bit
+        // quotient).  The "would-be bit 24" (implicit-1 for the case
+        // when M_A/M_B >= 1) is not captured in Q; it's detected via a
+        // pre-loop compare stored in Q_HI.
+        // ================================================================
+        .L__divsf3_div_init:
+        // Pre-loop compare M_A vs D (24-bit unsigned).  Store 1 in Q_HI
+        // if M_A >= M_B (case A), 0 otherwise (case B).
+        lda A_M2
+        cmp D2
+        bcc .L__divsf3_case_b_init
+        bne .L__divsf3_case_a_init
+        lda A_M1
+        cmp D1
+        bcc .L__divsf3_case_b_init
+        bne .L__divsf3_case_a_init
+        lda A_M0
+        cmp D0
+        bcc .L__divsf3_case_b_init
+
+        .L__divsf3_case_a_init:
+        lda #1
+        sta Q_HI
+        jmp .L__divsf3_div_setup
+
+        .L__divsf3_case_b_init:
+        lda #0
+        sta Q_HI
+
+        .L__divsf3_div_setup:
+        // Move M_A into R (as the "high half" of the 48-bit dividend).
+        // Zero out Q slots.
+        lda A_M0
+        sta R0
+        lda A_M1
+        sta R1
+        lda A_M2
+        sta R2
+        lda #0
+        sta A_M0   // Q0 = 0
+        sta A_M1   // Q1 = 0
+        sta A_M2   // Q2 = 0
+
+        // For case A (M_A >= M_B), pre-subtract D from R to establish
+        // the loop invariant "R < D".  The invariant is required for
+        // the shift-subtract algorithm to produce binary quotient bits.
+        // (The pre-subtract accounts for the "would-be bit 24 = 1" of
+        // the true 25-bit quotient; we already recorded that in Q_HI.)
+        lda Q_HI
+        beq .L__divsf3_no_presub
+        sec
+        lda R0
+        sbc D0
+        sta R0
+        lda R1
+        sbc D1
+        sta R1
+        lda R2
+        sbc D2
+        sta R2
+        .L__divsf3_no_presub:
+
+        ldy #24
+
+        // ================================================================
+        // Phase 7b -- DIVIDE LOOP: 24 iterations of shift-subtract.
+
+        // Layout: [R2:R1:R0:Q2:Q1:Q0] as a 48-bit shift register.
+        // Each iteration:
+        // 1. Shift left [R:Q] by 1.  Bit 23 of Q shifts into R bit 0.
+        // The bit shifted out of R2's MSB (call it R_hi) reflects
+        // whether the pre-shift R had bit 23 set -- i.e. whether
+        // "true" post-shift R was >= 2^24 > D.
+        // 2. If R_hi = 1: force subtract D from R (the borrow in the
+        // 24-bit SBC exactly cancels the 2^24 bit we shifted out).
+        // 3. Else: compare R with D and subtract in place only if R >= D.
+        // 4. If we subtracted, set Q bit 0 = 1.
+        // ================================================================
+        .L__divsf3_div_loop:
+        asl A_M0   // ASL Q0
+        rol A_M1   // ROL Q1
+        rol A_M2   // ROL Q2
+        rol R0
+        rol R1
+        rol R2   // C_out = pre-shift R2 bit 7
+        bcs .L__divsf3_div_do_sub
+
+        // C_out = 0: decide with a 24-bit compare (high byte first, with
+        // early-out), then subtract in place only if it commits.  This is
+        // cheaper than subtracting into scratch and copying back: the
+        // no-subtract half of the iterations costs three instructions
+        // instead of a full 24-bit SBC chain plus two copies.
+        lda R2
+        cmp D2
+        bcc .L__divsf3_div_no_sub
+        bne .L__divsf3_div_do_sub
+        lda R1
+        cmp D1
+        bcc .L__divsf3_div_no_sub
+        bne .L__divsf3_div_do_sub
+        lda R0
+        cmp D0
+        bcc .L__divsf3_div_no_sub
+
+        .L__divsf3_div_do_sub:
+        // Either C_out = 1 (true post-shift R was in [2^24, 2^25) > D, so
+        // the subtract is forced -- the borrow out of the 24-bit SBC chain
+        // exactly consumes the 2^24 bit that shifted out), or the compare
+        // above proved R >= D.  Both cases subtract D from R in place and
+        // set the quotient bit.
+        sec
+        lda R0
+        sbc D0
+        sta R0
+        lda R1
+        sbc D1
+        sta R1
+        lda R2
+        sbc D2
+        sta R2
+        inc A_M0   // Q bit 0 = 1
+
+        .L__divsf3_div_no_sub:
+        dey
+        bne .L__divsf3_div_loop
+
+        // ================================================================
+        // Phase 7c -- POST-LOOP CLEANUP.
+
+        // The algorithm maintains the invariant Q * D + R = dividend,
+        // but at the boundary case where the dividend is an exact
+        // multiple of D, R can end at R = D (rather than R = 0 with
+        // Q += 1).  Detect and correct: if R >= D, subtract D from R
+        // and increment Q.
+        // ================================================================
+        // Compare R with D (24-bit high byte first).
+        lda R2
+        cmp D2
+        bcc .L__divsf3_div_end
+        bne .L__divsf3_div_cleanup
+        lda R1
+        cmp D1
+        bcc .L__divsf3_div_end
+        bne .L__divsf3_div_cleanup
+        lda R0
+        cmp D0
+        bcc .L__divsf3_div_end
+
+        .L__divsf3_div_cleanup:
+        sec
+        lda R0
+        sbc D0
+        sta R0
+        lda R1
+        sbc D1
+        sta R1
+        lda R2
+        sbc D2
+        sta R2
+        // Q += 1 (ripple through Q0/Q1/Q2).
+        inc A_M0
+        bne .L__divsf3_div_end
+        inc A_M1
+        bne .L__divsf3_div_end
+        inc A_M2
+
+        .L__divsf3_div_end:
+
+        // ================================================================
+        // Phase 8 -- POST-LOOP MANTISSA EXTRACTION.
+
+        // Q_HI bit 0 = 1 (Ma >= Mb, ratio in [1, 2)):
+        // mantissa = 0x800000 | (Q >> 1)
+        // round bit = Q bit 0
+        // R_EXP unchanged
+
+        // Q_HI bit 0 = 0 (Ma < Mb, ratio in [0.5, 1)):
+        // mantissa = Q (bit 23 should already be set)
+        // round bit = 0 (approximated -- see algorithm outline)
+        // R_EXP -= 1
+
+        // Sticky = (R != 0).
+
+        // Store round bit in TMP1, sticky in TMP0 for the round phase.
+        // ================================================================
+        lda Q_HI
+        and #1
+        beq .L__divsf3_case_b
+
+        // Case A: Q_HI bit 0 = 1.  Shift Q right by 1, capture bit 0 as
+        // round bit, OR bit 23 into position (from Q_HI).
+        // Round bit = Q0 bit 0 pre-shift.
+        lda A_M0
+        and #1
+        sta TMP1   // TMP1 = round bit
+        lsr A_M2
+        ror A_M1
+        ror A_M0
+        lda A_M2
+        ora #$80   // set implicit-1 at bit 23
+        sta A_M2
+        jmp .L__divsf3_compute_sticky
+
+        .L__divsf3_case_b:
+        // Case B: Q_HI bit 0 = 0.  Q is mantissa as-is.  Round bit
+        // requires a "virtual 25th iteration": shift R left, then
+        // compare with D.  If (2*R) >= D (or shift produced C_out=1),
+        // round bit = 1 and new R = 2*R - D; else round = 0 and new
+        // R = 2*R.  The updated R provides sticky info.  R_EXP -= 1.
+        asl R0
+        rol R1
+        rol R2
+        bcs .L__divsf3_round_b_do_sub   // C_out=1: true R > D, always sub
+        // Compare 24-bit R with D.
+        lda R2
+        cmp D2
+        bcc .L__divsf3_round_b_zero
+        bne .L__divsf3_round_b_do_sub
+        lda R1
+        cmp D1
+        bcc .L__divsf3_round_b_zero
+        bne .L__divsf3_round_b_do_sub
+        lda R0
+        cmp D0
+        bcc .L__divsf3_round_b_zero
+
+        .L__divsf3_round_b_do_sub:
+        sec
+        lda R0
+        sbc D0
+        sta R0
+        lda R1
+        sbc D1
+        sta R1
+        lda R2
+        sbc D2
+        sta R2
+        lda #1
+        sta TMP1   // round bit = 1
+        jmp .L__divsf3_case_b_exp_dec
+
+        .L__divsf3_round_b_zero:
+        lda #0
+        sta TMP1   // round bit = 0
+
+        .L__divsf3_case_b_exp_dec:
+        // R_EXP -= 1.
+        lda R_EXP_LO
+        bne 7f
+        dec R_EXP_HI
+        7: dec R_EXP_LO
+
+        .L__divsf3_compute_sticky:
+        // Sticky = R != 0.
+        lda R0
+        ora R1
+        ora R2
+        beq 8f
+        lda #1
+        8: sta TMP0   // TMP0 = sticky (0 or 1)
+
+        // ================================================================
+        // Phase 9 -- OVERFLOW / UNDERFLOW dispatch (same as mulsf3).
+
+        // R_EXP < 0            -> underflow (subnormal or zero)
+        // R_EXP == 0           -> subnormal
+        // R_EXP in [1, 0xFE]   -> normal, round
+        // R_EXP >= 0xFF        -> overflow (signed Inf)
+        // ================================================================
+        lda R_EXP_HI
+        bmi .L__divsf3_und
+        bne .L__divsf3_ovf
+        lda R_EXP_LO
+        beq .L__divsf3_und
+        cmp #$ff
+        bcc .L__divsf3_round
+        // fall through: overflow
+
+        .L__divsf3_ovf:
+        lda #$ff
+        sta A_EXP
+        lda #0
+        sta A_M0
+        sta A_M1
+        lda #$80
+        sta A_M2
+        jmp .L__divsf3_pack_a
+
+        .L__divsf3_und:
+        // Subnormal result: shift mantissa right by (1 - R_EXP).
+
+        // Rounding through the shift is tricky.  Correct semantics:
+        // per iteration, the OLD round bit becomes part of new sticky
+        // (moves down one position), the shifted-out mantissa bit
+        // becomes the new round bit.  After K shifts, round = pre-shift
+        // mantissa bit (K-1); sticky = OR of pre-shift mantissa bits
+        // (K-2..0) | pre-shift round | pre-shift sticky.
+        sec
+        lda #1
+        sbc R_EXP_LO
+        cmp #32
+        bcc 9f
+        jmp .L__divsf3_return_zero
+        9: sta CNT
+
+        .L__divsf3_und_loop:
+        lda CNT
+        beq .L__divsf3_und_done
+        // OLD round bit contributes to sticky.
+        lda TMP1
+        beq 10f
+        lda #1
+        sta TMP0
+        10:
+        // Shift mantissa right by 1.
+        lsr A_M2
+        ror A_M1
+        ror A_M0
+        // C from ROR A_M0 = bit that just fell off = new round bit.
+        lda #0
+        rol a   // A = 1 if C=1 else 0
+        sta TMP1
+        dec CNT
+        jmp .L__divsf3_und_loop
+        .L__divsf3_und_done:
+        lda #0
+        sta R_EXP_LO
+        sta R_EXP_HI
+
+        .L__divsf3_round:
+        // ================================================================
+        // Phase 10 -- ROUND: nearest, ties to even.
+
+        // round bit  = TMP1
+        // sticky     = TMP0
+        // LSB        = A_M0 bit 0
+
+        // Round up iff round && (sticky || LSB).
+        // ================================================================
+        lda TMP1
+        beq .L__divsf3_no_round   // round bit clear -> no round
+        // round bit set: round up iff (sticky || LSB).
+        lda TMP0
+        bne .L__divsf3_do_round   // sticky set -> round up
+        lda A_M0
+        and #1
+        beq .L__divsf3_no_round   // LSB even, sticky 0 -> tie to even
+        .L__divsf3_do_round:
+        inc A_M0
+        bne 11f
+        inc A_M1
+        bne 11f
+        inc A_M2
+        bne 11f
+        // Full carry-out: mantissa wrapped 0xFFFFFF -> 0.  Set bit 7
+        // (implicit) and bump exp.
+        lda #$80
+        sta A_M2
+        inc R_EXP_LO
+        bne 11f
+        inc R_EXP_HI
+        11:
+        // Re-check overflow.
+        lda R_EXP_HI
+        bne .L__divsf3_ovf
+        lda R_EXP_LO
+        cmp #$ff
+        bcc .L__divsf3_no_round
+        jmp .L__divsf3_ovf
+
+        .L__divsf3_no_round:
+        // Subnormal-grew-into-normal fix (only relevant if we came
+        // via the underflow path): if R_EXP == 0 but mantissa bit 23
+        // set, bump R_EXP to 1.
+        lda R_EXP_LO
+        ora R_EXP_HI
+        bne .L__divsf3_setup_pack
+        bit A_M2
+        bpl .L__divsf3_setup_pack
+        lda #1
+        sta R_EXP_LO
+
+        .L__divsf3_setup_pack:
+        lda R_EXP_LO
+        sta A_EXP
+        // fall through to .L__divsf3_pack_a
+
+        // ================================================================
+        // Phase 11 -- PACK a into ABI return position.
+
+        // Same layout as addsf3/mulsf3 pack.
+        // ================================================================
+        .L__divsf3_pack_a:
+        lda A_EXP
+        lsr a
+        sta TMP1
+        lda A_M2
+        and #$7f
+        bcc 12f
+        ora #$80
+        12: sta __rc2
+        lda TMP1
+        ora R_SIGN
+        sta __rc3
+        lda A_M0
+        ldx A_M1
+        rts
+
+        // ================================================================
+        // Return signed zero.  R_SIGN was computed in Phase 3; the low
+        // three bytes are 0 and byte 3 is R_SIGN.
+        // ================================================================
+        .L__divsf3_return_zero:
+        lda #0
+        sta __rc2
+        lda R_SIGN
+        sta __rc3
+        ldx #0
+        lda #0
+        rts

--- a/compiler-rt/lib/builtins/mos/imag-regs-zp.inc
+++ b/compiler-rt/lib/builtins/mos/imag-regs-zp.inc
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Common .zeropage declarations for llvm-mos imaginary registers __rcN.
+//
+// __rcN are defined by imag-regs.ld at final-link time and live in zero
+// page.  The mos assembler does not know that until link time, so by
+// default it emits the 3-byte absolute form of lda/sta/... on any symbol
+// whose address is not yet known.  We give it the hint here so it uses
+// the 2-byte zero-page encoding instead.  Missing this bloats functions
+// by ~30% and can push conditional branches out of the +/-127 range
+// where the assembler silently truncates them.
+//
+// See https://llvm-mos.org/wiki/Assembler_relaxation.
+//
+// This file is included from every mos/*.S that references __rcN so the
+// hint list stays in one place.  Declaring an unused __rcN is harmless
+// -- the directive only affects addressing-mode selection when the
+// symbol is actually referenced by an instruction.
+
+.zeropage __rc2
+.zeropage __rc3
+.zeropage __rc4
+.zeropage __rc5
+.zeropage __rc6
+.zeropage __rc7
+.zeropage __rc8
+.zeropage __rc9
+.zeropage __rc10
+.zeropage __rc11
+.zeropage __rc12
+.zeropage __rc13
+.zeropage __rc14
+.zeropage __rc15
+.zeropage __rc16
+.zeropage __rc17
+.zeropage __rc18
+.zeropage __rc19

--- a/compiler-rt/lib/builtins/mos/mulsf3.S
+++ b/compiler-rt/lib/builtins/mos/mulsf3.S
@@ -1,0 +1,874 @@
+//===-- lib/mos/mulsf3.S - Single-precision multiplication (MOS 6502) -*- Asm -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+//
+// __mulsf3(a, b) -- IEEE 754 binary32 multiplication for MOS (6502).
+//
+// Rounding: round-to-nearest-ties-to-even, hardcoded.  No fenv support
+// (see addsf3.c for the rationale).
+//
+// This file follows the same structural pattern as addsf3.c: one naked
+// top-level function containing one big asm volatile block, all state
+// in caller-saved zero-page slots, .L-prefixed local labels, invert-and-
+// jump for out-of-range branches.  See addsf3.c for the reference
+// material on IEEE 754 layout, the MOS ABI, and assembler gotchas that
+// applies verbatim here.
+//
+// ============================================================================
+// REFERENCE: multiplication algorithm outline
+// ============================================================================
+//
+// value(x)  = (-1)^s * 1.m * 2^(e-127)     for normal x
+// = (-1)^s * 0.m * 2^-126        for subnormal x
+//
+// The product's sign is the XOR of input signs.  For the magnitude, we
+// need a 24-bit x 24-bit unsigned integer multiply of the "significand
+// with implicit 1 restored" -- a value in [2^23, 2^24) for normals.  The
+// full 48-bit product lands in [2^46, 2^48); its top bit distinguishes
+// the two cases:
+//
+// product bit 47 set:  product in [2^47, 2^48)  ->  quotient in [2,4)
+// (exp adjustment +1, no bit shift)
+// product bit 47 clear (bit 46 set): product in [2^46, 2^47) -> [1,2)
+// (no exp change, shift product left by 1)
+//
+// After that shift, bit 47 of the 48-bit product always holds the new
+// implicit-1 bit, so we can pull mantissa/round/guard/sticky out of
+// fixed positions regardless of which case applied.
+//
+// The result exponent is computed in signed 16-bit as
+//
+// result_exp = eff_a + eff_b - 127
+//
+// where eff_a is a's biased exponent (or, for subnormals renormalized
+// by shifting their significand left by k bits, 1 - k -- which can go
+// as low as -22).  Range is roughly [-171, 381].  The +1 from the bit-47
+// case is applied after the multiply.
+//
+// Subnormal renormalization: while significand bit 23 (M2 bit 7) is 0,
+// shift the 24-bit significand left by 1 and decrement the effective
+// exponent (which starts at 0 for a raw subnormal).  A raw subnormal has
+// at least one bit set (the exp==0 && mantissa==0 case is a true zero
+// handled by the zero-dispatch above), so the loop terminates.
+//
+// ============================================================================
+// REFERENCE: the shift-and-add multiply core
+// ============================================================================
+//
+// Classic 6502 right-shift multiply, extended to 24 x 24 -> 48.  Layout
+// during the loop:
+//
+// [PH2 : PH1 : PH0 : B_M2 : B_M1 : B_M0]        (48-bit shift register)
+// ^^^^^^^^^^^^^^^^^                              product high half
+// ^^^^^^^^^^^^^^^^^^^         multiplier B; becomes
+// product low half as
+// B's bits are consumed
+//
+// A_M2 : A_M1 : A_M0                             multiplicand A (fixed)
+//
+// Setup: PH2:PH1:PH0 = 0; multiplier already in B_M2:B_M1:B_M0.
+//
+// Pre-shift: LSR B_M2 / ROR B_M1 / ROR B_M0.  This puts B's LSB into C
+// for the first iteration's decide, and shifts the multiplier once so
+// that after 24 iterations the accumulator has traveled the full width.
+//
+// Loop body (repeated 24 times):
+//
+// BCC skip           ; if the bit we just extracted was 0, no add
+// CLC
+// LDA PH0; ADC A_M0; STA PH0
+// LDA PH1; ADC A_M1; STA PH1
+// LDA PH2; ADC A_M2; STA PH2
+// ; C now = carry-out of the 24-bit add (i.e., accumulator bit 24)
+// skip:
+// ROR PH2            ; incorporate C into bit 7 of PH2, shift right
+// ROR PH1            ; ripple; each ROR moves its LSB into C for
+// ROR PH0            ; the next ROR up the chain
+// ROR B_M2
+// ROR B_M1
+// ROR B_M0           ; final C = B_M0's old bit 0 = next multiplier bit
+// DEY
+// BNE loop
+//
+// When BCC skips the add, C is still 0 (that's what we branched on), so
+// the ROR chain shifts a 0 into PH2's MSB -- which is correct: no add
+// means no carry into bit 24 of the accumulator.
+//
+// ============================================================================
+// REFERENCE: rounding, packing, and edge cases
+// ============================================================================
+//
+// After the multiply and the bit-47 normalize step, the layout is:
+//
+// PH2 bit 7 = implicit 1 (mantissa MSB)
+// PH2..PH0  = 24-bit mantissa (including implicit)
+// B_M2 bit 7 = round bit (R)
+// B_M2 bit 6 = guard bit (G)
+// OR(B_M2 & 0x3F, B_M1, B_M0) = sticky (S)
+//
+// Round up iff R && (G || S || mantissa_LSB).  A rounding overflow
+// (mantissa was 0xFFFFFF and got incremented) is detected by
+// mantissa == 0 after the increment; we restore bit 7 and bump exp.
+//
+// If result_exp <= 0, the result is subnormal (or zero): shift the
+// mantissa right by (1 - result_exp) with sticky, then round, then set
+// exp = 0.  If the shift count would leave nothing (>= 25), return
+// signed zero.
+//
+// If result_exp >= 0xFF (after any exp++ from bit-47 normalize or from
+// round-up wrap), return signed infinity.
+//
+// ============================================================================
+// REFERENCE: zero-page layout
+// ============================================================================
+//
+// Slot assignment is constrained by the ABI: on entry a's bytes 2/3 sit
+// in __rc2/__rc3 and b's four bytes sit in __rc4..__rc7.  Byte 0/1 of a
+// arrive in A/X (registers, not zero page).  We picked the layout so
+// unpack can reuse the input slots in-place without needing extra
+// scratch: A's byte2/byte3 sit at __rc2/__rc3 so A_M2 and A_EXP land
+// there naturally after transformation; B's byte 0/1 need no move at
+// all (they're already at B_M0/B_M1 = __rc4/__rc5), and B_M2/B_EXP
+// overwrite b's byte2/byte3 in place at __rc6/__rc7.  A_M0/A_M1 come
+// from registers A/X so they get fresh slots (__rc8/__rc9).
+//
+// __rc2  A_M2    a mantissa top byte (implicit 1 in bit 7 for normals)
+// __rc3  A_EXP   a's biased exponent
+// __rc4  B_M0    b mantissa byte 0 (untouched from input)
+// __rc5  B_M1    b mantissa byte 1 (untouched from input)
+// __rc6  B_M2    b mantissa top byte (implicit 1 in bit 7 for normals)
+// __rc7  B_EXP   b's biased exponent
+// __rc8  A_M0    a mantissa byte 0 (from register A)
+// __rc9  A_M1    a mantissa byte 1 (from register X)
+// __rc10 A_SIGN  a's sign in bit 7 (0x00 or 0x80)
+// __rc11 B_SIGN  b's sign in bit 7
+// __rc12 R_SIGN  result sign in bit 7
+// __rc13 R_EXP_LO signed 16-bit result exponent, low byte
+// __rc14 R_EXP_HI  ... high byte
+// __rc15 PH0     product high accumulator, byte 0
+// __rc16 PH1
+// __rc17 PH2     product high, MSB (bit 47 lands here after multiply)
+// __rc18 CNT     shift counter for the subnormal-result shift
+//                (the multiply loop counts down in Y)
+// __rc19 TMP     scratch (used by subnormal-result shift and pack)
+//
+// After unpack, __rc2 (A_M2) and __rc3 (A_EXP) hold a's transformed
+// bytes.  The pack phase at the end overwrites those two slots directly
+// with the result byte2/byte3, which is fine because A_M2 and A_EXP
+// aren't needed after we've read them into the packer.
+//
+// ===----------------------------------------------------------------------===//
+
+
+#include "imag-regs-zp.inc"
+
+#define A_M2  __rc2
+#define A_EXP  __rc3
+#define B_M0  __rc4
+#define B_M1  __rc5
+#define B_M2  __rc6
+#define B_EXP  __rc7
+#define A_M0  __rc8
+#define A_M1  __rc9
+#define A_SIGN  __rc10
+#define B_SIGN  __rc11
+#define R_SIGN  __rc12
+#define R_EXP_LO  __rc13
+#define R_EXP_HI  __rc14
+#define PH0  __rc15
+#define PH1  __rc16
+#define PH2  __rc17
+#define CNT  __rc18
+#define TMP  __rc19
+
+
+.text
+.globl __mulsf3
+.type __mulsf3, @function
+__mulsf3:
+        // ================================================================
+        // Phase 1 -- UNPACK A.
+
+        // Incoming: A = a_byte0, X = a_byte1, __rc2 = a_byte2, __rc3 =
+        // a_byte3.  We move byte0/byte1 out of the registers into
+        // A_M0/A_M1 first (freeing A and X), then transform __rc2 and
+        // __rc3 in place into A_M2 and A_EXP; the sign gets its own
+        // slot (A_SIGN) since it doesn't share a destination.
+
+        // Restore the implicit leading 1 in A_M2 bit 7 for normals;
+        // leave it clear for subnormals (renormalize later) and zeros
+        // (handled by dispatch).
+        // ================================================================
+        sta A_M0   // A_M0 = byte0 (from A)
+        stx A_M1   // A_M1 = byte1 (from X)
+
+        // Sign from byte3
+        lda __rc3
+        and #$80
+        sta A_SIGN
+
+        // Exp = (byte3 << 1) | (byte2 >> 7).  Order: LDA __rc2 / ASL A
+        // sets C from byte2 bit 7 without touching byte2 in memory;
+        // then LDA __rc3 preserves C; ROL A produces the biased exp.
+        lda __rc2
+        asl a   // C = byte2 bit 7 = E0
+        lda __rc3   // A = byte3, C preserved
+        rol a   // A = biased exp
+        sta A_EXP   // overwrites __rc3 (was byte3)
+
+        // A_M2 = (byte2 & 0x7f) | (exp != 0 ? 0x80 : 0).  __rc2 still
+        // holds byte2 (we only did LDA / ASL A, no store).
+        lda __rc2
+        and #$7f
+        ldx A_EXP
+        beq 1f
+        ora #$80
+        1: sta A_M2   // overwrites __rc2 (was byte2)
+
+        // ================================================================
+        // Phase 2 -- UNPACK B.
+
+        // Same shape as A, but no register moves needed: b_byte0 arrives
+        // already at __rc4 = B_M0, and b_byte1 at __rc5 = B_M1.  We only
+        // need to transform __rc6 (byte2 -> B_M2) and __rc7 (byte3 ->
+        // B_EXP) in place, and extract the sign into B_SIGN.
+        // ================================================================
+        lda __rc7
+        and #$80
+        sta B_SIGN
+
+        lda __rc6
+        asl a
+        lda __rc7
+        rol a
+        sta B_EXP   // overwrites __rc7
+
+        lda __rc6
+        and #$7f
+        ldx B_EXP
+        beq 2f
+        ora #$80
+        2: sta B_M2   // overwrites __rc6
+
+        // ================================================================
+        // Phase 3 -- RESULT SIGN.
+
+        // The product sign is the XOR of the input signs.  Since both
+        // A_SIGN and B_SIGN have bit 7 = sign and bits 6..0 = 0, an EOR
+        // gives the right result directly in bit 7.
+        // ================================================================
+        lda A_SIGN
+        eor B_SIGN
+        sta R_SIGN
+
+        // ================================================================
+        // Phase 4 -- INF/NAN dispatch.
+
+        // If a's exp is 0xFF, a is either NaN (mantissa != 0) or Inf.
+        // If b's exp is 0xFF, similar.  Special-case combinations:
+
+        // NaN * anything  -> quiet NaN (return a with bit 22 set)
+        // anything * NaN  -> quiet NaN (return b with bit 22 set)
+        // Inf * 0         -> qNaN (0x7fc00000)
+        // 0 * Inf         -> qNaN (0x7fc00000)
+        // Inf * finite    -> signed Inf (result_sign)
+        // finite * Inf    -> signed Inf (result_sign)
+
+        // Note that A_M2's implicit-1 bit was set during unpack because
+        // exp is 0xFF (nonzero), so the "is mantissa zero" check has to
+        // mask off bit 7.
+        // ================================================================
+        lda A_EXP
+        cmp #$ff
+        bne .L__mulsf3_chk_b_special
+
+        // a is Inf or NaN.  Distinguish.
+        lda A_M2
+        and #$7f
+        ora A_M1
+        ora A_M0
+        beq .L__mulsf3_a_is_inf
+
+        // a is NaN: quiet it and return a.  Setting bit 22 (M2 bit 6)
+        // makes any signalling NaN quiet.  A_M2 already has the implicit
+        // 1 in bit 7; setting bit 6 gives the "quiet" marker.  Also copy
+        // a's original sign back into R_SIGN so pack uses it.
+        lda A_M2
+        ora #$40
+        sta A_M2
+        lda A_SIGN
+        sta R_SIGN
+        jmp .L__mulsf3_pack_a
+
+        .L__mulsf3_a_is_inf:
+        // a is Inf.  Check b for NaN or 0.  If b is NaN return b.  If b
+        // is 0 return qNaN.  Otherwise return signed Inf.
+        lda B_EXP
+        cmp #$ff
+        beq .L__mulsf3_a_inf_b_infnan
+
+        // b is finite.  If b is 0, this is Inf * 0 -> qNaN.
+        lda B_EXP
+        ora B_M0
+        ora B_M1
+        ora B_M2
+        beq .L__mulsf3_return_qnan
+        // b is finite and nonzero -> return signed Inf.
+        jmp .L__mulsf3_return_signed_inf
+
+        .L__mulsf3_a_inf_b_infnan:
+        // b's exp is 0xFF.  NaN vs Inf?
+        lda B_M2
+        and #$7f
+        ora B_M1
+        ora B_M0
+        beq .L__mulsf3_return_signed_inf   // b is Inf -> Inf*Inf = signed Inf
+        // b is NaN -> return quiet(b).
+        lda B_M2
+        ora #$40
+        sta A_M2
+        lda B_M1
+        sta A_M1
+        lda B_M0
+        sta A_M0
+        lda B_EXP
+        sta A_EXP
+        lda B_SIGN
+        sta R_SIGN
+        jmp .L__mulsf3_pack_a
+
+        .L__mulsf3_chk_b_special:
+        // a is not special.  Is b special?
+        lda B_EXP
+        cmp #$ff
+        bne .L__mulsf3_chk_zero
+
+        // b is Inf or NaN.
+        lda B_M2
+        and #$7f
+        ora B_M1
+        ora B_M0
+        beq .L__mulsf3_b_is_inf
+        // b is NaN -> return quiet(b).
+        lda B_M2
+        ora #$40
+        sta A_M2
+        lda B_M1
+        sta A_M1
+        lda B_M0
+        sta A_M0
+        lda B_EXP
+        sta A_EXP
+        lda B_SIGN
+        sta R_SIGN
+        jmp .L__mulsf3_pack_a
+
+        .L__mulsf3_b_is_inf:
+        // b is Inf, a is finite.  If a is 0, Inf*0 -> qNaN.
+        lda A_EXP
+        ora A_M0
+        ora A_M1
+        ora A_M2   // a_M2 has bit 7 clear iff
+                                             // subnormal or zero; a is not
+                                             // NaN/Inf here so this OR is
+                                             // 0 only for true zero
+        beq .L__mulsf3_return_qnan
+        // fall through to return signed Inf.
+
+        .L__mulsf3_return_signed_inf:
+        lda #0
+        sta A_M0
+        sta A_M1
+        lda #$80
+        sta A_M2   // mantissa 0, exp 0xff
+        lda #$ff
+        sta A_EXP
+        jmp .L__mulsf3_pack_a
+
+        .L__mulsf3_return_qnan:
+        // Canonical qNaN 0x7fc00000: byte3 = 0x7f, byte2 = 0xc0, low = 0.
+        lda #$c0
+        sta __rc2
+        lda #$7f
+        sta __rc3
+        ldx #0
+        lda #0
+        rts
+
+        // ================================================================
+        // Phase 5 -- ZERO dispatch.
+
+        // If either operand is zero, the product is signed zero
+        // (R_SIGN was already computed as a XOR b).
+
+        // Test: (exp | m0 | m1 | m2) == 0.  For zero, all four are 0.
+        // For subnormal, at least one mantissa byte is nonzero (implicit
+        // wasn't set for subnormals during unpack).  For normal, exp
+        // is nonzero.
+        // ================================================================
+        .L__mulsf3_chk_zero:
+        lda A_EXP
+        ora A_M0
+        ora A_M1
+        ora A_M2
+        beq .L__mulsf3_return_zero
+        lda B_EXP
+        ora B_M0
+        ora B_M1
+        ora B_M2
+        bne .L__mulsf3_not_zero
+
+        .L__mulsf3_return_zero:
+        // Return signed zero: byte3 = R_SIGN, byte2 = 0, low = 0.
+        lda #0
+        sta __rc2
+        lda R_SIGN
+        sta __rc3
+        ldx #0
+        lda #0
+        rts
+
+        .L__mulsf3_not_zero:
+
+        // ================================================================
+        // Phase 6 -- RESULT EXPONENT + SUBNORMAL RENORMALIZATION.
+
+        // R_EXP is a signed 16-bit accumulator that ends up as the biased
+        // result exponent (with pre-round adjustments).  We build it in
+        // three steps so we never have to sign-extend an ambiguous byte:
+
+        // (a) R_EXP = A_EXP + B_EXP - 127.  Since A_EXP, B_EXP are
+        // unsigned 0..254 at this point, the sum is 0..508 (fits
+        // in 9 bits) and the subtraction can borrow into the high
+        // byte; result range [-127, 381], all representable.
+
+        // (b) If A was subnormal (raw A_EXP == 0), the sum used 0 for
+        // A but a's "effective biased exp" is (1 - k) where k is
+        // the left-shift count needed to normalize a's significand.
+        // So we add 1 to R_EXP up front, then decrement it once
+        // for each left shift in the renormalize loop.
+
+        // (c) Same for B.
+
+        // A raw subnormal has M2 bit 7 = 0 (unpack skipped the implicit-1
+        // set for exp==0) and at least one mantissa byte nonzero (true
+        // zero was dispatched in phase 5), so the shift loop terminates.
+        // ================================================================
+
+        // R_EXP = A_EXP + B_EXP (unsigned, 9-bit sum captured with carry)
+        clc
+        lda A_EXP
+        adc B_EXP
+        sta R_EXP_LO
+        lda #0
+        adc #0   // A = carry (0 or 1)
+        sta R_EXP_HI
+
+        // R_EXP -= 127
+        sec
+        lda R_EXP_LO
+        sbc #127
+        sta R_EXP_LO
+        lda R_EXP_HI
+        sbc #0
+        sta R_EXP_HI
+
+        // If a subnormal (A_EXP == 0): R_EXP += 1, then loop left-shift
+        // A's significand until M2 bit 7 is set, decrementing R_EXP per
+        // shift.
+        lda A_EXP
+        bne .L__mulsf3_renorm_b
+        inc R_EXP_LO
+        bne 3f
+        inc R_EXP_HI
+        3:
+        .L__mulsf3_renorm_a_loop:
+        bit A_M2
+        bmi .L__mulsf3_renorm_b
+        asl A_M0
+        rol A_M1
+        rol A_M2
+        // R_EXP -= 1  (16-bit dec)
+        lda R_EXP_LO
+        bne 4f
+        dec R_EXP_HI
+        4: dec R_EXP_LO
+        jmp .L__mulsf3_renorm_a_loop
+
+        .L__mulsf3_renorm_b:
+        // Same for b.
+        lda B_EXP
+        bne .L__mulsf3_mul_init
+        inc R_EXP_LO
+        bne 5f
+        inc R_EXP_HI
+        5:
+        .L__mulsf3_renorm_b_loop:
+        bit B_M2
+        bmi .L__mulsf3_mul_init
+        asl B_M0
+        rol B_M1
+        rol B_M2
+        lda R_EXP_LO
+        bne 6f
+        dec R_EXP_HI
+        6: dec R_EXP_LO
+        jmp .L__mulsf3_renorm_b_loop
+
+        .L__mulsf3_mul_init:
+
+        // ================================================================
+        // Phase 8 -- MULTIPLY: 24 x 24 -> 48-bit unsigned.
+
+        // See the "shift-and-add multiply core" reference at the top.
+        // Multiplicand: A_M0..A_M2.  Multiplier and low half of product:
+        // B_M0..B_M2.  High half of product accumulator: PH0..PH2, init 0.
+        // ================================================================
+        lda #0
+        sta PH0
+        sta PH1
+        sta PH2
+        ldy #24
+
+        // Skip whole bytes of a multiplier whose low byte(s) are zero.
+        // Those iterations add nothing (the multiplier bit is 0) and only
+        // shift a still-zero accumulator, so they can be replaced by a
+        // byte-shuffle of the multiplier plus a smaller iteration count:
+        // running the same loop with (M >> 8) for 16 instead of 24
+        // iterations leaves the 48-bit register holding A * M unchanged,
+        // because each retained multiplier bit ends up shifted 8 places
+        // less, exactly compensating the 8 places M was shifted down.
+        //
+        // This is free-ish when it does not fire (6 cycles) and saves
+        // ~420 cycles per skipped byte.  It fires for the constants real
+        // code multiplies by most often -- every float whose value is a
+        // small integer or a simple fraction (2.0, 0.5, 10.0, 100.0, ...)
+        // has trailing zero mantissa bytes.
+        //
+        // At most two bytes can be skipped: the multiplier is normalized
+        // here (B_M2 bit 7 set), so after two shuffles B_M0 is nonzero.
+        lda B_M0
+        bne .L__mulsf3_mul_pre
+        lda B_M1
+        sta B_M0
+        lda B_M2
+        sta B_M1
+        lda #0
+        sta B_M2
+        ldy #16
+        lda B_M0
+        bne .L__mulsf3_mul_pre
+        lda B_M1   // == old B_M2, nonzero
+        sta B_M0
+        lda #0
+        sta B_M1   // B_M2 is already 0
+        ldy #8
+
+        .L__mulsf3_mul_pre:
+        // Pre-shift: shift multiplier right by 1 to get bit 0 into C.
+        lsr B_M2
+        ror B_M1
+        ror B_M0
+
+        .L__mulsf3_mul_loop:
+        bcc .L__mulsf3_mul_noadd
+        clc
+        lda PH0
+        adc A_M0
+        sta PH0
+        lda PH1
+        adc A_M1
+        sta PH1
+        lda PH2
+        adc A_M2
+        sta PH2
+        .L__mulsf3_mul_noadd:
+        ror PH2
+        ror PH1
+        ror PH0
+        ror B_M2
+        ror B_M1
+        ror B_M0
+        dey
+        bne .L__mulsf3_mul_loop
+
+        // ================================================================
+        // Phase 9 -- BIT-47 NORMALIZE.
+
+        // Product now in [PH2:PH1:PH0:B_M2:B_M1:B_M0].  Bit 47 = PH2 bit 7.
+        // set  -> product in [2^47, 2^48); exp += 1, no shift
+        // clear -> product in [2^46, 2^47) (bit 46 set); shift left 1
+
+        // For inputs with both implicit bits set (normals or renormalized
+        // subnormals with M2 bit 7 = 1), the product is guaranteed >=
+        // 2^46, so bit 46 or bit 47 is set.  (We would never reach here
+        // with a zero mantissa product because zero was dispatched.)
+        // ================================================================
+        bit PH2
+        bmi .L__mulsf3_norm_47_set
+        // Shift 48-bit product left by 1
+        asl B_M0
+        rol B_M1
+        rol B_M2
+        rol PH0
+        rol PH1
+        rol PH2
+        jmp .L__mulsf3_chk_ovf
+
+        .L__mulsf3_norm_47_set:
+        // Bit 47 was already set; exp += 1 (may overflow into hi byte).
+        inc R_EXP_LO
+        bne .L__mulsf3_chk_ovf
+        inc R_EXP_HI
+
+        .L__mulsf3_chk_ovf:
+        // ================================================================
+        // Phase 10 -- OVERFLOW / UNDERFLOW dispatch.
+
+        // R_EXP < 0            -> underflow: subnormal or zero
+        // R_EXP == 0           -> subnormal (biased-0 with mantissa
+        // bit 47 set means smaller than the
+        // smallest normal; shift right by 1)
+        // R_EXP in [1, 0xFE]   -> normal, proceed to round
+        // R_EXP >= 0xFF        -> overflow: signed infinity
+        // ================================================================
+        lda R_EXP_HI
+        bmi .L__mulsf3_chk_und   // R_EXP < 0
+        bne .L__mulsf3_overflow   // hi > 0 -> definitely overflow
+        lda R_EXP_LO
+        beq .L__mulsf3_chk_und   // R_EXP == 0 -> subnormal
+        cmp #$ff
+        bcc .L__mulsf3_round   // R_EXP in [1, 0xFE] -> normal
+        // fall through: R_EXP >= 0xFF -> overflow
+
+        .L__mulsf3_overflow:
+        lda #$ff
+        sta A_EXP
+        lda #0
+        sta PH0
+        sta PH1
+        lda #$80
+        sta PH2
+        jmp .L__mulsf3_pack_ph
+
+        .L__mulsf3_chk_und:
+        // ================================================================
+        // Phase 11 -- UNDERFLOW / SUBNORMAL RESULT.
+
+        // R_EXP <= 0 -> result is subnormal (or zero).  We need to shift
+        // the [PH2:PH1:PH0:B_M2:B_M1:B_M0] product right by (1 - R_EXP)
+        // bits, keeping sticky, then round, then set exp = 0.
+
+        // If the shift count >= 25, everything except sticky is gone; the
+        // rounded result is either 0 or the smallest subnormal.  For
+        // simplicity we return signed 0 for shift >= 32 and clamp shift
+        // to 25 otherwise.
+        // ================================================================
+        // shift_count = 1 - R_EXP (positive; larger for more-negative
+        // R_EXP).  We compute this as (1 - R_EXP_LO) with borrow, but
+        // since R_EXP is negative (bit 7 of R_EXP_HI set), we know
+        // shift_count = 1 + |R_EXP|.
+
+        // Compute: shift = 1 - R_EXP_LO - 256*R_EXP_HI.  Since R_EXP_HI
+        // is 0xFF for small negatives (|R_EXP| < 128), shift =
+        // 1 - R_EXP_LO + 256 which is > 256 iff R_EXP_LO < -255... which
+        // can't happen (R_EXP >= -171).  Just use 1 - R_EXP_LO as byte
+        // arithmetic; if R_EXP_LO is e.g. 0xEA (-22), 1 - 0xEA = 0x17
+        // (as unsigned 8-bit, with borrow).  We want +23; 1 - (-22) = 23.
+        // sec / lda #1 / sbc R_EXP_LO gives 1 - R_EXP_LO in A, which for
+        // R_EXP_LO = 0xEA gives 0x17 = 23.  Perfect.
+
+        sec
+        lda #1
+        sbc R_EXP_LO   // A = 1 - R_EXP_LO (byte)
+
+        // If R_EXP_HI is nonzero-and-not-0xFF (impossible), or if the
+        // shift count is huge (>= 32), just return signed 0.  We treat
+        // shift >= 32 as underflow-to-zero.  .L__mulsf3_return_zero is >128 bytes
+        // back from here, out of short-branch range, so use invert-and-jmp
+        // to avoid silent branch-offset truncation.
+        cmp #32
+        bcc 15f   // shift < 32, continue
+        jmp .L__mulsf3_return_zero
+        15:
+
+        // Shift the 48-bit product right by A bits.  Use whole-byte
+        // shifts for count >= 8, then bit loop for residual.  Sticky
+        // accumulates in TMP.
+        sta CNT
+        lda #0
+        sta TMP   // sticky accumulator = 0
+
+        .L__mulsf3_sub_byte:
+        lda CNT
+        cmp #8
+        bcc .L__mulsf3_sub_bits
+        // Shift right by 8 = shuffle bytes down.  OR B_M0 into sticky first.
+        lda B_M0
+        beq 7f
+        lda #1
+        sta TMP
+        7: lda B_M1
+        sta B_M0
+        lda B_M2
+        sta B_M1
+        lda PH0
+        sta B_M2
+        lda PH1
+        sta PH0
+        lda PH2
+        sta PH1
+        lda #0
+        sta PH2
+        lda CNT
+        sec
+        sbc #8
+        sta CNT
+        jmp .L__mulsf3_sub_byte
+
+        .L__mulsf3_sub_bits:
+        ldy CNT
+        beq .L__mulsf3_sub_done
+        .L__mulsf3_sub_bit_loop:
+        lsr PH2
+        ror PH1
+        ror PH0
+        ror B_M2
+        ror B_M1
+        ror B_M0
+        bcc 8f
+        lda #1
+        sta TMP
+        8: dey
+        bne .L__mulsf3_sub_bit_loop
+
+        .L__mulsf3_sub_done:
+        // OR the accumulated sticky into B_M0's LSB region.  We use B_M0
+        // for sticky by writing 1 to it if TMP is nonzero.  Actually we
+        // want the sticky to be represented in the low bits below the
+        // guard for the round logic below.  Simplest: OR TMP into B_M0.
+        lda TMP
+        beq 10f
+        lda B_M0
+        ora #1
+        sta B_M0
+        10:
+        // Set R_EXP = 0 (subnormal marker).  R_EXP_HI already whatever.
+        lda #0
+        sta R_EXP_LO
+        sta R_EXP_HI
+
+        .L__mulsf3_round:
+        // ================================================================
+        // Phase 12 -- ROUND: nearest, ties to even.
+
+        // R = B_M2 bit 7, G = B_M2 bit 6, S = OR(B_M2 & 0x3F, B_M1, B_M0),
+        // LSB = PH0 bit 0.  Round up iff R && (G || S || LSB).
+        // ================================================================
+        bit B_M2   // N = bit 7 (R), V = bit 6 (G)
+        bpl .L__mulsf3_no_round   // R clear -> no round
+
+        // R set.  Compute (G || S || LSB).  Start with (B_M2 & 0x7F)
+        // OR B_M1 OR B_M0 OR (PH0 & 1).
+        lda B_M2
+        and #$7f   // strip R, keep G+partial S
+        ora B_M1
+        ora B_M0
+        sta TMP
+        lda PH0
+        and #1   // LSB
+        ora TMP
+        beq .L__mulsf3_no_round   // exact tie AND LSB even -> no round
+
+        // Round up: ripple increment PH0..PH2.
+        inc PH0
+        bne .L__mulsf3_no_round
+        inc PH1
+        bne .L__mulsf3_no_round
+        inc PH2
+        bne .L__mulsf3_no_round
+        // Full carry-out: mantissa wrapped 0xFFFFFF -> 0x000000.
+        // Restore bit 7 (implicit 1) and bump exp; check overflow.
+        lda #$80
+        sta PH2
+        inc R_EXP_LO
+        bne 11f
+        inc R_EXP_HI
+        11:
+        // Recheck overflow after round bump.  .L__mulsf3_overflow is > 127 bytes
+        // back from here, out of short-branch range -- the assembler
+        // silently truncates out-of-range branch offsets, so we use
+        // invert-and-jmp for both checks.
+        lda R_EXP_HI
+        beq 13f   // hi==0, skip forward
+        jmp .L__mulsf3_overflow
+        13: lda R_EXP_LO
+        cmp #$ff
+        bcc .L__mulsf3_no_round   // R_EXP <= 0xFE, no overflow
+        jmp .L__mulsf3_overflow
+
+        .L__mulsf3_no_round:
+        // Post-round check: if we were subnormal (R_EXP == 0) and the
+        // round caused mantissa to become normal (PH2 bit 7 set), we
+        // need to bump R_EXP to 1 for correct encoding.  If R_EXP was
+        // already nonzero we skip.  If PH2 bit 7 is clear the result
+        // stays subnormal.
+        lda R_EXP_LO
+        ora R_EXP_HI
+        bne .L__mulsf3_setup_pack   // not exp 0, skip
+        bit PH2
+        bpl .L__mulsf3_setup_pack   // still subnormal
+        lda #1
+        sta R_EXP_LO
+
+        .L__mulsf3_setup_pack:
+        // Move R_EXP into A_EXP for the shared packer below (packer
+        // expects A_EXP as the biased result exponent).
+        lda R_EXP_LO
+        sta A_EXP
+
+        .L__mulsf3_pack_ph:
+        // ================================================================
+        // Phase 13 -- PACK: reassemble bytes into ABI return slots.
+
+        // Same layout as addsf3 pack, but our mantissa lives in
+        // PH0..PH2 instead of A_M1..A_M3.  Copy PH -> A_M then reuse
+        // the pack sequence.
+
+        // Layout on entry:
+        // A_EXP  = biased result exponent (0..0xFF)
+        // R_SIGN = result sign in bit 7
+        // PH2    = mantissa MSB (bit 7 = implicit 1 for normals, 0 for
+        // subnormals or zero)
+        // PH1    = mantissa mid
+        // PH0    = mantissa low
+        // ================================================================
+        lda PH0
+        sta A_M0
+        lda PH1
+        sta A_M1
+        lda PH2
+        sta A_M2
+        // fall through to .L__mulsf3_pack_a
+
+        .L__mulsf3_pack_a:
+        // Byte3 = R_SIGN | (A_EXP >> 1); byte2 = ((A_EXP & 1) << 7) |
+        // (A_M2 & 0x7F); byte1 = A_M1; byte0 = A_M0.
+        lda A_EXP
+        lsr a   // A = exp>>1, C = exp bit 0
+        sta TMP
+        lda A_M2
+        and #$7f
+        bcc 12f
+        ora #$80
+        12: sta __rc2   // byte2
+        lda TMP
+        ora R_SIGN
+        sta __rc3   // byte3
+        lda A_M0   // byte0 -> A
+        ldx A_M1   // byte1 -> X
+        rts

--- a/compiler-rt/lib/builtins/mos/subsf3.S
+++ b/compiler-rt/lib/builtins/mos/subsf3.S
@@ -1,0 +1,49 @@
+//===-- lib/mos/subsf3.S - Single-precision subtraction (MOS 6502) -*- Asm -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// __subsf3(a, b) = a - b, via a + (-b): flip b's sign bit and tail-call
+// __addsf3.  All arithmetic, all edge-case handling, all rounding is
+// inherited from __addsf3 (see addsf3.S).
+//
+// Why this shape:
+//   - Duplicating __addsf3's ~900-byte body just to swap a subtract
+//     sign somewhere in the middle would be pure maintenance risk for
+//     zero behavioral gain -- especially given how sensitive the
+//     rounding logic is (see the IEEE 754 sticky-bit sign-flip fix in
+//     __addsf3 for what a subtract-path shortcut can go wrong).
+//   - The upstream generic subsf3.c takes exactly this "a + (-b)"
+//     approach.  Ours is the same idea, but 11 bytes instead of a
+//     compiler-generated wrapper around C bit-fiddling.
+//
+// Registers on entry (llvm-mos ABI):
+//     A  = a byte 0     __rc2 = a byte 2
+//     X  = a byte 1     __rc3 = a byte 3
+//                       __rc4 = b byte 0    __rc6 = b byte 2
+//                       __rc5 = b byte 1    __rc7 = b byte 3  (sign bit = 7)
+//
+// TAY/TYA around the EOR is because 6502's EOR only operates on A, but
+// __addsf3 expects a's byte 0 in A on entry.  Y is otherwise unused by
+// the numeric-argument ABI (numeric args ride A/X + __rc2..__rc15).
+// The JMP tail-call means __addsf3's RTS returns directly to
+// __subsf3's caller; no stack frame here.
+//
+//===----------------------------------------------------------------------===//
+
+#include "imag-regs-zp.inc"
+
+.text
+.globl __subsf3
+.type __subsf3, @function
+__subsf3:
+        tay                                     // stash a byte 0
+        lda __rc7                               // b byte 3 (sign in bit 7)
+        eor #$80                                // flip sign
+        sta __rc7
+        tya                                     // restore a byte 0 to A
+        jmp __addsf3
+.size __subsf3, .-__subsf3

--- a/compiler-rt/test/builtins/Unit/addsf3_test.c
+++ b/compiler-rt/test/builtins/Unit/addsf3_test.c
@@ -92,5 +92,55 @@ int main(void) {
   // Large normal values near overflow
   status |= test__addsf3(0x7f7fffff, 0x7f7fffff, 0x7f800000); // max + max = inf
 
+  // Regression: opposite-sign near-cancellation whose true result is a nonzero
+  // subnormal.  The normalize bit-loop must stop *at* the exp==1 -> exp==0
+  // transition without an additional shift-and-decrement, because IEEE 754
+  // subnormals reuse the same reference scale as the smallest normal (they
+  // just drop the implicit leading 1).  An implementation that shifts one
+  // more time across that boundary silently returns exactly 2x the correct
+  // magnitude for any such subnormal result.
+  status |= test__addsf3(0x00a00000u, 0x80800000u, 0x00200000u);
+  status |= test__addsf3(0x00810000u, 0x80800000u, 0x00010000u);
+  status |= test__addsf3(0x00800001u, 0x80800000u, 0x00000001u);
+  status |= test__addsf3(0x03000000u, 0x82fffffeu, 0x00000020u);
+  // Additional cases discovered by fuzzing a Python model vs numpy float32.
+  status |= test__addsf3(0x00513f55u, 0x808ac0efu, 0x8039819au);
+  status |= test__addsf3(0x007247f1u, 0x808ac31eu, 0x80187b2du);
+  status |= test__addsf3(0x007775f9u, 0x8093b73fu, 0x801c4146u);
+  status |= test__addsf3(0x00740e32u, 0x809786e6u, 0x802378b4u);
+  status |= test__addsf3(0x00ef502eu, 0x80c3a704u, 0x002ba92au);
+  status |= test__addsf3(0x0250d539u, 0x825322c0u, 0x80126c38u);
+  status |= test__addsf3(0x00d60017u, 0x80b739b2u, 0x001ec665u);
+  status |= test__addsf3(0x02fcce07u, 0x82fd68ffu, 0x8009af80u);
+
+  // Regression: opposite-sign add where b needs an alignment right-shift and
+  // some of b's low bits are truncated (sticky bit set).  For the SUBTRACT
+  // path this means the computed difference is slightly too large by a
+  // strictly-positive amount less than one ULP, so a nonzero sticky must
+  // bias the round DOWN -- the mirror image of the add-path convention where
+  // a nonzero sticky biases up.  Implementations that reuse the add-path
+  // rounding logic on the subtract path produce results that are exactly
+  // +1 ULP high.
+  status |= test__addsf3(0x216ee743u, 0x9a7a602fu, 0x216ee359u);
+  status |= test__addsf3(0x291f4cbeu, 0xa2b4701fu, 0x291f471au);
+  status |= test__addsf3(0x006ae03eu, 0x87a2a103u, 0x87a29f57u);
+  status |= test__addsf3(0x237f6e73u, 0x9b70803cu, 0x237f6d82u);
+  status |= test__addsf3(0x1843199eu, 0x8e380fb8u, 0x18431992u);
+  status |= test__addsf3(0x222fb009u, 0x97d01c62u, 0x222fb002u);
+
+  // Regression: subtract of (2^N) - epsilon where epsilon is far below the
+  // ULP of the result.  The mantissa rounds up from 0xFFFFFF to 0x1000000,
+  // which is renormalized to 0x800000 with exp incremented cleanly (no
+  // overflow to infinity).  An implementation whose round-up-with-mantissa-
+  // wrap path falls through into the "return b" packer (used by the
+  // NaN-quiet and both-zeros paths) will corrupt the result by loading b's
+  // fields into a's slots -- typically returning -b instead of the correct
+  // ~2^N.  The path is only reachable when subtract's ripple-decrement +
+  // normalize combines with a round-up that wraps the mantissa.
+  status |= test__addsf3(0x40000000u, 0x80000001u, 0x40000000u);
+  status |= test__addsf3(0x50000000u, 0xb0000000u, 0x50000000u);
+  status |= test__addsf3(0x60000000u, 0x80000001u, 0x60000000u);
+  status |= test__addsf3(0x7e000000u, 0x80000001u, 0x7e000000u);
+
   return status;
 }

--- a/compiler-rt/test/builtins/Unit/subsf3_test.c
+++ b/compiler-rt/test/builtins/Unit/subsf3_test.c
@@ -379,5 +379,54 @@ int main() {
   status |= test__subsf3(0xff800000, 0xff800000, 0x7fc00000);
 #endif // ARM_NAN_HANDLING
 
+  // Regression: opposite-sign near-cancellation whose true result is a
+  // nonzero subnormal.  The normalize bit-loop must stop *at* the
+  // exp==1 -> exp==0 transition without an additional shift-and-
+  // decrement, because IEEE 754 subnormals reuse the same reference
+  // scale as the smallest normal (they just drop the implicit leading
+  // 1).  An implementation that shifts one more time across that
+  // boundary silently returns exactly 2x the correct magnitude for
+  // any such subnormal result.
+  status |= test__subsf3(0x00a00000, 0x00800000, 0x00200000);
+  status |= test__subsf3(0x00810000, 0x00800000, 0x00010000);
+  status |= test__subsf3(0x00800001, 0x00800000, 0x00000001);
+  status |= test__subsf3(0x03000000, 0x02fffffe, 0x00000020);
+  // Additional cases discovered by fuzzing a Python model vs numpy float32.
+  status |= test__subsf3(0x00513f55, 0x008ac0ef, 0x8039819a);
+  status |= test__subsf3(0x007247f1, 0x008ac31e, 0x80187b2d);
+  status |= test__subsf3(0x007775f9, 0x0093b73f, 0x801c4146);
+  status |= test__subsf3(0x00740e32, 0x009786e6, 0x802378b4);
+  status |= test__subsf3(0x00ef502e, 0x00c3a704, 0x002ba92a);
+  status |= test__subsf3(0x0250d539, 0x025322c0, 0x80126c38);
+  status |= test__subsf3(0x00d60017, 0x00b739b2, 0x001ec665);
+  status |= test__subsf3(0x02fcce07, 0x02fd68ff, 0x8009af80);
+
+  // Regression: subtract where b needs an alignment right-shift and
+  // some of b's low bits are truncated (sticky bit set).  Truncating
+  // b downward makes the computed difference slightly too *large* by
+  // a strictly-positive amount less than one ULP, so a nonzero sticky
+  // must bias the round DOWN -- the mirror image of the add-path
+  // convention where a nonzero sticky biases up.  Implementations
+  // that reuse the add-path rounding logic on the subtract path
+  // produce results that are exactly +1 ULP high.
+  status |= test__subsf3(0x216ee743, 0x1a7a602f, 0x216ee359);
+  status |= test__subsf3(0x291f4cbe, 0x22b4701f, 0x291f471a);
+  status |= test__subsf3(0x006ae03e, 0x07a2a103, 0x87a29f57);
+  status |= test__subsf3(0x237f6e73, 0x1b70803c, 0x237f6d82);
+  status |= test__subsf3(0x1843199e, 0x0e380fb8, 0x18431992);
+  status |= test__subsf3(0x222fb009, 0x17d01c62, 0x222fb002);
+
+  // Regression: subtract of (2^N) - epsilon where epsilon is far below the
+  // ULP of the result.  The mantissa rounds up from 0xFFFFFF to 0x1000000,
+  // which is renormalized to 0x800000 with exp incremented cleanly (no
+  // overflow to infinity).  An implementation whose round-up-with-mantissa-
+  // wrap path falls through into a "return b" packer (used by NaN-quiet and
+  // both-zeros paths) will corrupt the result by loading b's fields into
+  // a's slots -- typically returning -b instead of the correct ~2^N.
+  status |= test__subsf3(0x40000000, 0x00000001, 0x40000000);
+  status |= test__subsf3(0x50000000, 0x30000000, 0x50000000);
+  status |= test__subsf3(0x60000000, 0x00000001, 0x60000000);
+  status |= test__subsf3(0x7e000000, 0x00000001, 0x7e000000);
+
   return status;
 }


### PR DESCRIPTION
Round two of the softfloat PR (previous attempt closed at #575).
Rewritten from naked-C to `.S`, with two subtract-path bugs found by
@wbniv fixed, and in-tree regression coverage added for the bug classes
that the existing 25-vector `addsf3_test.c` did not probe.

## Summary

Adds MOS 6502 hand-tuned `.S` implementations of the four single-precision
IEEE 754 soft-float compiler-rt builtins: `__addsf3`, `__subsf3`,
`__mulsf3`, `__divsf3`.  All four confine state to caller-saved zero-page
slots (`__rc2..__rc19`), so there is no prologue/epilogue and no stack
frame.  Rounding is hardcoded round-to-nearest-ties-to-even (no fenv --
the generic compiler-rt fenv machinery is ~30x more expensive per call
than the arithmetic it wraps).

## Numbers (vs upstream generic, on the existing compiler-rt Unit tests, under mos-sim)

| routine   | vectors        | isolated .text gen -> mos | full-test cycles gen -> mos     |
|-----------|----------------|---------------------------|----------------------------------|
| `__addsf3`  | 43             | 3130 -> **703 B** (-78%)  | ~34,000 -> ~35,700               |
| `__subsf3`  | 40             | -> **11 B** (trampoline)  | (delegates to `__addsf3`)          |
| `__mulsf3`  | 350+           | 2424 -> **681 B** (-72%)  | 2,310,376 -> **967,608** (-58%)  |
| `__divsf3`  | 351            | 3305 -> **806 B** (-76%)  | 5,438,847 -> **535,174** (-90%)  |

The 10x `__divsf3` speedup is because the generic path is Newton-
Raphson (three iterations, each needing a 32x32 multiply -- catastrophic
on the 6502).  Shift-subtract long division is a much better algorithmic
fit here.

End-to-end validation via a 60x25 ASCII Mandelbrot demo: **bit-identical
output** vs the generic softfloat implementation (MD5 verified) at
**3.2x speed** (~200M cycles vs ~638M).

## Two subtract-path bugs fixed relative to the earlier naked-C version

Both were discovered by @wbniv transcribing the previous implementation
into a Python model and fuzzing against numpy float32 as ground truth.

- **Bug 1 (severe) -- subnormal-result doubling.**  When the correctly-
  rounded result of `a - b` is a nonzero subnormal float (< ~1.175e-38),
  an implementation whose normalize bit-loop tests `A_EXP == 0` before
  deciding whether to shift does one extra shift-and-decrement at the
  `exp==1 -> exp==0` transition.  IEEE 754 subnormals reuse the same
  reference scale as the smallest normal (they just drop the implicit
  leading 1), so the loop must stop at that boundary without shifting.
  Buggy implementations return exactly 2x the correct magnitude -- in a
  random fuzz, ~31% of nonzero-subnormal difference cases came back
  doubled.
- **Bug 2 -- alignment sticky-bit sign flip.**  On the subtract path,
  when `b` needs an alignment right-shift and some of `b`'s low bits are
  truncated, the computed difference is slightly too *large* by
  <1 ULP.  Correct rounding must bias DOWN -- the mirror of the
  add-path convention where a nonzero sticky biases up.  Implementations
  that reuse the add-path rounding logic on the subtract path produce
  results that are exactly +1 ULP high (~63/300k in random fuzz, always
  d=+1).

Regression vectors covering both classes have been added to
`compiler-rt/test/builtins/Unit/addsf3_test.c` (+18) and a new
`subsf3_test.c` (+40, includes 22 baseline IEEE 754 shape cases).
The vectors are hex-encoded so they exercise the same shapes on any
target implementing the softfloat builtins.

## Response to review feedback from #575

- **@wbniv** identified both subtract-path bugs and suggested the fixes
  used here.  Thank you.
- **@mysterymath** pointed out that naked-C + `asm volatile` was the
  wrong shape.  Confirmed empirically: LTO cannot optimize inside a
  naked+`asm volatile` body, and the MOS toolchain does DCE via
  `--gc-sections` + archive semantics regardless of LTO, so nothing was
  gained by staying in C.  This PR is `.S`.

## Assembler notes

- Local labels use a per-function `.L__addsf3_*` / `.L__mulsf3_*` /
  `.L__divsf3_*` prefix.  Keeps them out of the object symbol table and
  unique across sibling files.
- Far branches (>127 B) use invert-and-jmp or a shared JMP trampoline
  to work around the LLVM MC assembler's silent 8-bit branch-offset
  truncation.
- `.zeropage __rcN` directives at the top of each `.S` declare the
  imaginary registers as zero-page symbols, so `lda`/`sta` emit the
  2-byte zp encoding.  See https://llvm-mos.org/wiki/Assembler_relaxation.

## Test plan

- [x] `Unit/addsf3_test.c` (43 vectors: 25 upstream + 18 regression) passes
- [x] `Unit/subsf3_test.c` (40 vectors: 22 baseline + 18 regression) passes
- [x] `Unit/mulsf3_test.c` (350+ vectors) passes
- [x] `Unit/divsf3_test.c` (351 vectors) passes
- [x] 27,656-vector fuzz against `__subsf3` (spanning cancel/align/full-STK/random shapes): 0 mismatches
- [x] Full compiler-rt build (`ninja runtimes/install-builtins-mos-unknown-unknown`)
- [x] Downstream `llvm-mos-sdk` `libcrt.a` rebuilds cleanly
- [x] End-to-end Mandelbrot via installed archive: bit-identical to generic, 3.2x speed