### PR TITLE
feat(MOS): DWARF register numbering and CFI support (escape-based alternative to #568)

### DIFF
--- a/clang/test/CodeGen/MOS/builtin-frame-address.c
+++ b/clang/test/CodeGen/MOS/builtin-frame-address.c
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -triple mos -emit-llvm -o - %s | FileCheck %s
+
+// Test that __builtin_frame_address and __builtin_return_address compile
+// correctly on MOS (16-bit int target). The intrinsics require i32 depth
+// argument, so clang must zero-extend the 16-bit UnsignedIntTy.
+
+void* test_frame_address(void) {
+    // CHECK: call ptr @llvm.frameaddress.p0(i32 0)
+    return __builtin_frame_address(0);
+}
+
+void* test_return_address(void) {
+    // CHECK: call ptr @llvm.returnaddress(i32 0)
+    return __builtin_return_address(0);
+}

--- a/llvm/lib/CodeGen/MIRParser/MILexer.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MILexer.cpp
@@ -226,6 +226,7 @@ static MIToken::TokenKind getIdentifierKind(StringRef Identifier) {
       .Case("same_value", MIToken::kw_cfi_same_value)
       .Case("offset", MIToken::kw_cfi_offset)
       .Case("rel_offset", MIToken::kw_cfi_rel_offset)
+      .Case("val_offset", MIToken::kw_cfi_val_offset)
       .Case("def_cfa_register", MIToken::kw_cfi_def_cfa_register)
       .Case("def_cfa_offset", MIToken::kw_cfi_def_cfa_offset)
       .Case("adjust_cfa_offset", MIToken::kw_cfi_adjust_cfa_offset)

--- a/llvm/lib/CodeGen/MIRParser/MILexer.h
+++ b/llvm/lib/CodeGen/MIRParser/MILexer.h
@@ -85,6 +85,7 @@ struct MIToken {
     kw_cfi_same_value,
     kw_cfi_offset,
     kw_cfi_rel_offset,
+    kw_cfi_val_offset,
     kw_cfi_def_cfa_register,
     kw_cfi_def_cfa_offset,
     kw_cfi_adjust_cfa_offset,

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -2791,6 +2791,13 @@ bool MIParser::parseCFIOperand(MachineOperand &Dest) {
     CFIIndex = MF.addFrameInst(
         MCCFIInstruction::createRelOffset(nullptr, Reg, Offset));
     break;
+  case MIToken::kw_cfi_val_offset:
+    if (parseCFIRegister(Reg) || expectAndConsume(MIToken::comma) ||
+        parseCFIOffset(Offset))
+      return true;
+    CFIIndex = MF.addFrameInst(
+        MCCFIInstruction::createValOffset(nullptr, Reg, Offset));
+    break;
   case MIToken::kw_cfi_def_cfa_register:
     if (parseCFIRegister(Reg))
       return true;
@@ -3313,6 +3320,7 @@ bool MIParser::parseMachineOperand(const unsigned OpCode, const unsigned OpIdx,
   case MIToken::kw_cfi_same_value:
   case MIToken::kw_cfi_offset:
   case MIToken::kw_cfi_rel_offset:
+  case MIToken::kw_cfi_val_offset:
   case MIToken::kw_cfi_def_cfa_register:
   case MIToken::kw_cfi_def_cfa_offset:
   case MIToken::kw_cfi_adjust_cfa_offset:

--- a/llvm/lib/CodeGen/MachineOperand.cpp
+++ b/llvm/lib/CodeGen/MachineOperand.cpp
@@ -737,6 +737,13 @@ static void printCFI(raw_ostream &OS, const MCCFIInstruction &CFI,
     printCFIRegister(CFI.getRegister(), OS, TRI);
     OS << ", " << CFI.getOffset();
     break;
+  case MCCFIInstruction::OpValOffset:
+    OS << "val_offset ";
+    if (MCSymbol *Label = CFI.getLabel())
+      MachineOperand::printSymbol(OS, *Label);
+    printCFIRegister(CFI.getRegister(), OS, TRI);
+    OS << ", " << CFI.getOffset();
+    break;
   case MCCFIInstruction::OpAdjustCfaOffset:
     OS << "adjust_cfa_offset ";
     if (MCSymbol *Label = CFI.getLabel())

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCAsmInfo.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCAsmInfo.cpp
@@ -42,7 +42,9 @@ MOSMCAsmInfo::MOSMCAsmInfo(const Triple &TT, const MCTargetOptions &Options)
   // to convey banking information; this field is used, among others, by the
   // DWARF debug structures.
   CodePointerSize = 4;
-  CalleeSaveStackSlotSize = 0;
+  // MOS is an 8-bit architecture with 1-byte stack slots.
+  // This is also used as the DWARF data alignment factor for CFI.
+  CalleeSaveStackSlotSize = 1;
   SeparatorString = "\n";
   CommentString = ";";
   UseMotorolaIntegers = true;
@@ -51,6 +53,7 @@ MOSMCAsmInfo::MOSMCAsmInfo(const Triple &TT, const MCTargetOptions &Options)
   // Maximum instruction length across all supported subtargets.
   MaxInstLength = 7;
   SupportsDebugInformation = true;
+  ExceptionsType = ExceptionHandling::DwarfCFI;
 
   initializeAtSpecifiers(AtSpecifiers);
 }

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCTargetDesc.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCTargetDesc.cpp
@@ -17,10 +17,13 @@
 #include "MOSMCInstrAnalysis.h"
 #include "MOSTargetStreamer.h"
 #include "TargetInfo/MOSTargetInfo.h"
+#include "../MOSCFIExprHelpers.h"
 
-#include "llvm/BinaryFormat/ELF.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/MC/MCAsmBackend.h"
 #include "llvm/MC/MCCodeEmitter.h"
+#include "llvm/MC/MCDwarf.h"
 #include "llvm/MC/MCELFStreamer.h"
 #include "llvm/MC/MCInstrAnalysis.h"
 #include "llvm/MC/MCInstrInfo.h"
@@ -48,9 +51,72 @@ MCInstrInfo *llvm::createMOSMCInstrInfo() {
 
 static MCRegisterInfo *createMOSMCRegisterInfo(const Triple &TT) {
   MCRegisterInfo *X = new MCRegisterInfo();
-  InitMOSMCRegisterInfo(X, 0);
-
+  InitMOSMCRegisterInfo(X, MOS::PC);
   return X;
+}
+
+/// Emit a DWARF expression that computes a normalized hardware stack address.
+/// The 6502 hardware stack is at 0x0100-0x01FF. The S register is physically
+/// 8-bit, but some debuggers report it as 16-bit (e.g., MAME reports 0x01FE).
+/// This expression normalizes to always produce addresses in 0x0100-0x01FF:
+///   result = ((S + Offset) & 0xFF) | 0x0100
+static void emitNormalizedHardwareStackExpr(SmallVectorImpl<char> &Expr,
+                                             unsigned DwarfS,
+                                             int8_t Offset) {
+  // DW_OP_breg<S> <offset> - S + offset
+  Expr.push_back(static_cast<char>(dwarf::DW_OP_breg0 + DwarfS));
+  Expr.push_back(static_cast<char>(Offset));
+
+  // DW_OP_const1u 0xFF
+  Expr.push_back(static_cast<char>(dwarf::DW_OP_const1u));
+  Expr.push_back(static_cast<char>(0xFF));
+
+  // DW_OP_and - keep low byte only
+  Expr.push_back(static_cast<char>(dwarf::DW_OP_and));
+
+  // DW_OP_const2u 0x0100 (little-endian: 0x00, 0x01)
+  Expr.push_back(static_cast<char>(dwarf::DW_OP_const2u));
+  Expr.push_back(static_cast<char>(0x00));
+  Expr.push_back(static_cast<char>(0x01));
+
+  // DW_OP_or - force into hardware stack page
+  Expr.push_back(static_cast<char>(dwarf::DW_OP_or));
+}
+
+static MCAsmInfo *createMOSMCAsmInfo(const MCRegisterInfo &MRI,
+                                      const Triple &TT,
+                                      const MCTargetOptions &Options) {
+  MCAsmInfo *MAI = new MOSMCAsmInfo(TT, Options);
+
+  // Initialize initial frame state for hardware stack.
+  // 6502 JSR pushes (return_address - 1) onto hardware stack:
+  //   - First pushes high byte to [SP], then decrements SP
+  //   - Then pushes low byte to [SP], then decrements SP
+  // After JSR, SP points to next free slot (two below pushed address).
+  // Stack layout after JSR:
+  //   [SP+1] = low byte of (return_address - 1)
+  //   [SP+2] = high byte of (return_address - 1)
+  //
+  // We use normalized expressions to handle both 8-bit and 16-bit S values.
+  // Each hardware stack address is computed independently (not CFA-relative)
+  // to avoid subtraction underflow when S wraps within the stack page.
+  // This must match ABISysV_mos::CreateFunctionEntryUnwindPlan().
+
+  unsigned DwarfS = MRI.getDwarfRegNum(MOS::S, true);
+  unsigned DwarfPC = MRI.getDwarfRegNum(MOS::PC, true);
+
+  // CFA = normalized(S + 3) = ((S + 3) & 0xFF) | 0x0100
+  SmallString<16> CfaExpr;
+  emitNormalizedHardwareStackExpr(CfaExpr, DwarfS, 3);
+  MAI->addInitialFrameState(mos::createDefCfaExpression(CfaExpr));
+
+  // PC = [normalized(S + 1)] - direct expression, NOT [CFA - 2]
+  // The return address is at S+1 (low byte) and S+2 (high byte).
+  SmallString<16> PcExpr;
+  emitNormalizedHardwareStackExpr(PcExpr, DwarfS, 1);
+  MAI->addInitialFrameState(mos::createExpression(DwarfPC, PcExpr));
+
+  return MAI;
 }
 
 static MCSubtargetInfo *createMOSMCSubtargetInfo(const Triple &TT,
@@ -98,8 +164,8 @@ static MCInstrAnalysis *createMOSMCInstrAnalysis(const MCInstrInfo *Info) {
 }
 
 extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeMOSTargetMC() {
-  // Register the MC asm info.
-  RegisterMCAsmInfo<MOSMCAsmInfo> X(getTheMOSTarget());
+  // Register the MC asm info with initial frame state for CFI.
+  TargetRegistry::RegisterMCAsmInfo(getTheMOSTarget(), createMOSMCAsmInfo);
 
   // Register the MC instruction info.
   TargetRegistry::RegisterMCInstrInfo(getTheMOSTarget(), createMOSMCInstrInfo);

--- a/llvm/lib/Target/MOS/MOSAsmPrinter.cpp
+++ b/llvm/lib/Target/MOS/MOSAsmPrinter.cpp
@@ -21,8 +21,6 @@
 #include "MOSSubtarget.h"
 #include "TargetInfo/MOSTargetInfo.h"
 
-#include "llvm/ADT/StringSet.h"
-#include "llvm/BinaryFormat/MOSFlags.h"
 #include "llvm/CodeGen/AsmPrinter.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineJumpTableInfo.h"
@@ -40,6 +38,8 @@ using namespace llvm;
 #define DEBUG_TYPE "asm-printer"
 
 namespace {
+
+/// MOS-specific AsmPrinter implementation.
 
 class MOSAsmPrinter : public AsmPrinter {
   MOSMCInstLower InstLowering;
@@ -197,10 +197,12 @@ bool MOSAsmPrinter::PrintAsmMemoryOperand(const MachineInstr *MI, unsigned OpNo,
 }
 
 void MOSAsmPrinter::emitStartOfAsmFile(Module &M) {
-  auto &MTS =
-      *static_cast<MOSTargetStreamer *>(OutStreamer->getTargetStreamer());
+  auto *MTS =
+      static_cast<MOSTargetStreamer *>(OutStreamer->getTargetStreamer());
+  if (!MTS)
+    return;
   for (int I = 0; I < 32; I++)
-    MTS.emitDirectiveZeroPage(OutContext.getOrCreateSymbol("__rc" + Twine(I)));
+    MTS->emitDirectiveZeroPage(OutContext.getOrCreateSymbol("__rc" + Twine(I)));
 }
 
 void MOSAsmPrinter::emitJumpTableInfo() {

--- a/llvm/lib/Target/MOS/MOSCFIExprHelpers.h
+++ b/llvm/lib/Target/MOS/MOSCFIExprHelpers.h
@@ -1,0 +1,72 @@
+//===-- MOSCFIExprHelpers.h - MOS CFI expression-form helpers ---*- C++ -*-===//
+//
+// Part of LLVM-MOS, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// MCCFIInstruction has no first-class constructors for DW_CFA_expression,
+// DW_CFA_val_expression, or DW_CFA_def_cfa_expression.  Targets that need
+// them assemble the raw escape byte sequence and hand it to
+// MCCFIInstruction::createEscape.
+//
+// These helpers do exactly that, with signatures that match what
+// first-class constructors would take.  If upstream ever grows real
+// constructors (see the discussion on llvm-mos/llvm-mos#568), migration
+// is a body swap on these three functions with no changes at the call
+// sites.
+//
+// Encoding (DWARF 5, section 6.4.2):
+//   DW_CFA_def_cfa_expression  opcode <ULEB128 len> <expr bytes>
+//   DW_CFA_expression          opcode <ULEB128 reg> <ULEB128 len> <expr bytes>
+//   DW_CFA_val_expression      opcode <ULEB128 reg> <ULEB128 len> <expr bytes>
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_MOS_MOSCFIEXPRHELPERS_H
+#define LLVM_LIB_TARGET_MOS_MOSCFIEXPRHELPERS_H
+
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/MC/MCDwarf.h"
+#include "llvm/Support/LEB128.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace llvm {
+namespace mos {
+
+inline MCCFIInstruction createDefCfaExpression(StringRef Expr) {
+  SmallString<32> Data;
+  raw_svector_ostream OS(Data);
+  OS << uint8_t(dwarf::DW_CFA_def_cfa_expression);
+  encodeULEB128(Expr.size(), OS);
+  OS << Expr;
+  return MCCFIInstruction::createEscape(nullptr, OS.str());
+}
+
+inline MCCFIInstruction createRegExpression(uint8_t CFAOpcode,
+                                            unsigned DwarfReg,
+                                            StringRef Expr) {
+  SmallString<32> Data;
+  raw_svector_ostream OS(Data);
+  OS << CFAOpcode;
+  encodeULEB128(DwarfReg, OS);
+  encodeULEB128(Expr.size(), OS);
+  OS << Expr;
+  return MCCFIInstruction::createEscape(nullptr, OS.str());
+}
+
+inline MCCFIInstruction createExpression(unsigned DwarfReg, StringRef Expr) {
+  return createRegExpression(dwarf::DW_CFA_expression, DwarfReg, Expr);
+}
+
+inline MCCFIInstruction createValExpression(unsigned DwarfReg, StringRef Expr) {
+  return createRegExpression(dwarf::DW_CFA_val_expression, DwarfReg, Expr);
+}
+
+} // namespace mos
+} // namespace llvm
+
+#endif // LLVM_LIB_TARGET_MOS_MOSCFIEXPRHELPERS_H

--- a/llvm/lib/Target/MOS/MOSFrameLowering.cpp
+++ b/llvm/lib/Target/MOS/MOSFrameLowering.cpp
@@ -14,12 +14,13 @@
 
 #include "MCTargetDesc/MOSMCTargetDesc.h"
 #include "MOS.h"
-#include "MOSInstrBuilder.h"
 #include "MOSMachineFunctionInfo.h"
 #include "MOSRegisterInfo.h"
 #include "MOSSubtarget.h"
 
 #include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/CodeGen/GlobalISel/CallLowering.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
@@ -32,12 +33,43 @@
 #include "llvm/CodeGen/TargetFrameLowering.h"
 #include "llvm/CodeGen/TargetInstrInfo.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
-#include "llvm/Support/Compiler.h"
+#include "llvm/IR/DiagnosticInfo.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCDwarf.h"
 #include "llvm/Support/ErrorHandling.h"
+
+#include "MOSCFIExprHelpers.h"
 
 #define DEBUG_TYPE "mos-framelowering"
 
 using namespace llvm;
+
+/// Emit a DWARF expression that computes a normalized hardware stack address.
+/// The 6502 hardware stack is at 0x0100-0x01FF. The S register is physically
+/// 8-bit, but some debuggers report it as 16-bit (e.g., MAME reports 0x01FE).
+/// This expression normalizes to always produce addresses in 0x0100-0x01FF:
+///   result = ((S + Offset) & 0xFF) | 0x0100
+static void emitNormalizedHardwareStackExpr(SmallVectorImpl<char> &Expr,
+                                             unsigned DwarfS, int8_t Offset) {
+  // DW_OP_breg<S> <offset> - S + offset
+  Expr.push_back(static_cast<char>(dwarf::DW_OP_breg0 + DwarfS));
+  Expr.push_back(static_cast<char>(Offset));
+
+  // DW_OP_const1u 0xFF
+  Expr.push_back(static_cast<char>(dwarf::DW_OP_const1u));
+  Expr.push_back(static_cast<char>(0xFF));
+
+  // DW_OP_and - keep low byte only
+  Expr.push_back(static_cast<char>(dwarf::DW_OP_and));
+
+  // DW_OP_const2u 0x0100 (little-endian: 0x00, 0x01)
+  Expr.push_back(static_cast<char>(dwarf::DW_OP_const2u));
+  Expr.push_back(static_cast<char>(0x00));
+  Expr.push_back(static_cast<char>(0x01));
+
+  // DW_OP_or - force into hardware stack page
+  Expr.push_back(static_cast<char>(dwarf::DW_OP_or));
+}
 
 MOSFrameLowering::MOSFrameLowering()
     : TargetFrameLowering(StackGrowsDown, /*StackAlignment=*/Align(1),
@@ -281,15 +313,23 @@ MachineBasicBlock::iterator MOSFrameLowering::eliminateCallFramePseudoInstr(
 
 void MOSFrameLowering::emitPrologue(MachineFunction &MF,
                                     MachineBasicBlock &MBB) const {
-  const MachineFrameInfo &MFI = MF.getFrameInfo();
+  MachineFrameInfo &MFI = MF.getFrameInfo();
   const TargetRegisterInfo &TRI = *MF.getRegInfo().getTargetRegisterInfo();
+  const MCRegisterInfo *MRI = MF.getContext().getRegisterInfo();
   MachineIRBuilder Builder(MBB, MBB.begin());
+  DebugLoc DL;
 
   // Stack pointer adjustments need to occur after the CLD in an interrupt
   // handler or the sum might be incorrect.
   for (MachineInstr &MI : MBB)
     if (MI.getOpcode() == MOS::CLD_Implied)
       Builder.setInsertPt(MBB, std::next(MI.getIterator()));
+
+  // If __builtin_return_address(0) is used, save the return address from
+  // the hardware stack to a frame slot. This must happen BEFORE any CSRs
+  // are pushed to the hardware stack, so the return address is at S+1/S+2.
+  if (MFI.isReturnAddressTaken())
+    emitReturnAddressSave(MF, MBB, Builder.getInsertPt(), DL);
 
   int64_t StackSize = MFI.getStackSize();
   // If the interrupted routine is in the middle of decrementing its stack
@@ -303,26 +343,131 @@ void MOSFrameLowering::emitPrologue(MachineFunction &MF,
   if (StackSize)
     offsetSP(Builder, -StackSize);
 
-  if (!hasFP(MF))
-    return;
-
   // Skip the callee-saved push instructions.
   auto MBBI = std::find_if_not(Builder.getInsertPt(), MBB.end(),
                                [](const MachineInstr &MI) {
                                  return MI.getFlag(MachineInstr::FrameSetup);
                                });
 
+  // Emit CFI for stack adjustment. The CFA is based on the soft stack pointer
+  // RS0. After the prologue, CFA = RS0 + StackSize.
+  //
+  // MOS 65xx has two independent stacks:
+  //   1. Hardware stack (S register, 0x0100-0x01FF) - where JSR pushes return addresses
+  //   2. Soft stack (RS0) - where local variables and callee-saved registers live
+  //
+  // The CIE initial frame state says: CFA=S+3, PC=[CFA-2]=[S+1]
+  // This is correct at function entry before the prologue.
+  //
+  // When we change CFA to soft-stack based (RS0+StackSize), we must ALSO
+  // emit a DW_CFA_expression for PC, because the return address is still
+  // on the HARDWARE stack, not on the soft stack.
+  //
+  // However, the prologue also pushes callee-saved registers to the hardware
+  // stack using PHA instructions (up to 4 CSRs). Each PHA decrements S by 1.
+  // So the return address is at S + 1 + HardStackCSRCount, not just S + 1.
+  if (StackSize) {
+    // Get the DWARF register number for RS0 (soft stack pointer)
+    unsigned DwarfSP = MRI->getDwarfRegNum(MOS::RS0, true);
+    BuildCFI(MBB, MBBI, DL,
+             MCCFIInstruction::cfiDefCfa(nullptr, DwarfSP, StackSize),
+             MachineInstr::FrameSetup);
+
+    // Emit RS0 (soft stack pointer) restoration rule.
+    // The caller's RS0 = CFA (since we defined CFA = RS0 + StackSize).
+    // DW_CFA_val_offset: register's previous value = CFA + offset
+    // With offset 0: caller's RS0 = CFA = RS0 + StackSize
+    BuildCFI(MBB, MBBI, DL,
+             MCCFIInstruction::createValOffset(nullptr, DwarfSP, 0),
+             MachineInstr::FrameSetup);
+
+    // Count how many callee-saved registers were pushed to the hardware stack.
+    // These are marked as target-spilled but not in CSRZPOffsets.
+    const auto &FuncInfo = MF.getInfo<MOSFunctionInfo>();
+    unsigned HardStackCSRCount = 0;
+    for (const CalleeSavedInfo &CSI : MFI.getCalleeSavedInfo()) {
+      if (FuncInfo->CSRZPOffsets.count(CSI.getReg()))
+        continue;
+      if (CSI.isTargetSpilled())
+        ++HardStackCSRCount;
+    }
+
+    // Emit DW_CFA_expression to tell the debugger that PC (return address)
+    // is on the hardware stack, NOT relative to the soft stack CFA.
+    //
+    // DW_CFA_expression implies the expression yields an ADDRESS from which
+    // the register value is loaded (implicit dereference).
+    //
+    // We use normalized expressions to handle both 8-bit and 16-bit S values.
+    // The expression computes: ((S + offset) & 0xFF) | 0x0100
+    // This ensures the result is always in the hardware stack range 0x0100-0x01FF.
+    unsigned DwarfPC = MRI->getDwarfRegNum(MOS::PC, true);
+    unsigned DwarfS = MRI->getDwarfRegNum(MOS::S, true);
+    int8_t PCOffset = 1 + HardStackCSRCount;
+
+    SmallString<16> PcExpr;
+    emitNormalizedHardwareStackExpr(PcExpr, DwarfS, PCOffset);
+    BuildCFI(MBB, MBBI, DL, mos::createExpression(DwarfPC, PcExpr.str()),
+             MachineInstr::FrameSetup);
+
+    // Emit DW_CFA_val_expression for S register restoration.
+    //
+    // The S register is modified by:
+    //   1. The JSR that called this function (decrements S by 2)
+    //   2. PHA instructions in the prologue (each decrements S by 1)
+    //
+    // When LLDB unwinds from this frame to the caller, it needs the caller's
+    // S value so it can correctly evaluate the caller's PC expression.
+    //
+    // The caller's S = current S + HardStackCSRCount + 2
+    //   - HardStackCSRCount: undo the PHAs in this function's prologue
+    //   - 2: undo the JSR that called this function
+    //
+    // DW_CFA_val_expression means: the previous value of the register
+    // IS the result of the expression (not an address to dereference).
+    //
+    // We use normalized expressions here too - returning a 16-bit 0x01xx value
+    // is safe: 16-bit debuggers use it as-is, 8-bit debuggers truncate to low byte.
+    {
+      int8_t SOffset = HardStackCSRCount + 2;
+      SmallString<16> SExpr;
+      emitNormalizedHardwareStackExpr(SExpr, DwarfS, SOffset);
+      BuildCFI(MBB, MBBI, DL, mos::createValExpression(DwarfS, SExpr.str()),
+               MachineInstr::FrameSetup);
+    }
+  }
+
+  // Emit CFI for callee-saved registers saved to the soft stack.
+  emitCalleeSavedFrameMoves(MBB, MBBI, DL, /*IsPrologue=*/true);
+
+  if (!hasFP(MF))
+    return;
+
   // Set the frame pointer to the stack pointer.
   Builder.setInsertPt(MBB, MBBI);
   Builder.setDebugLoc({});
   Builder.buildCopy(TRI.getFrameRegister(MF), Register(MOS::RS0));
+
+  // Emit CFI to indicate CFA is now based on the frame pointer.
+  // After setting FP = SP, CFA = FP + StackSize.
+  // We must use cfiDefCfa (not createDefCfaRegister) because the CIE uses
+  // a DWARF expression, not register+offset, so there's no offset to preserve.
+  unsigned DwarfFP = MRI->getDwarfRegNum(TRI.getFrameRegister(MF), true);
+  int64_t FPStackSize = MFI.getStackSize();
+  if (isISR(MF))
+    FPStackSize += 256;
+  BuildCFI(MBB, std::next(Builder.getInsertPt()), DL,
+           MCCFIInstruction::cfiDefCfa(nullptr, DwarfFP, FPStackSize),
+           MachineInstr::FrameSetup);
 }
 
 void MOSFrameLowering::emitEpilogue(MachineFunction &MF,
                                     MachineBasicBlock &MBB) const {
   const MachineFrameInfo &MFI = MF.getFrameInfo();
   const TargetRegisterInfo &TRI = *MF.getRegInfo().getTargetRegisterInfo();
+  const MCRegisterInfo *MRI = MF.getContext().getRegisterInfo();
   MachineIRBuilder Builder(MBB, MBB.getFirstTerminator());
+  DebugLoc DL;
 
   // Restore the stack pointer from the frame pointer.
   if (hasFP(MF)) {
@@ -335,8 +480,24 @@ void MOSFrameLowering::emitEpilogue(MachineFunction &MF,
 
     // Set the stack pointer to the frame pointer.
     Builder.buildCopy(MOS::RS0, TRI.getFrameRegister(MF));
+
+    // Emit CFI to switch CFA back to SP-based.
+    unsigned DwarfSP = MRI->getDwarfRegNum(MOS::RS0, true);
+    int64_t StackSize = MFI.getStackSize();
+    if (isISR(MF))
+      StackSize += 256;
+    BuildCFI(MBB, std::next(Builder.getInsertPt()), DL,
+             MCCFIInstruction::cfiDefCfa(nullptr, DwarfSP, StackSize),
+             MachineInstr::FrameDestroy);
+
     Builder.setInsertPt(MBB, MBB.getFirstTerminator());
   }
+
+  // Find insertion point before the terminator for CFI emissions.
+  auto MBBI = MBB.getFirstTerminator();
+
+  // Emit CFI for callee-saved register restoration.
+  emitCalleeSavedFrameMoves(MBB, MBBI, DL, /*IsPrologue=*/false);
 
   int64_t StackSize = MFI.getStackSize();
 
@@ -364,10 +525,29 @@ bool MOSFrameLowering::hasFPImpl(const MachineFunction &MF) const {
 void MOSFrameLowering::offsetSP(MachineIRBuilder &Builder,
                                 int64_t Offset) const {
   assert(Offset);
-  if (Offset < SHRT_MIN)
-    report_fatal_error("Stack pointer decrement too large: " + Twine(-Offset));
-  if (Offset > SHRT_MAX)
-    report_fatal_error("Stack pointer increment too large: " + Twine(Offset));
+  MachineFunction &MF = Builder.getMF();
+  const Function &F = MF.getFunction();
+
+  // MOS uses a 16-bit soft stack pointer (RS0), so stack adjustments are
+  // limited to 65535 bytes (the range of a 16-bit value). Larger adjustments
+  // cannot be represented in a single 16-bit addition.
+  // This is a target limitation, not a compiler bug.
+  constexpr int64_t MaxOffset = 65535;
+  if (Offset < -MaxOffset || Offset > MaxOffset) {
+    uint64_t RequestedSize = static_cast<uint64_t>(Offset < 0 ? -Offset : Offset);
+    F.getContext().diagnose(DiagnosticInfoStackSize(
+        F, RequestedSize, MaxOffset, DS_Error));
+    F.getContext().diagnose(DiagnosticInfoUnsupported(
+        F,
+        "stack frame too large for MOS target: the 16-bit soft stack pointer "
+        "can only be adjusted by up to 65535 bytes per function, but this "
+        "function requires " +
+            Twine(RequestedSize) +
+            " bytes. The MOS 6502 has a 64KB address space, so stack frames "
+            "this large are not practical. Consider reducing local variable "
+            "size, splitting the function, or using heap allocation."));
+    return;
+  }
 
   auto Bytes = static_cast<uint16_t>(Offset);
   int64_t LoBytes = Bytes & 0xFF;
@@ -405,4 +585,134 @@ bool MOSFrameLowering::isISR(const MachineFunction &MF) const {
     return false;
   return F.hasFnAttribute("interrupt") ||
          F.hasFnAttribute("interrupt-norecurse");
+}
+
+StackOffset MOSFrameLowering::getFrameIndexReference(const MachineFunction &MF,
+                                                     int FI,
+                                                     Register &FrameReg) const {
+  const MachineFrameInfo &MFI = MF.getFrameInfo();
+  const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
+
+  int64_t Offset = MFI.getObjectOffset(FI);
+
+  if (MFI.getStackID(FI) == TargetStackID::Default) {
+    // For soft stack variables, offset is relative to the frame pointer.
+    // The frame pointer points to the base of the frame, so we need to add
+    // the stack size to get the correct offset.
+    Offset += MFI.getStackSize();
+    FrameReg = TRI->getFrameRegister(MF);
+  } else {
+    // For static stack and zero-page allocations, use a zero base register.
+    // The offset is the absolute address in these cases.
+    FrameReg = MOS::NoRegister;
+  }
+
+  return StackOffset::getFixed(Offset);
+}
+
+void MOSFrameLowering::BuildCFI(MachineBasicBlock &MBB,
+                                MachineBasicBlock::iterator MBBI,
+                                const DebugLoc &DL,
+                                const MCCFIInstruction &CFIInst,
+                                MachineInstr::MIFlag Flag) const {
+  MachineFunction &MF = *MBB.getParent();
+  unsigned CFIIndex = MF.addFrameInst(CFIInst);
+  BuildMI(MBB, MBBI, DL,
+          MF.getSubtarget().getInstrInfo()->get(TargetOpcode::CFI_INSTRUCTION))
+      .addCFIIndex(CFIIndex)
+      .setMIFlag(Flag);
+}
+
+void MOSFrameLowering::emitCalleeSavedFrameMoves(
+    MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
+    const DebugLoc &DL, bool IsPrologue) const {
+  MachineFunction &MF = *MBB.getParent();
+  const MachineFrameInfo &MFI = MF.getFrameInfo();
+  const MCRegisterInfo *MRI = MF.getContext().getRegisterInfo();
+  const std::vector<CalleeSavedInfo> &CSI = MFI.getCalleeSavedInfo();
+  const auto &FuncInfo = MF.getInfo<MOSFunctionInfo>();
+
+  for (const CalleeSavedInfo &I : CSI) {
+    // Skip registers saved to zero page or target-spilled to hard stack
+    if (FuncInfo->CSRZPOffsets.count(I.getReg()) || I.isTargetSpilled())
+      continue;
+
+    // Skip registers saved to static stack - they have absolute addresses,
+    // not CFA-relative offsets, so we can't describe them with DWARF CFI.
+    if (MFI.getStackID(I.getFrameIdx()) == TargetStackID::MosStatic)
+      continue;
+
+    int64_t Offset = MFI.getObjectOffset(I.getFrameIdx());
+    MCRegister Reg = I.getReg();
+    unsigned DwarfReg = MRI->getDwarfRegNum(Reg, true);
+
+    if (IsPrologue) {
+      BuildCFI(MBB, MBBI, DL,
+               MCCFIInstruction::createOffset(nullptr, DwarfReg, Offset),
+               MachineInstr::FrameSetup);
+    } else {
+      BuildCFI(MBB, MBBI, DL,
+               MCCFIInstruction::createRestore(nullptr, DwarfReg),
+               MachineInstr::FrameDestroy);
+    }
+  }
+}
+
+void MOSFrameLowering::emitReturnAddressSave(
+    MachineFunction &MF, MachineBasicBlock &MBB,
+    MachineBasicBlock::iterator InsertPt, const DebugLoc &DL) const {
+  const MOSSubtarget &STI = MF.getSubtarget<MOSSubtarget>();
+  const TargetInstrInfo &TII = *STI.getInstrInfo();
+  MOSFunctionInfo *FuncInfo = MF.getInfo<MOSFunctionInfo>();
+
+  int RAIndex = FuncInfo->getReturnAddrFrameIndex();
+  assert(RAIndex != -1 && "Return address frame index not created");
+
+  // At function entry, before CSRs are pushed:
+  //   Return address low byte is at StackBase + 1 + S
+  //   Return address high byte is at StackBase + 2 + S
+  // JSR pushes (PC-1), so we add 1 to get the actual return address.
+  uint16_t StackBase = STI.getHardwareStackBase();
+
+  // TSX - transfer S to X
+  BuildMI(MBB, InsertPt, DL, TII.get(MOS::TSX_Implied));
+
+  // LDA StackBase+1,X - load low byte of (return_addr - 1)
+  BuildMI(MBB, InsertPt, DL, TII.get(MOS::LDAAbsIdx), MOS::A)
+      .addImm(StackBase + 1)
+      .addReg(MOS::X);
+
+  // CLC; ADC #1 - add 1 to low byte
+  BuildMI(MBB, InsertPt, DL, TII.get(MOS::CLC_Implied));
+  BuildMI(MBB, InsertPt, DL, TII.get(MOS::ADCImm))
+      .addDef(MOS::A)
+      .addDef(MOS::C)
+      .addDef(MOS::V)
+      .addReg(MOS::A)
+      .addImm(1)
+      .addReg(MOS::C, RegState::Undef);
+
+  // STA frame_slot+0 - store low byte
+  BuildMI(MBB, InsertPt, DL, TII.get(MOS::STAbs))
+      .addReg(MOS::A)
+      .addFrameIndex(RAIndex, 0);
+
+  // LDA StackBase+2,X - load high byte
+  BuildMI(MBB, InsertPt, DL, TII.get(MOS::LDAAbsIdx), MOS::A)
+      .addImm(StackBase + 2)
+      .addReg(MOS::X);
+
+  // ADC #0 - propagate carry to high byte
+  BuildMI(MBB, InsertPt, DL, TII.get(MOS::ADCImm))
+      .addDef(MOS::A)
+      .addDef(MOS::C)
+      .addDef(MOS::V)
+      .addReg(MOS::A)
+      .addImm(0)
+      .addReg(MOS::C);
+
+  // STA frame_slot+1 - store high byte
+  BuildMI(MBB, InsertPt, DL, TII.get(MOS::STAbs))
+      .addReg(MOS::A)
+      .addFrameIndex(RAIndex, 1);
 }

--- a/llvm/lib/Target/MOS/MOSFrameLowering.h
+++ b/llvm/lib/Target/MOS/MOSFrameLowering.h
@@ -57,6 +57,9 @@ public:
   void emitPrologue(MachineFunction &MF, MachineBasicBlock &MBB) const override;
   void emitEpilogue(MachineFunction &MF, MachineBasicBlock &MBB) const override;
 
+  StackOffset getFrameIndexReference(const MachineFunction &MF, int FI,
+                                     Register &FrameReg) const override;
+
   // Computes the size of the static stack.
   uint64_t staticSize(const MachineFrameInfo &MFI) const;
 
@@ -67,6 +70,18 @@ private:
   bool hasFPImpl(const MachineFunction &MF) const override;
 
   void offsetSP(MachineIRBuilder &Builder, int64_t Offset) const;
+
+  void BuildCFI(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
+                const DebugLoc &DL, const MCCFIInstruction &CFIInst,
+                MachineInstr::MIFlag Flag = MachineInstr::NoFlags) const;
+
+  void emitCalleeSavedFrameMoves(MachineBasicBlock &MBB,
+                                 MachineBasicBlock::iterator MBBI,
+                                 const DebugLoc &DL, bool IsPrologue) const;
+
+  void emitReturnAddressSave(MachineFunction &MF, MachineBasicBlock &MBB,
+                             MachineBasicBlock::iterator InsertPt,
+                             const DebugLoc &DL) const;
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/MOS/MOSLegalizerInfo.cpp
+++ b/llvm/lib/Target/MOS/MOSLegalizerInfo.cpp
@@ -17,6 +17,7 @@
 
 #include "MOSLegalizerInfo.h"
 
+#include "MOS.h"
 #include "MCTargetDesc/MOSMCTargetDesc.h"
 #include "MOSFrameLowering.h"
 #include "MOSInstrInfo.h"
@@ -514,6 +515,51 @@ bool MOSLegalizerInfo::legalizeIntrinsic(LegalizerHelper &Helper,
             MachineMemOperand::MOLoad | MachineMemOperand::MODereferenceable,
             Ty.getSizeInBytes(), Align()));
 
+    MI.eraseFromParent();
+    return true;
+  }
+  case Intrinsic::frameaddress: {
+    // __builtin_frame_address(0) returns the current frame pointer.
+    // MOS uses RS15 as frame pointer when hasFP(), otherwise RS0 (soft SP).
+    MachineFunction &MF = *MI.getMF();
+    const MOSRegisterInfo *TRI =
+        MF.getSubtarget<MOSSubtarget>().getRegisterInfo();
+    MF.getFrameInfo().setFrameAddressIsTaken(true);
+
+    Register FrameReg = TRI->getFrameRegister(MF);
+    Register Dst = MI.getOperand(0).getReg();
+    Builder.buildCopy(Dst, FrameReg);
+    MI.eraseFromParent();
+    return true;
+  }
+  case Intrinsic::returnaddress: {
+    // __builtin_return_address(0) returns the return address.
+    // On MOS, the return address is on the hardware stack. The prologue
+    // saves it to a frame slot when isReturnAddressIsTaken() is true.
+    // Here we create that frame slot (if not already created) and load from it.
+    MachineFunction &MF = *MI.getMF();
+    MachineFrameInfo &MFI = MF.getFrameInfo();
+    MOSFunctionInfo *FuncInfo = MF.getInfo<MOSFunctionInfo>();
+    MFI.setReturnAddressIsTaken(true);
+
+    // Get or create the frame slot for the return address.
+    int RAIndex = FuncInfo->getReturnAddrFrameIndex();
+    if (RAIndex == -1) {
+      // Return address is 16-bit (pointer size).
+      RAIndex = MFI.CreateStackObject(2, Align(1), false);
+      FuncInfo->setReturnAddrFrameIndex(RAIndex);
+    }
+
+    // Load the return address from the frame slot into a pointer-typed register.
+    Register Dst = MI.getOperand(0).getReg();
+    MachinePointerInfo PtrInfo = MachinePointerInfo::getFixedStack(MF, RAIndex);
+    auto *MMO = MF.getMachineMemOperand(
+        PtrInfo, MachineMemOperand::MOLoad | MachineMemOperand::MODereferenceable,
+        2, Align(1));
+
+    // Build frame index, then load from it into destination.
+    auto FIReg = Builder.buildFrameIndex(P, RAIndex);
+    Builder.buildLoad(Dst, FIReg, *MMO);
     MI.eraseFromParent();
     return true;
   }

--- a/llvm/lib/Target/MOS/MOSMachineFunctionInfo.h
+++ b/llvm/lib/Target/MOS/MOSMachineFunctionInfo.h
@@ -33,6 +33,14 @@ struct MOSFunctionInfo : public MachineFunctionInfo {
   const GlobalValue *StaticStackValue = nullptr;
   const GlobalValue *ZeroPageStackValue = nullptr;
   DenseMap<Register, size_t> CSRZPOffsets;
+
+  /// Frame index for the slot where the return address is saved.
+  /// Only valid when MachineFrameInfo::isReturnAddressIsTaken() is true.
+  /// -1 means the frame index hasn't been created yet.
+  int ReturnAddrFrameIndex = -1;
+
+  int getReturnAddrFrameIndex() const { return ReturnAddrFrameIndex; }
+  void setReturnAddrFrameIndex(int FI) { ReturnAddrFrameIndex = FI; }
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/MOS/MOSRegisterInfo.td
+++ b/llvm/lib/Target/MOS/MOSRegisterInfo.td
@@ -6,6 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+// MOS register numbers are expected to follow the DWARF Specification for MOS
+// Compatible Processors, at https://www.llvm-mos.org/wiki/DWARF_specification .
+// Some DWARF-defined registers overlap one another in this specification.
+// This behavior is by design.  There is no penalty in ELF or DWARF for having
+// overlapping register ranges, and coding is often easier than with purely 
+// unique numbering.
+
 //===----------------------------------------------------------------------===//
 //  Subregister indices
 //===----------------------------------------------------------------------===//
@@ -48,44 +55,58 @@ def sublsb : MOSSubRegIndex<1>;
 // with legacy assembly code that depends on the register names as variables.
 // (The MOS instructions generally don't name the target register as a
 // parameter. The target registers are implied by the opcode.)
-class MOSReg<bits<16> num, string name>
-  : Register<!strconcat("llvm_mos_", name)>, DwarfRegNum<[num]> {
-  field bits<16> Num = num;
-  let HWEncoding = num;
+class MOSReg<bits<32> dwarfnum, string name, bits<16> hwenc = 0>
+  : Register<!strconcat("llvm_mos_", name)>, DwarfRegNum<[dwarfnum]> {
+  field bits<32> Num = dwarfnum;
+  let HWEncoding = hwenc;
   let Namespace = "MOS";
   let AltNames = [name];
 }
 
 // An 8-bit value register (GPR or imaginary). Contains a 1-bit LSB subregister
 // to allow them to store boolean values.
-multiclass MOSReg8<bits<16> num, string name> {
-  def LSB : MOSReg<!add(num, 1), name#"LSB">;
+multiclass MOSReg8<bits<32> dwarfnum, string name, bits<16> hwenc = 0> {
+  def LSB : MOSReg<!add(0x100, dwarfnum), name#"LSB">;
 
-  def NAME : MOSReg<num, name> {
+  def NAME : MOSReg<dwarfnum, name, hwenc> {
     let SubRegs = [!cast<Register>(NAME#LSB)];
     let SubRegIndices = [sublsb];
   }
 }
 
+// MOS 8-bit accumulator
 defm A : MOSReg8<0, "a">;
-defm X : MOSReg8<2, "x">;
-defm Y : MOSReg8<4, "y">;
-def S : MOSReg<6, "s">;
 
-def C : MOSReg<7, "C">;
-def N : MOSReg<8, "N">;
-def V : MOSReg<9, "V">;
-def Z : MOSReg<10, "Z">;
+// MOS 8-bit X register
+defm X : MOSReg8<1, "x">;
+
+// MOS 8-bit Y register
+defm Y : MOSReg8<2, "y">;
+
+// MOS 8-bit stack register.  Some debuggers falsely claim this to be
+// a 16-bit value that always has 0x01 in the high byte.
+def S : MOSReg<4, "s">;
+
+// Program counter - not directly accessible but needed for DWARF CFI.
+// DWARF register 5 per MOS DWARF specification.
+def PC : MOSReg<5, "pc">;
+
+def C : MOSReg<0x200, "C">;
+def N : MOSReg<0x206, "N">;
+def V : MOSReg<0x205, "V">;
+def Z : MOSReg<0x201, "Z">;
 
 // N and Z are always set together, so model them as one register with two
 // one-bit subregisters.
-def NZ : MOSReg<11, "NZ"> {
+def NZ : MOSReg<0x207, "NZ"> {
   let SubRegs = [N, Z];
   let SubRegIndices = [subn, subz];
   let CoveredBySubRegs = true;
 }
 
-def P : MOSReg<12, "P"> {
+// The 8-bit processor status register, known occasionally as P and
+// occasionally as SR
+def P : MOSReg<3, "P"> {
   let SubRegs = [C, NZ, V];
   let SubRegIndices = [subcarry, subnz, subv];
 }
@@ -110,39 +131,50 @@ def P : MOSReg<12, "P"> {
 // and the linker script for a given memory layout later assigns these to their
 // real locations.
 
-// The first 16-bit imaginary register is reserved as the soft stack pointer.
-// The second 16-bit imaginary register is reserved as a frame pointer whenever
-// necessary, on a function-by-function basis.
+// The first 16-bit imaginary register (RS0) is reserved as the soft stack pointer.
+// RS15 is reserved as a frame pointer whenever necessary, on a function-by-function
+// basis (when hasFP() returns true, e.g., for VLAs or __builtin_frame_address).
+
+defvar MaxImag8Regs = 256;
+// DWARF register offsets according to MOS DWARF specification
+// Type 0x02: RC imaginary registers start at 0x00020000
+defvar Imag8RegsOffset = 0x20000;
+// RC LSB registers start at 0x00021000
+defvar Imag8LSBOffset = 0x21000;
+
+defvar MaxImag16Regs = !sra(MaxImag8Regs, 1);
+// Type 0x03: RS imaginary registers start at 0x00030000
+defvar Imag16RegsOffset = 0x30000;
 
 // 8-bit imaginary registers.
-multiclass MOSImagReg8<bits<16> num, string name> : MOSReg8<num, name>;
+multiclass MOSImagReg8<bits<32> num, string name> {
+  def LSB : MOSReg<!add(Imag8LSBOffset, num), name#"LSB">;
+
+  def NAME : MOSReg<!add(Imag8RegsOffset, num), name> {
+    let SubRegs = [!cast<Register>(NAME#LSB)];
+    let SubRegIndices = [sublsb];
+  }
+}
 
 // 16-bit imaginary registers (consecutive pairs of 8-bit registers).
-class MOSImagReg16<bits<16> num, string name, list<Register> subregs>
-    : MOSReg<num, name> {
+class MOSImagReg16<bits<32> num, string name, list<Register> subregs>
+    : MOSReg<!add(Imag16RegsOffset, num), name, 0> {
   let SubRegs = subregs;
   let SubRegIndices = [sublo, subhi];
   let CoveredBySubRegs = 1;
 }
 
-defvar MaxImag8Regs = 256;
-// The starting DWARF number for the imaginary registers.
-defvar Imag8RegsOffset = 0x10;
-
-defvar MaxImag16Regs = !sra(MaxImag8Regs, 1);
-defvar Imag16RegsOffset = !add(Imag8RegsOffset, !shl(MaxImag8Regs,1));
-
 // Now we enumerate the imaginary registers.
 // Imaginary 8-bit registers, starting with the prefix rc
 foreach I = 0...!add(MaxImag8Regs, -1) in {
   // There exist MaxImag8Regs rcXX registers...
-  defm RC#I: MOSImagReg8<!add(!shl(I,1), Imag8RegsOffset), "rc"#!cast<string>(I)>;
+  defm RC#I: MOSImagReg8<I, "rc"#!cast<string>(I)>;
 }
 
 // Imaginary 16-bit registers, starting with the prefix rs
 foreach I = 0...!add(MaxImag16Regs, -1) in {
   // There exist MaxImag16Regs rsXX registers...
-  def RS#I: MOSImagReg16<!add(I, Imag16RegsOffset), "rs"#!cast<string>(I),
+  def RS#I: MOSImagReg16<I, "rs"#!cast<string>(I),
       [!cast<Register>("RC"#!shl(I, 1)),
        !cast<Register>("RC"#!add(!shl(I,1),1))]>;
 }
@@ -205,8 +237,10 @@ def MOSAsmParamRegClass : MOSReg8Class<(add X, Y, S)>;
 def Anyi1 : MOSReg1Class<(add (sequence "RC%uLSB", 0, !add(MaxImag8Regs, -1)), CV_GPR_LSB)>;
 def Anyi8 : MOSReg8Class<(add Imag8, GPR)>;
 
-def Fake : MOSReg<13, "Fake">;
+def Fake : MOSReg<0x300, "Fake">;
 let isAllocatable = false in {
   def Fakei32 : MOSRegClass<[i32], 8, (add Fake)>;
   def Fakei64 : MOSRegClass<[i64], 8, (add Fake)>;
+  // PC is not directly accessible but needed for DWARF CFI
+  def PCc : MOSReg16Class<(add PC)>;
 }

--- a/llvm/lib/Target/MOS/MOSSubtarget.h
+++ b/llvm/lib/Target/MOS/MOSSubtarget.h
@@ -77,6 +77,11 @@ public:
     return hasHUC6280() ? 0x2000 : 0;
   }
 
+  /// Get the base address of the hardware stack.
+  /// On 6502, this is always 0x0100 (stack page).
+  /// On 65816, this may differ based on configuration.
+  uint16_t getHardwareStackBase() const { return 0x0100; }
+
   bool enableMachineScheduler() const override { return true; }
   bool enableSubRegLiveness() const override { return true; }
 

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -2509,6 +2509,7 @@ ExceptionHandling Triple::getDefaultExceptionHandling() const {
   case Triple::hexagon:
   case Triple::lanai:
   case Triple::m68k:
+  case Triple::mos:
   case Triple::msp430:
   case Triple::systemz:
   case Triple::xcore:

--- a/llvm/test/CodeGen/MOS/frame-pointer-cfi.ll
+++ b/llvm/test/CodeGen/MOS/frame-pointer-cfi.ll
@@ -1,0 +1,21 @@
+; RUN: llc -verify-machineinstrs < %s | FileCheck %s
+
+; Test that frame pointer functions emit correct CFI with offset.
+; When hasFP() is true (e.g., VLA usage), the CFI should use .cfi_def_cfa
+; with an explicit offset, not .cfi_def_cfa_register which loses the offset.
+
+target datalayout = "e-m:e-p:16:8-p1:8:8-i16:8-i32:8-i64:8-f32:8-f64:8-a:8-Fi8-n8"
+target triple = "mos"
+
+declare void @use(ptr)
+
+; VLA triggers frame pointer usage (hasFP() returns true)
+define void @test_vla(i16 %n) {
+; CHECK-LABEL: test_vla:
+; CHECK: .cfi_def_cfa
+; After setting FP = SP, we should see .cfi_def_cfa with register AND offset
+; CHECK-NOT: .cfi_def_cfa_register
+  %vla = alloca i16, i16 %n
+  call void @use(ptr %vla)
+  ret void
+}

--- a/llvm/test/CodeGen/MOS/large-stack-frame.ll
+++ b/llvm/test/CodeGen/MOS/large-stack-frame.ll
@@ -1,0 +1,19 @@
+; RUN: llc -mtriple=mos < %s | FileCheck %s
+
+; Test that MOS can handle large stack allocations up to the 64KB limit.
+
+define void @large_stack() {
+; CHECK-LABEL: large_stack:
+; CHECK: clc
+; CHECK: lda __rc0
+; CHECK: adc
+; CHECK: sta __rc0
+; CHECK: lda __rc1
+; CHECK: adc
+; CHECK: sta __rc1
+  %arr = alloca [60000 x i8]
+  call void @use(ptr %arr)
+  ret void
+}
+
+declare void @use(ptr)

--- a/llvm/test/CodeGen/MOS/prologepilog-ir.mir
+++ b/llvm/test/CodeGen/MOS/prologepilog-ir.mir
@@ -58,6 +58,10 @@ body:             |
     ; 6502-NEXT: $a, $c, $v = ADCImm $a, 255, $c
     ; 6502-NEXT: $rc1 = COPY killed $a
     ; 6502-NEXT: $a = PL
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 2
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; 6502-NEXT: STAbs $a, target-index(mos-static-stack) :: (store (s8) into %stack.0)
     ; 6502-NEXT: $a = LDAbs target-index(mos-static-stack) + 1 :: (load (s8) from %stack.1)
     ; 6502-NEXT: $c = LDCImm 0
@@ -79,6 +83,10 @@ body:             |
     ; 65C02-NEXT: $a, $c, $v = ADCImm $a, 255, $c
     ; 65C02-NEXT: $rc1 = COPY killed $a
     ; 65C02-NEXT: $a = PL
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 2
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; 65C02-NEXT: STAbs $a, target-index(mos-static-stack) :: (store (s8) into %stack.0)
     ; 65C02-NEXT: $a = LDAbs target-index(mos-static-stack) + 1 :: (load (s8) from %stack.1)
     ; 65C02-NEXT: $c = LDCImm 0
@@ -112,8 +120,10 @@ body: |
     ; 6502-NEXT: frame-setup PH killed $a
     ; 6502-NEXT: $rs15 = COPY $rs0
     ; 6502-NEXT: $a = LDAbs target-index(mos-static-stack) + 2 :: (load (s8) from %stack.2 + 1)
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs15, 0
     ; 6502-NEXT: $rs0 = COPY $rs15
     ; 6502-NEXT: $a = frame-destroy PL
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION def_cfa $rs0, 0
     ; 6502-NEXT: $rc31 = frame-destroy COPY killed $a
     ; 6502-NEXT: $a = frame-destroy PL
     ; 6502-NEXT: $rc30 = frame-destroy COPY killed $a
@@ -126,8 +136,10 @@ body: |
     ; 65C02-NEXT: frame-setup PH killed $x
     ; 65C02-NEXT: $rs15 = COPY $rs0
     ; 65C02-NEXT: $a = LDAbs target-index(mos-static-stack) + 2 :: (load (s8) from %stack.2 + 1)
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs15, 0
     ; 65C02-NEXT: $rs0 = COPY $rs15
     ; 65C02-NEXT: $x = frame-destroy PL
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION def_cfa $rs0, 0
     ; 65C02-NEXT: $rc31 = frame-destroy COPY killed $x
     ; 65C02-NEXT: $x = frame-destroy PL
     ; 65C02-NEXT: $rc30 = frame-destroy COPY killed $x
@@ -162,6 +174,11 @@ body: |
     ; 6502-NEXT: $a = COPY $rc17
     ; 6502-NEXT: $y = LDImm 0
     ; 6502-NEXT: STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.0)
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 257
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x05, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x06, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc17, -1
     ; 6502-NEXT: $x = LDImm 42
     ; 6502-NEXT: $a = LDImm 43
     ; 6502-NEXT: $y = LDImm 44
@@ -175,6 +192,7 @@ body: |
     ; 6502-NEXT: $a = frame-destroy PL
     ; 6502-NEXT: $x = frame-destroy COPY killed $a
     ; 6502-NEXT: $a = frame-destroy PL
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc17
     ; 6502-NEXT: PH $a
     ; 6502-NEXT: $c = LDCImm 0
     ; 6502-NEXT: $a = COPY $rc0
@@ -207,6 +225,11 @@ body: |
     ; 65C02-NEXT: $a = COPY $rc17
     ; 65C02-NEXT: $y = LDImm 0
     ; 65C02-NEXT: STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.0)
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 257
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x05, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x06, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc17, -1
     ; 65C02-NEXT: $x = LDImm 42
     ; 65C02-NEXT: $a = LDImm 43
     ; 65C02-NEXT: $y = LDImm 44
@@ -218,6 +241,7 @@ body: |
     ; 65C02-NEXT: $y = frame-destroy PL
     ; 65C02-NEXT: $x = frame-destroy PL
     ; 65C02-NEXT: $a = frame-destroy PL
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc17
     ; 65C02-NEXT: PH $a
     ; 65C02-NEXT: $c = LDCImm 0
     ; 65C02-NEXT: $a = COPY $rc0
@@ -263,6 +287,11 @@ body: |
   ; 6502-NEXT:   $a = COPY $rc17
   ; 6502-NEXT:   $y = LDImm 0
   ; 6502-NEXT:   STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.0)
+  ; 6502-NEXT:   frame-setup CFI_INSTRUCTION def_cfa $rs0, 257
+  ; 6502-NEXT:   frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+  ; 6502-NEXT:   frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x05, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+  ; 6502-NEXT:   frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x06, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+  ; 6502-NEXT:   frame-setup CFI_INSTRUCTION offset $rc17, -1
   ; 6502-NEXT: {{  $}}
   ; 6502-NEXT: bb.1.entry:
   ; 6502-NEXT:   $x = LDImm 42
@@ -276,6 +305,7 @@ body: |
   ; 6502-NEXT:   $a = frame-destroy PL
   ; 6502-NEXT:   $x = frame-destroy COPY killed $a
   ; 6502-NEXT:   $a = frame-destroy PL
+  ; 6502-NEXT:   frame-destroy CFI_INSTRUCTION restore $rc17
   ; 6502-NEXT:   PH $a
   ; 6502-NEXT:   $c = LDCImm 0
   ; 6502-NEXT:   $a = COPY $rc0
@@ -310,6 +340,11 @@ body: |
   ; 65C02-NEXT:   $a = COPY $rc17
   ; 65C02-NEXT:   $y = LDImm 0
   ; 65C02-NEXT:   STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.0)
+  ; 65C02-NEXT:   frame-setup CFI_INSTRUCTION def_cfa $rs0, 257
+  ; 65C02-NEXT:   frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+  ; 65C02-NEXT:   frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x05, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+  ; 65C02-NEXT:   frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x06, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+  ; 65C02-NEXT:   frame-setup CFI_INSTRUCTION offset $rc17, -1
   ; 65C02-NEXT: {{  $}}
   ; 65C02-NEXT: bb.1.entry:
   ; 65C02-NEXT:   $x = LDImm 42
@@ -321,6 +356,7 @@ body: |
   ; 65C02-NEXT:   $y = frame-destroy PL
   ; 65C02-NEXT:   $x = frame-destroy PL
   ; 65C02-NEXT:   $a = frame-destroy PL
+  ; 65C02-NEXT:   frame-destroy CFI_INSTRUCTION restore $rc17
   ; 65C02-NEXT:   PH $a
   ; 65C02-NEXT:   $c = LDCImm 0
   ; 65C02-NEXT:   $a = COPY $rc0
@@ -369,6 +405,12 @@ body: |
   ; 6502-NEXT:   $a = COPY $rc31
   ; 6502-NEXT:   $y = LDImm 0
   ; 6502-NEXT:   STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.1)
+  ; 6502-NEXT:   frame-setup CFI_INSTRUCTION def_cfa $rs0, 258
+  ; 6502-NEXT:   frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+  ; 6502-NEXT:   frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x05, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+  ; 6502-NEXT:   frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x06, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+  ; 6502-NEXT:   frame-setup CFI_INSTRUCTION offset $rc30, -1
+  ; 6502-NEXT:   frame-setup CFI_INSTRUCTION offset $rc31, -2
   ; 6502-NEXT: {{  $}}
   ; 6502-NEXT: bb.1.entry:
   ; 6502-NEXT:   $rs15 = IMPLICIT_DEF
@@ -385,6 +427,8 @@ body: |
   ; 6502-NEXT:   $a = frame-destroy PL
   ; 6502-NEXT:   $y = frame-destroy COPY killed $a
   ; 6502-NEXT:   $a = frame-destroy PL
+  ; 6502-NEXT:   frame-destroy CFI_INSTRUCTION restore $rc30
+  ; 6502-NEXT:   frame-destroy CFI_INSTRUCTION restore $rc31
   ; 6502-NEXT:   PH $a
   ; 6502-NEXT:   $c = LDCImm 0
   ; 6502-NEXT:   $a = COPY $rc0
@@ -423,6 +467,12 @@ body: |
   ; 65C02-NEXT:   $a = COPY $rc31
   ; 65C02-NEXT:   $y = LDImm 0
   ; 65C02-NEXT:   STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.1)
+  ; 65C02-NEXT:   frame-setup CFI_INSTRUCTION def_cfa $rs0, 258
+  ; 65C02-NEXT:   frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+  ; 65C02-NEXT:   frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x05, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+  ; 65C02-NEXT:   frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x06, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+  ; 65C02-NEXT:   frame-setup CFI_INSTRUCTION offset $rc30, -1
+  ; 65C02-NEXT:   frame-setup CFI_INSTRUCTION offset $rc31, -2
   ; 65C02-NEXT: {{  $}}
   ; 65C02-NEXT: bb.1.entry:
   ; 65C02-NEXT:   $rs15 = IMPLICIT_DEF
@@ -438,6 +488,8 @@ body: |
   ; 65C02-NEXT:   $rc16 = frame-destroy COPY killed $y
   ; 65C02-NEXT:   $y = frame-destroy PL
   ; 65C02-NEXT:   $a = frame-destroy PL
+  ; 65C02-NEXT:   frame-destroy CFI_INSTRUCTION restore $rc30
+  ; 65C02-NEXT:   frame-destroy CFI_INSTRUCTION restore $rc31
   ; 65C02-NEXT:   PH $a
   ; 65C02-NEXT:   $c = LDCImm 0
   ; 65C02-NEXT:   $a = COPY $rc0
@@ -486,6 +538,12 @@ body: |
   ; 6502-NEXT:   $a = COPY $rc31
   ; 6502-NEXT:   $y = LDImm 0
   ; 6502-NEXT:   STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.1)
+  ; 6502-NEXT:   frame-setup CFI_INSTRUCTION def_cfa $rs0, 258
+  ; 6502-NEXT:   frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+  ; 6502-NEXT:   frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x05, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+  ; 6502-NEXT:   frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x06, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+  ; 6502-NEXT:   frame-setup CFI_INSTRUCTION offset $rc30, -1
+  ; 6502-NEXT:   frame-setup CFI_INSTRUCTION offset $rc31, -2
   ; 6502-NEXT: {{  $}}
   ; 6502-NEXT: bb.1.entry:
   ; 6502-NEXT:   $rs15 = IMPLICIT_DEF
@@ -504,6 +562,8 @@ body: |
   ; 6502-NEXT:   $a = frame-destroy PL
   ; 6502-NEXT:   $y = frame-destroy COPY killed $a
   ; 6502-NEXT:   $a = frame-destroy PL
+  ; 6502-NEXT:   frame-destroy CFI_INSTRUCTION restore $rc30
+  ; 6502-NEXT:   frame-destroy CFI_INSTRUCTION restore $rc31
   ; 6502-NEXT:   PH $a
   ; 6502-NEXT:   $c = LDCImm 0
   ; 6502-NEXT:   $a = COPY $rc0
@@ -542,6 +602,12 @@ body: |
   ; 65C02-NEXT:   $a = COPY $rc31
   ; 65C02-NEXT:   $y = LDImm 0
   ; 65C02-NEXT:   STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.1)
+  ; 65C02-NEXT:   frame-setup CFI_INSTRUCTION def_cfa $rs0, 258
+  ; 65C02-NEXT:   frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+  ; 65C02-NEXT:   frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x05, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+  ; 65C02-NEXT:   frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x06, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+  ; 65C02-NEXT:   frame-setup CFI_INSTRUCTION offset $rc30, -1
+  ; 65C02-NEXT:   frame-setup CFI_INSTRUCTION offset $rc31, -2
   ; 65C02-NEXT: {{  $}}
   ; 65C02-NEXT: bb.1.entry:
   ; 65C02-NEXT:   $rs15 = IMPLICIT_DEF
@@ -559,6 +625,8 @@ body: |
   ; 65C02-NEXT:   $rc16 = frame-destroy COPY killed $y
   ; 65C02-NEXT:   $y = frame-destroy PL
   ; 65C02-NEXT:   $a = frame-destroy PL
+  ; 65C02-NEXT:   frame-destroy CFI_INSTRUCTION restore $rc30
+  ; 65C02-NEXT:   frame-destroy CFI_INSTRUCTION restore $rc31
   ; 65C02-NEXT:   PH $a
   ; 65C02-NEXT:   $c = LDCImm 0
   ; 65C02-NEXT:   $a = COPY $rc0
@@ -654,6 +722,27 @@ body: |
     ; 6502-NEXT: $a = COPY $rc19
     ; 6502-NEXT: $y = LDImm 0
     ; 6502-NEXT: STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.16)
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 273
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x05, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x06, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc3, -1
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc4, -2
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc5, -3
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc6, -4
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc7, -5
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc8, -6
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc9, -7
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc10, -8
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc11, -9
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc12, -10
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc13, -11
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc14, -12
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc15, -13
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc16, -14
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc17, -15
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc18, -16
+    ; 6502-NEXT: frame-setup CFI_INSTRUCTION offset $rc19, -17
     ; 6502-NEXT: JSR &fn, mos_csr
     ; 6502-NEXT: $y = LDImm 0
     ; 6502-NEXT: $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.16)
@@ -713,6 +802,23 @@ body: |
     ; 6502-NEXT: $a = frame-destroy PL
     ; 6502-NEXT: $x = frame-destroy COPY killed $a
     ; 6502-NEXT: $a = frame-destroy PL
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc3
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc4
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc5
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc6
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc7
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc8
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc9
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc10
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc11
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc12
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc13
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc14
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc15
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc16
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc17
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc18
+    ; 6502-NEXT: frame-destroy CFI_INSTRUCTION restore $rc19
     ; 6502-NEXT: PH $a
     ; 6502-NEXT: $c = LDCImm 0
     ; 6502-NEXT: $a = COPY $rc0
@@ -793,6 +899,27 @@ body: |
     ; 65C02-NEXT: $a = COPY $rc19
     ; 65C02-NEXT: $y = LDImm 0
     ; 65C02-NEXT: STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.16)
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 273
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x05, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x06, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc3, -1
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc4, -2
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc5, -3
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc6, -4
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc7, -5
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc8, -6
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc9, -7
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc10, -8
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc11, -9
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc12, -10
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc13, -11
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc14, -12
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc15, -13
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc16, -14
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc17, -15
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc18, -16
+    ; 65C02-NEXT: frame-setup CFI_INSTRUCTION offset $rc19, -17
     ; 65C02-NEXT: JSR &fn, mos_csr
     ; 65C02-NEXT: $y = LDImm 0
     ; 65C02-NEXT: $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.16)
@@ -850,6 +977,23 @@ body: |
     ; 65C02-NEXT: $y = frame-destroy PL
     ; 65C02-NEXT: $x = frame-destroy PL
     ; 65C02-NEXT: $a = frame-destroy PL
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc3
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc4
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc5
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc6
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc7
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc8
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc9
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc10
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc11
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc12
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc13
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc14
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc15
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc16
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc17
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc18
+    ; 65C02-NEXT: frame-destroy CFI_INSTRUCTION restore $rc19
     ; 65C02-NEXT: PH $a
     ; 65C02-NEXT: $c = LDCImm 0
     ; 65C02-NEXT: $a = COPY $rc0

--- a/llvm/test/CodeGen/MOS/prologepilog.mir
+++ b/llvm/test/CodeGen/MOS/prologepilog.mir
@@ -15,6 +15,10 @@ body: |
     ; CHECK-NEXT: $a = COPY $rc1
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 254, $c
     ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 258
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; CHECK-NEXT: $c = LDCImm 0
     ; CHECK-NEXT: $a = COPY $rc0
     ; CHECK-NEXT: $a, $c, dead $v = ADCImm $a, 1, $c
@@ -36,6 +40,10 @@ body: |
     ; CHECK-NEXT: $a = COPY $rc1
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 254, $c
     ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 258
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; CHECK-NEXT: $c = LDCImm 0
     ; CHECK-NEXT: $rc2 = COPY $rc0
     $rc2, $c, dead $v = AddrLostk %stack.1, 0
@@ -55,6 +63,10 @@ body: |
     ; CHECK-NEXT: $a = COPY $rc1
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 254, $c
     ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 258
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; CHECK-NEXT: $c = LDCImm 0
     ; CHECK-NEXT: $a = COPY $rc1
     ; CHECK-NEXT: $a, dead $c, dead $v = ADCImm $a, 1, $c
@@ -77,6 +89,10 @@ body: |
     ; CHECK-NEXT: $a = COPY $rc1
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 254, $c
     ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 258
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; CHECK-NEXT: $c = LDCImm 0
     ; CHECK-NEXT: $rc3 = COPY $rc1
     $c = LDCImm 0
@@ -96,6 +112,10 @@ body: |
     ; CHECK-NEXT: $a = COPY $rc1
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 251, $c
     ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 1234
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; CHECK-NEXT: $c = LDCImm 0
     ; CHECK-NEXT: $a = COPY $rc0
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 210, $c
@@ -117,6 +137,10 @@ body: |
     ; CHECK-NEXT: $a = COPY $rc1
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 254, $c
     ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 512
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; CHECK-NEXT: $c = LDCImm 0
     ; CHECK-NEXT: $a = COPY $rc1
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 2, $c
@@ -139,6 +163,10 @@ body:             |
     ; CHECK-NEXT: $a = COPY $rc1
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 255, $c
     ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 3
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; CHECK-NEXT: $y = LDImm 1
     ; CHECK-NEXT: $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.1 + 1)
     $a, early-clobber $rs1 = LDStk %stack.1, 1 :: (load 1 from %stack.1 + 1)
@@ -158,6 +186,10 @@ body:             |
     ; CHECK-NEXT: $a = COPY $rc1
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 254, $c
     ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 258
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; CHECK-NEXT: $c = LDCImm 0
     ; CHECK-NEXT: $rc2 = COPY $rc0
     ; CHECK-NEXT: $a = COPY $rc1
@@ -182,6 +214,10 @@ body:             |
     ; CHECK-NEXT: $a = COPY $rc1
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 255, $c
     ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 3
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; CHECK-NEXT: $y = LDImm 1
     ; CHECK-NEXT: $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.1 + 1)
     ; CHECK-NEXT: $x = COPY killed $a
@@ -202,6 +238,10 @@ body:             |
     ; CHECK-NEXT: $a = COPY $rc1
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 255, $c
     ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 3
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; CHECK-NEXT: $y = LDImm 1
     ; CHECK-NEXT: $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.1 + 1)
     ; CHECK-NEXT: $x = COPY killed $a
@@ -222,6 +262,10 @@ body:             |
     ; CHECK-NEXT: $a = COPY $rc1
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 255, $c
     ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 3
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; CHECK-NEXT: $y = LDImm 1
     ; CHECK-NEXT: $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.1 + 1)
     ; CHECK-NEXT: $c = COPY $alsb
@@ -243,6 +287,10 @@ body: |
     ; CHECK-NEXT: $a = COPY $rc1
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 255, $c
     ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 4
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; CHECK-NEXT: $y = LDImm 2
     ; CHECK-NEXT: $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.0 + 2, align 2)
     ; CHECK-NEXT: $rc0 = COPY killed $a
@@ -269,6 +317,10 @@ body:             |
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 255, $c
     ; CHECK-NEXT: $rc1 = COPY killed $a
     ; CHECK-NEXT: $a = PL
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 3
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; CHECK-NEXT: $y = LDImm 1
     ; CHECK-NEXT: STIndirIdx $a, $rs0, killed $y :: (store (s8) into %stack.1 + 1)
     early-clobber $rs1 = STStk $a, %stack.1, 1 :: (store 1 into %stack.1 + 1)
@@ -288,6 +340,10 @@ body:             |
     ; CHECK-NEXT: $a = COPY $rc1
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 255, $c
     ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 3
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; CHECK-NEXT: $c = COPY $xlsb
     ; CHECK-NEXT: $alsb = COPY $c
     ; CHECK-NEXT: $y = LDImm 1
@@ -310,6 +366,10 @@ body:             |
     ; CHECK-NEXT: $a = COPY $rc1
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 254, $c
     ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 258
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; CHECK-NEXT: $c = LDCImm 0
     ; CHECK-NEXT: $rc2 = COPY $rc0
     ; CHECK-NEXT: $a = COPY $rc1
@@ -334,6 +394,10 @@ body: |
     ; CHECK-NEXT: $a = COPY $rc1
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 255, $c
     ; CHECK-NEXT: $rc1 = COPY killed $a
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 4
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x01, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x02, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; CHECK-NEXT: $rs0 = KILL $rs0
     ; CHECK-NEXT: $a = COPY $rc0
     ; CHECK-NEXT: $y = LDImm 2
@@ -364,11 +428,17 @@ body: |
     ; CHECK-NEXT: frame-setup PH killed $a
     ; CHECK-NEXT: $a = frame-setup COPY $rc31
     ; CHECK-NEXT: frame-setup PH killed $a
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 3
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x03, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x04, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
     ; CHECK-NEXT: $rs15 = COPY $rs0
     ; CHECK-NEXT: $y = LDImm 1
     ; CHECK-NEXT: $a = LDIndirIdx $rs15, killed $y :: (load (s8) from %stack.2 + 1)
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs15, 3
     ; CHECK-NEXT: $rs0 = COPY $rs15
     ; CHECK-NEXT: $a = frame-destroy PL
+    ; CHECK-NEXT: frame-destroy CFI_INSTRUCTION def_cfa $rs0, 3
     ; CHECK-NEXT: $rc31 = frame-destroy COPY killed $a
     ; CHECK-NEXT: $a = frame-destroy PL
     ; CHECK-NEXT: $rc30 = frame-destroy COPY killed $a
@@ -412,6 +482,12 @@ body: |
     ; CHECK-NEXT: $a = COPY $rc31
     ; CHECK-NEXT: $y = LDImm 0
     ; CHECK-NEXT: STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.1)
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 2
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x05, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x06, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION offset $rc30, -1
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION offset $rc31, -2
     ; CHECK-NEXT: $rs13 = IMPLICIT_DEF
     ; CHECK-NEXT: $rs14 = IMPLICIT_DEF
     ; CHECK-NEXT: $rs15 = IMPLICIT_DEF
@@ -429,6 +505,8 @@ body: |
     ; CHECK-NEXT: $rc27 = frame-destroy COPY killed $a
     ; CHECK-NEXT: $a = frame-destroy PL
     ; CHECK-NEXT: $rc26 = frame-destroy COPY killed $a
+    ; CHECK-NEXT: frame-destroy CFI_INSTRUCTION restore $rc30
+    ; CHECK-NEXT: frame-destroy CFI_INSTRUCTION restore $rc31
     ; CHECK-NEXT: $c = LDCImm 0
     ; CHECK-NEXT: $a = COPY $rc0
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 2, $c
@@ -478,14 +556,24 @@ body: |
     ; CHECK-NEXT: $a = COPY $rc31
     ; CHECK-NEXT: $y = LDImm 0
     ; CHECK-NEXT: STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.4)
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs0, 4
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x05, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x06, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION offset $rc28, -1
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION offset $rc29, -2
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION offset $rc30, -3
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION offset $rc31, -4
     ; CHECK-NEXT: $rs15 = COPY $rs0
     ; CHECK-NEXT: $rs12 = IMPLICIT_DEF
+    ; CHECK-NEXT: frame-setup CFI_INSTRUCTION def_cfa $rs15, 4
     ; CHECK-NEXT: $rs13 = IMPLICIT_DEF
     ; CHECK-NEXT: $rs14 = IMPLICIT_DEF
     ; CHECK-NEXT: $rs0 = COPY $rs15
     ; CHECK-NEXT: $y = LDImm 0
     ; CHECK-NEXT: $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.4)
     ; CHECK-NEXT: $rc31 = COPY killed $a
+    ; CHECK-NEXT: frame-destroy CFI_INSTRUCTION def_cfa $rs0, 4
     ; CHECK-NEXT: $y = LDImm 1
     ; CHECK-NEXT: $a = LDIndirIdx $rs0, killed $y :: (load (s8) from %stack.3)
     ; CHECK-NEXT: $rc30 = COPY killed $a
@@ -503,6 +591,10 @@ body: |
     ; CHECK-NEXT: $rc25 = frame-destroy COPY killed $a
     ; CHECK-NEXT: $a = frame-destroy PL
     ; CHECK-NEXT: $rc24 = frame-destroy COPY killed $a
+    ; CHECK-NEXT: frame-destroy CFI_INSTRUCTION restore $rc28
+    ; CHECK-NEXT: frame-destroy CFI_INSTRUCTION restore $rc29
+    ; CHECK-NEXT: frame-destroy CFI_INSTRUCTION restore $rc30
+    ; CHECK-NEXT: frame-destroy CFI_INSTRUCTION restore $rc31
     ; CHECK-NEXT: $c = LDCImm 0
     ; CHECK-NEXT: $a = COPY $rc0
     ; CHECK-NEXT: $a, $c, $v = ADCImm $a, 4, $c
@@ -552,6 +644,12 @@ body: |
   ; CHECK-NEXT:   $a = COPY $rc31
   ; CHECK-NEXT:   $y = LDImm 0
   ; CHECK-NEXT:   STIndirIdx killed $a, $rs0, killed $y :: (store (s8) into %stack.1)
+  ; CHECK-NEXT:   frame-setup CFI_INSTRUCTION def_cfa $rs0, 2
+  ; CHECK-NEXT:   frame-setup CFI_INSTRUCTION val_offset $rs0, 0
+  ; CHECK-NEXT:   frame-setup CFI_INSTRUCTION escape 0x10, 0x05, 0x09, 0x74, 0x05, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+  ; CHECK-NEXT:   frame-setup CFI_INSTRUCTION escape 0x16, 0x04, 0x09, 0x74, 0x06, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21
+  ; CHECK-NEXT:   frame-setup CFI_INSTRUCTION offset $rc30, -1
+  ; CHECK-NEXT:   frame-setup CFI_INSTRUCTION offset $rc31, -2
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
@@ -573,6 +671,8 @@ body: |
   ; CHECK-NEXT:   $rc27 = frame-destroy COPY killed $a
   ; CHECK-NEXT:   $a = frame-destroy PL
   ; CHECK-NEXT:   $rc26 = frame-destroy COPY killed $a
+  ; CHECK-NEXT:   frame-destroy CFI_INSTRUCTION restore $rc30
+  ; CHECK-NEXT:   frame-destroy CFI_INSTRUCTION restore $rc31
   ; CHECK-NEXT:   $c = LDCImm 0
   ; CHECK-NEXT:   $a = COPY $rc0
   ; CHECK-NEXT:   $a, $c, $v = ADCImm $a, 2, $c

--- a/llvm/test/CodeGen/MOS/zp-alloc.ll
+++ b/llvm/test/CodeGen/MOS/zp-alloc.ll
@@ -10,7 +10,8 @@ target triple = "mos-sim"
 
 define i64 @foo(i64 %live_across_call) norecurse {
 ; CHECK-LABEL: foo:
-; CHECK:       ; %bb.0: ; %entry
+; CHECK:         .cfi_startproc
+; CHECK-NEXT:  ; %bb.0: ; %entry
 ; CHECK-NEXT:    sta mos8(.Lfoo_zp_stk)
 ; CHECK-NEXT:    stx mos8(.Lfoo_zp_stk+1)
 ; CHECK-NEXT:    ldx __rc2
@@ -52,7 +53,8 @@ entry:
 
 define void @bar() norecurse noinline {
 ; CHECK-LABEL: bar:
-; CHECK:       ; %bb.0: ; %entry
+; CHECK:         .cfi_startproc
+; CHECK-NEXT:  ; %bb.0: ; %entry
 ; CHECK-NEXT:    ldx global
 ; CHECK-NEXT:    stx mos8(global_alias)
 ; CHECK-NEXT:    rts
@@ -66,7 +68,8 @@ declare void @ext() nocallback
 
 define void @csr() norecurse {
 ; CHECK-LABEL: csr:
-; CHECK:       ; %bb.0: ; %entry
+; CHECK:         .cfi_startproc
+; CHECK-NEXT:  ; %bb.0: ; %entry
 ; CHECK-NEXT:    ldx #48
 ; CHECK-NEXT:    ldy #57
 ; CHECK-NEXT:    sty mos8(.Lcsr_zp_stk)
@@ -111,7 +114,8 @@ declare void @ext_ptr(ptr %p) nocallback
 
 define void @alloca() norecurse {
 ; CHECK-LABEL: alloca:
-; CHECK:       ; %bb.0: ; %entry
+; CHECK:         .cfi_startproc
+; CHECK-NEXT:  ; %bb.0: ; %entry
 ; CHECK-NEXT:    ldx #mos8(.Lalloca_zp_stk)
 ; CHECK-NEXT:    ldy #mos8(0)
 ; CHECK-NEXT:    stx __rc2
@@ -127,7 +131,8 @@ entry:
 
 define void @extern_global_user(i8 %i) norecurse {
 ; CHECK-LABEL: extern_global_user:
-; CHECK:       ; %bb.0: ; %entry
+; CHECK:         .cfi_startproc
+; CHECK-NEXT:  ; %bb.0: ; %entry
 ; CHECK-NEXT:    sta extern_global
 ; CHECK-NEXT:    rts
 entry:
@@ -139,7 +144,8 @@ entry:
 
 define void @inr() norecurse "interrupt-norecurse" {
 ; CHECK-LABEL: inr:
-; CHECK:       ; %bb.0: ; %entry
+; CHECK:         .cfi_startproc
+; CHECK-NEXT:  ; %bb.0: ; %entry
 ; CHECK-NEXT:    cld
 ; CHECK-NEXT:    pha
 ; CHECK-NEXT:    clc
@@ -188,6 +194,10 @@ define void @inr() norecurse "interrupt-norecurse" {
 ; CHECK-NEXT:    stx .Linr_sstk+15 ; 1-byte Folded Spill
 ; CHECK-NEXT:    ldx __rc19
 ; CHECK-NEXT:    stx .Linr_sstk+16 ; 1-byte Folded Spill
+; CHECK-NEXT:    .cfi_def_cfa llvm_mos_rs0, 256
+; CHECK-NEXT:    .cfi_val_offset llvm_mos_rs0, 0
+; CHECK-NEXT:    .cfi_escape 0x10, 0x05, 0x09, 0x74, 0x05, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21 ;
+; CHECK-NEXT:    .cfi_escape 0x16, 0x04, 0x09, 0x74, 0x06, 0x08, 0xff, 0x1a, 0x0a, 0x00, 0x01, 0x21 ;
 ; CHECK-NEXT:    ldx global
 ; CHECK-NEXT:    stx mos8(.Linr_zp_stk)
 ; CHECK-NEXT:    jsr inr_callee
@@ -250,7 +260,8 @@ entry:
 
 define void @inr_callee() norecurse noinline {
 ; CHECK-LABEL: inr_callee:
-; CHECK:       ; %bb.0: ; %entry
+; CHECK:         .cfi_startproc
+; CHECK-NEXT:  ; %bb.0: ; %entry
 ; CHECK-NEXT:    rts
 entry:
   ret void
@@ -260,7 +271,8 @@ declare void @ext_callback()
 
 define void @apparent_recursion() norecurse {
 ; CHECK-LABEL: apparent_recursion:
-; CHECK:       ; %bb.0: ; %entry
+; CHECK:         .cfi_startproc
+; CHECK-NEXT:  ; %bb.0: ; %entry
 ; CHECK-NEXT:    ldx global
 ; CHECK-NEXT:    stx mos8(.Lapparent_recursion_zp_stk)
 ; CHECK-NEXT:    jsr apparent_recursion_callee
@@ -276,7 +288,8 @@ entry:
 
 define void @apparent_recursion_callee() norecurse {
 ; CHECK-LABEL: apparent_recursion_callee:
-; CHECK:       ; %bb.0: ; %entry
+; CHECK:         .cfi_startproc
+; CHECK-NEXT:  ; %bb.0: ; %entry
 ; CHECK-NEXT:    ldx global
 ; CHECK-NEXT:    stx mos8(.Lapparent_recursion_callee_zp_stk)
 ; CHECK-NEXT:    jsr ext_callback


### PR DESCRIPTION
## Summary

Alternative to #568 for MOS DWARF/CFI expression-form emission.

Instead of adding first-class `OpExpression` / `OpValExpression` / `OpDefCfaExpression` variants to upstream `MCCFIInstruction`, this branch:

- Adds `llvm/lib/Target/MOS/MOSCFIExprHelpers.h` — MOS-only inline helpers (`mos::createExpression`, `mos::createValExpression`, `mos::createDefCfaExpression`) with first-class-shaped signatures that internally call `MCCFIInstruction::createEscape` and hand-assemble the DWARF byte sequence (per DWARF 5 §6.4.2).
- Adds upstream MIR printer/parser support for `DW_CFA_val_offset`. The prologue uses `MCCFIInstruction::createValOffset` — which has had C++ API support for a while but no MIR serialization, so it fell through to `<unserializable cfi directive>`. ~15 LOC across `MILexer.{h,cpp}`, `MIParser.cpp`, and `MachineOperand.cpp`, following the existing `OpOffset`/`OpRelOffset` pattern.
- Bundles the DWARF register numbering + CFI infrastructure originally developed in v33 (dual-stack CFA switching, PC recovery via normalized hardware-stack expressions, `__builtin_return_address` / `__builtin_frame_address`).

If upstream ever grows real constructors for the expression forms, migration is a body swap on the three helper functions in `MOSCFIExprHelpers.h` with no call-site churn.

## Test plan

- [ ] `ninja check-llvm-codegen-mos` — all four CFI-related tests pass (`prologepilog.mir`, `prologepilog-ir.mir`, `zp-alloc.ll`, `frame-pointer-cfi.ll`)
- [ ] `llc -mtriple=mos -filetype=asm` on a small function with an alloca + call emits `.cfi_def_cfa llvm_mos_rs0, N`, `.cfi_val_offset llvm_mos_rs0, 0`, `.cfi_escape 0x10, 0x05, 0x09, ...` (DW_CFA_expression), `.cfi_escape 0x16, 0x04, 0x09, ...` (DW_CFA_val_expression)
- [ ] MIR test check lines read as `val_offset $rs0, 0` and `escape 0x10, 0x05, 0x09, ...` — no `<unserializable cfi directive>` anywhere
- [ ] LLDB simulator plugin can unwind through a MOS frame using the emitted CFI