### PR TITLE
feat(lldb): add MOS ABI plugin

### DIFF
--- a/lldb/include/lldb/Target/ABI.h
+++ b/lldb/include/lldb/Target/ABI.h
@@ -179,6 +179,22 @@ public:
     return std::nullopt;
   }
 
+  virtual lldb::RegisterContextSP
+  CreateRegisterContextForThread(
+      lldb_private::Thread &thread,
+      uint32_t concrete_frame_idx) const {
+    // Default: return nullptr, meaning use the default RegisterContext
+    return nullptr;
+  }
+
+  // Returns true if the ABI is prepared to provide authoritative register info for override.
+  virtual bool ProvidesRegisterInfoOverride() const { return false; }
+
+  // If opted in, returns a fully-populated Register for the given name, or std::nullopt if not recognized.
+  virtual std::optional<lldb_private::DynamicRegisterInfo::Register>
+  GetCanonicalRegisterInfo(llvm::StringRef name) const { return std::nullopt; }
+
+
 protected:
   ABI(lldb::ProcessSP process_sp, std::unique_ptr<llvm::MCRegisterInfo> info_up)
       : m_process_wp(process_sp), m_mc_register_info_up(std::move(info_up)) {

--- a/lldb/source/Plugins/ABI/CMakeLists.txt
+++ b/lldb/source/Plugins/ABI/CMakeLists.txt
@@ -4,7 +4,7 @@ set_property(DIRECTORY PROPERTY LLDB_TOLERATED_PLUGIN_DEPENDENCIES
   TypeSystem
 )
 
-foreach(target AArch64 ARM ARC Hexagon LoongArch Mips MSP430 PowerPC RISCV SystemZ X86)
+foreach(target AArch64 ARM ARC Hexagon LoongArch Mips MOS MSP430 PowerPC RISCV SystemZ X86)
   if (${target} IN_LIST LLVM_TARGETS_TO_BUILD)
     add_subdirectory(${target})
   endif()

--- a/lldb/source/Plugins/ABI/MOS/ABISysV_mos.cpp
+++ b/lldb/source/Plugins/ABI/MOS/ABISysV_mos.cpp
@@ -1,0 +1,326 @@
+//===-- ABISysV_mos.cpp -----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ABISysV_mos.h"
+#include "MOSImaginaryRegisters.h"
+#include "MOSRegisterContext.h"
+
+#include "lldb/Core/PluginManager.h"
+#include "lldb/Core/Value.h"
+#include "lldb/Symbol/UnwindPlan.h"
+#include "lldb/Target/Process.h"
+#include "lldb/Target/Thread.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
+
+#include "Plugins/Process/gdb-remote/ThreadGDBRemote.h"
+
+#include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/TargetParser/Triple.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+LLDB_PLUGIN_DEFINE_ADV(ABISysV_mos, ArchitectureMOS)
+
+//------------------------------------------------------------------
+// Helper to look up DWARF register number by name via MCRegisterInfo.
+// This is DRY - the actual DWARF numbers come from MOSRegisterInfo.td
+// through the MCRegisterInfo generated at LLVM build time.
+//------------------------------------------------------------------
+static int GetDwarfRegNumByName(llvm::MCRegisterInfo *mc_info,
+                                llvm::StringRef name) {
+  if (!mc_info)
+    return -1;
+
+  // MCRegisterInfo stores names in uppercase
+  std::string mc_name = name.upper();
+
+  for (unsigned reg = 0; reg < mc_info->getNumRegs(); ++reg) {
+    if (mc_info->getName(reg) == mc_name) {
+      return mc_info->getDwarfRegNum(reg, /*isEH=*/false);
+    }
+  }
+  return -1;
+}
+
+//------------------------------------------------------------------
+// Static Functions
+//------------------------------------------------------------------
+
+void ABISysV_mos::Initialize() {
+  PluginManager::RegisterPlugin(GetPluginNameStatic(),
+                                "System V ABI for MOS targets", CreateInstance);
+}
+
+void ABISysV_mos::Terminate() {
+  MOSImaginaryRegisters::ClearCache();
+  PluginManager::UnregisterPlugin(CreateInstance);
+}
+
+ABISP ABISysV_mos::CreateInstance(lldb::ProcessSP process_sp,
+                                  const ArchSpec &arch) {
+  if (arch.GetTriple().getArch() == llvm::Triple::mos) {
+    return ABISP(
+        new ABISysV_mos(std::move(process_sp), MakeMCRegisterInfo(arch)));
+  }
+  return ABISP();
+}
+
+//------------------------------------------------------------------
+// MCBasedABI interface
+//------------------------------------------------------------------
+
+uint32_t ABISysV_mos::GetGenericNum(llvm::StringRef name) {
+  // Map register names to generic register numbers
+  if (name.equals_insensitive("pc"))
+    return LLDB_REGNUM_GENERIC_PC;
+  if (name.equals_insensitive("sp") || name.equals_insensitive("s"))
+    return LLDB_REGNUM_GENERIC_SP;
+  if (name.equals_insensitive("p"))
+    return LLDB_REGNUM_GENERIC_FLAGS;
+  // RS0 is the soft stack pointer (frame pointer)
+  if (name.equals_insensitive("rs0"))
+    return LLDB_REGNUM_GENERIC_FP;
+
+  return LLDB_INVALID_REGNUM;
+}
+
+void ABISysV_mos::AugmentRegisterInfo(
+    std::vector<DynamicRegisterInfo::Register> &regs) {
+  // First, call base class to handle standard DWARF/EH frame numbers
+  MCBasedABI::AugmentRegisterInfo(regs);
+
+  // Add imaginary registers if we have a main module
+  ModuleSP main_module = GetMainModule();
+  if (main_module && m_mc_register_info_up) {
+    MOSImaginaryRegisters &imag_regs = MOSImaginaryRegisters::GetOrCreate(
+        *main_module, *m_mc_register_info_up);
+    if (imag_regs.HasImaginaryRegisters()) {
+      imag_regs.AddToRegisterList(regs, *m_mc_register_info_up);
+
+      LLDB_LOG(GetLog(LLDBLog::Expressions),
+               "ABISysV_mos: Added {0} RC and {1} RS imaginary registers",
+               imag_regs.GetNumRCRegisters(), imag_regs.GetNumRSRegisters());
+    }
+  }
+}
+
+//------------------------------------------------------------------
+// ABI interface - trivial call support (not implemented for 6502)
+//------------------------------------------------------------------
+
+bool ABISysV_mos::PrepareTrivialCall(Thread &thread, lldb::addr_t sp,
+                                     lldb::addr_t func_addr,
+                                     lldb::addr_t return_addr,
+                                     llvm::ArrayRef<addr_t> args) const {
+  // 6502 doesn't support complex calling conventions in the traditional sense
+  return false;
+}
+
+bool ABISysV_mos::GetArgumentValues(Thread &thread, ValueList &values) const {
+  // 6502 argument passing is very architecture-specific
+  return false;
+}
+
+Status ABISysV_mos::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
+                                         lldb::ValueObjectSP &new_value) {
+  return Status::FromErrorString(
+      "Setting return values not implemented for MOS");
+}
+
+ValueObjectSP ABISysV_mos::GetReturnValueObjectImpl(Thread &thread,
+                                                    CompilerType &type) const {
+  return ValueObjectSP();
+}
+
+bool ABISysV_mos::RegisterIsVolatile(const RegisterInfo *reg_info) {
+  // Nothing ever happens behind your back on MOS, so no volatile registers
+  return false;
+}
+
+//------------------------------------------------------------------
+// Unwind Plans
+//------------------------------------------------------------------
+
+/// Build a DWARF expression that computes a normalized hardware stack address.
+/// The 6502 hardware stack is at 0x0100-0x01FF. The S register is physically
+/// 8-bit, but some debuggers report it as 16-bit (e.g., MAME reports 0x01FE).
+/// This expression normalizes to always produce addresses in 0x0100-0x01FF:
+///   result = ((S + Offset) & 0xFF) | 0x0100
+static void buildNormalizedHardwareStackExpr(std::vector<uint8_t> &expr,
+                                             uint8_t dwarf_s, int8_t offset) {
+  // DW_OP_breg<S> <offset> - S + offset
+  expr.push_back(llvm::dwarf::DW_OP_breg0 + dwarf_s);
+  expr.push_back(static_cast<uint8_t>(offset));
+
+  // DW_OP_const1u 0xFF
+  expr.push_back(llvm::dwarf::DW_OP_const1u);
+  expr.push_back(0xFF);
+
+  // DW_OP_and - keep low byte only
+  expr.push_back(llvm::dwarf::DW_OP_and);
+
+  // DW_OP_const2u 0x0100 (little-endian: 0x00, 0x01)
+  expr.push_back(llvm::dwarf::DW_OP_const2u);
+  expr.push_back(0x00);
+  expr.push_back(0x01);
+
+  // DW_OP_or - force into hardware stack page
+  expr.push_back(llvm::dwarf::DW_OP_or);
+}
+
+UnwindPlanSP ABISysV_mos::CreateFunctionEntryUnwindPlan() {
+  // Get the DWARF register numbers by name via MCRegisterInfo.
+  // These are looked up at runtime - no hardcoded constants.
+  // The actual DWARF numbers come from MOSRegisterInfo.td.
+  if (!m_mc_register_info_up)
+    return nullptr;
+
+  int dwarf_s = GetDwarfRegNumByName(m_mc_register_info_up.get(), "S");
+  int dwarf_pc = GetDwarfRegNumByName(m_mc_register_info_up.get(), "PC");
+
+  if (dwarf_s < 0 || dwarf_pc < 0) {
+    LLDB_LOG(GetLog(LLDBLog::Expressions),
+             "ABISysV_mos: Could not find DWARF numbers for S or PC");
+    return nullptr;
+  }
+
+  // 6502 calling convention:
+  // - JSR pushes (return_address - 1) onto hardware stack
+  //   - First pushes high byte to [SP], then decrements SP
+  //   - Then pushes low byte to [SP], then decrements SP
+  // - After JSR, SP points to next free slot (two below pushed address)
+  // - RTS increments SP, reads low byte, increments SP, reads high byte, adds 1
+  //
+  // Stack layout after JSR (S = current value):
+  //   [S+1] = low byte of (return_address - 1)
+  //   [S+2] = high byte of (return_address - 1)
+  //
+  // We use normalized expressions to handle both 8-bit and 16-bit S values.
+  // Each hardware stack address is computed independently (not CFA-relative)
+  // to avoid subtraction underflow when S wraps within the stack page.
+  //
+  // The expression computes: ((S + offset) & 0xFF) | 0x0100
+  // This ensures the result is always in the hardware stack range
+  // 0x0100-0x01FF.
+
+  // IMPORTANT: These expression vectors must be static because UnwindPlan
+  // stores raw pointers to the data, not copies. They must persist for the
+  // lifetime of the UnwindPlan.
+  static std::vector<uint8_t> cfa_expr;
+  static std::vector<uint8_t> pc_expr;
+  static std::vector<uint8_t> s_expr;
+  static bool initialized = false;
+  static int cached_dwarf_s = -1;
+
+  // Rebuild if not initialized or if DWARF number changed (shouldn't happen)
+  if (!initialized || cached_dwarf_s != dwarf_s) {
+    cfa_expr.clear();
+    pc_expr.clear();
+    s_expr.clear();
+
+    buildNormalizedHardwareStackExpr(cfa_expr, dwarf_s, 3); // CFA = S + 3
+    buildNormalizedHardwareStackExpr(pc_expr, dwarf_s, 1);  // PC at S + 1
+    buildNormalizedHardwareStackExpr(s_expr, dwarf_s, 2);   // S_prev = S + 2
+
+    cached_dwarf_s = dwarf_s;
+    initialized = true;
+  }
+
+  auto plan_sp = std::make_shared<UnwindPlan>(eRegisterKindDWARF);
+  plan_sp->SetSourceName("mos function-entry unwind plan");
+  plan_sp->SetSourcedFromCompiler(eLazyBoolNo);
+  plan_sp->SetUnwindPlanValidAtAllInstructions(eLazyBoolNo);
+  plan_sp->SetUnwindPlanForSignalTrap(eLazyBoolNo);
+
+  UnwindPlan::Row row;
+
+  // CFA = normalized(S + 3) = ((S + 3) & 0xFF) | 0x0100
+  row.GetCFAValue().SetIsDWARFExpression(cfa_expr.data(), cfa_expr.size());
+
+  // PC = [normalized(S + 1)] - direct expression, NOT [CFA - 2]
+  // atDWARFExpression means: dereference the address computed by the
+  // expression.
+  UnwindPlan::Row::AbstractRegisterLocation pc_loc;
+  pc_loc.SetAtDWARFExpression(pc_expr.data(), pc_expr.size());
+  row.SetRegisterInfo(dwarf_pc, pc_loc);
+
+  // S_prev = normalized(S + 2) - direct expression, NOT CFA - 1
+  // isDWARFExpression means: the expression result IS the register value.
+  UnwindPlan::Row::AbstractRegisterLocation s_loc;
+  s_loc.SetIsDWARFExpression(s_expr.data(), s_expr.size());
+  row.SetRegisterInfo(dwarf_s, s_loc);
+
+  plan_sp->AppendRow(std::move(row));
+  plan_sp->SetReturnAddressRegister(dwarf_pc);
+
+  return plan_sp;
+}
+
+UnwindPlanSP ABISysV_mos::CreateDefaultUnwindPlan() {
+  // The default unwind plan is used when we're in the middle of a function.
+  // For 6502, the return address is still on the hardware stack at S+1/S+2.
+  return CreateFunctionEntryUnwindPlan();
+}
+
+//------------------------------------------------------------------
+// Custom Register Context for imaginary registers
+//------------------------------------------------------------------
+
+lldb::RegisterContextSP
+ABISysV_mos::CreateRegisterContextForThread(lldb_private::Thread &thread,
+                                            uint32_t concrete_frame_idx) const {
+
+  // Downcast to ThreadGDBRemote - this is safe in the GDB remote context.
+  // We use static_cast because ThreadGDBRemote doesn't have LLVM RTTI
+  // (classof).
+  auto *gdb_thread =
+      static_cast<lldb_private::process_gdb_remote::ThreadGDBRemote *>(&thread);
+
+  // Get the register info from the thread
+  auto reg_info_sp = gdb_thread->GetRegisterInfoSP();
+  if (!reg_info_sp) {
+    LLDB_LOG(GetLog(LLDBLog::Expressions),
+             "ABISysV_mos: No register info available");
+    return nullptr;
+  }
+
+  // Get the imaginary registers helper for the main module
+  ModuleSP main_module = GetMainModule();
+  if (!main_module || !m_mc_register_info_up) {
+    LLDB_LOG(GetLog(LLDBLog::Expressions),
+             "ABISysV_mos: No main module or MCRegisterInfo, using base "
+             "register context");
+    return nullptr;
+  }
+
+  MOSImaginaryRegisters &imag_regs =
+      MOSImaginaryRegisters::GetOrCreate(*main_module, *m_mc_register_info_up);
+
+  return std::make_shared<MOSRegisterContext>(
+      *gdb_thread, concrete_frame_idx, reg_info_sp,
+      /*read_all_registers_at_once=*/false,
+      /*write_all_registers_at_once=*/false, imag_regs);
+}
+
+//------------------------------------------------------------------
+// Helper functions
+//------------------------------------------------------------------
+
+ModuleSP ABISysV_mos::GetMainModule() const {
+  ProcessSP process_sp = GetProcessSP();
+  if (!process_sp)
+    return nullptr;
+
+  TargetSP target_sp = process_sp->CalculateTarget();
+  if (!target_sp)
+    return nullptr;
+
+  return target_sp->GetExecutableModule();
+}

--- a/lldb/source/Plugins/ABI/MOS/ABISysV_mos.h
+++ b/lldb/source/Plugins/ABI/MOS/ABISysV_mos.h
@@ -1,0 +1,85 @@
+//===-- ABISysV_mos.h -------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_ABI_MOS_ABISYSV_MOS_H
+#define LLDB_SOURCE_PLUGINS_ABI_MOS_ABISYSV_MOS_H
+
+#include "lldb/Target/ABI.h"
+#include "lldb/lldb-forward.h"
+
+class ABISysV_mos : public lldb_private::MCBasedABI {
+public:
+  ~ABISysV_mos() override = default;
+
+  // Plugin interface
+  static void Initialize();
+  static void Terminate();
+  static lldb::ABISP CreateInstance(lldb::ProcessSP process_sp,
+                                    const lldb_private::ArchSpec &arch);
+  static llvm::StringRef GetPluginNameStatic() { return "sysv-mos"; }
+  llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
+
+  // ABI interface
+  size_t GetRedZoneSize() const override { return 0; }
+  uint64_t GetStackFrameSize() override {
+    return 256;
+  } // 6502 stack is 256 bytes
+
+  bool PrepareTrivialCall(lldb_private::Thread &thread, lldb::addr_t sp,
+                          lldb::addr_t func_addr, lldb::addr_t return_addr,
+                          llvm::ArrayRef<lldb::addr_t> args) const override;
+
+  bool GetArgumentValues(lldb_private::Thread &thread,
+                         lldb_private::ValueList &values) const override;
+
+  lldb_private::Status
+  SetReturnValueObject(lldb::StackFrameSP &frame_sp,
+                       lldb::ValueObjectSP &new_value) override;
+
+  bool CallFrameAddressIsValid(lldb::addr_t cfa) override {
+    // MOS uses 16-bit addresses, soft stack can be anywhere
+    return cfa <= 0xFFFF;
+  }
+
+  bool CodeAddressIsValid(lldb::addr_t pc) override {
+    // MOS uses 16-bit addresses
+    return pc <= 0xFFFF;
+  }
+
+  bool RegisterIsVolatile(const lldb_private::RegisterInfo *reg_info) override;
+
+  lldb::UnwindPlanSP CreateDefaultUnwindPlan() override;
+  lldb::UnwindPlanSP CreateFunctionEntryUnwindPlan() override;
+
+  // MCBasedABI interface
+  uint32_t GetGenericNum(llvm::StringRef name) override;
+
+  // Register augmentation - adds imaginary registers
+  void AugmentRegisterInfo(
+      std::vector<lldb_private::DynamicRegisterInfo::Register> &regs) override;
+
+  // Custom register context for imaginary register handling
+  lldb::RegisterContextSP
+  CreateRegisterContextForThread(lldb_private::Thread &thread,
+                                 uint32_t concrete_frame_idx) const override;
+
+protected:
+  lldb::ValueObjectSP
+  GetReturnValueObjectImpl(lldb_private::Thread &thread,
+                           lldb_private::CompilerType &type) const override;
+
+private:
+  ABISysV_mos(lldb::ProcessSP process_sp,
+              std::unique_ptr<llvm::MCRegisterInfo> info_up)
+      : MCBasedABI(std::move(process_sp), std::move(info_up)) {}
+
+  // Helper to get the main executable module
+  lldb::ModuleSP GetMainModule() const;
+};
+
+#endif // LLDB_SOURCE_PLUGINS_ABI_MOS_ABISYSV_MOS_H

--- a/lldb/source/Plugins/ABI/MOS/CMakeLists.txt
+++ b/lldb/source/Plugins/ABI/MOS/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_lldb_library(lldbPluginArchitectureMOS PLUGIN
+  ABISysV_mos.cpp
+  MOSImaginaryRegisters.cpp
+  MOSRegisterContext.cpp
+
+  LINK_LIBS
+    lldbCore
+    lldbSymbol
+    lldbTarget
+    lldbValueObject
+    lldbUtility
+  LINK_COMPONENTS
+    Support
+    TargetParser
+  )

--- a/lldb/source/Plugins/ABI/MOS/MOSImaginaryRegisters.cpp
+++ b/lldb/source/Plugins/ABI/MOS/MOSImaginaryRegisters.cpp
@@ -1,0 +1,239 @@
+//===-- MOSImaginaryRegisters.cpp -------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "MOSImaginaryRegisters.h"
+
+#include "lldb/Core/Module.h"
+#include "lldb/Symbol/Symbol.h"
+#include "lldb/Symbol/Symtab.h"
+#include "lldb/Utility/ConstString.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+// Static cache
+llvm::StringMap<MOSImaginaryRegisters> MOSImaginaryRegisters::s_cache_;
+
+//------------------------------------------------------------------
+// Helper to look up DWARF register number by name via MCRegisterInfo.
+// This is DRY - the actual DWARF numbers come from MOSRegisterInfo.td
+// through the MCRegisterInfo generated at LLVM build time.
+//------------------------------------------------------------------
+static int GetDwarfRegNumByName(llvm::MCRegisterInfo &mc_info,
+                                llvm::StringRef name) {
+  // MCRegisterInfo stores names in uppercase
+  std::string mc_name = name.upper();
+
+  for (unsigned reg = 0; reg < mc_info.getNumRegs(); ++reg) {
+    if (mc_info.getName(reg) == mc_name) {
+      return mc_info.getDwarfRegNum(reg, /*isEH=*/false);
+    }
+  }
+  return -1;
+}
+
+MOSImaginaryRegisters &
+MOSImaginaryRegisters::GetOrCreate(Module &module,
+                                   llvm::MCRegisterInfo &mc_info) {
+  // Use UUID as cache key, fall back to file path
+  std::string key = module.GetUUID().GetAsString();
+  if (key.empty()) {
+    key = module.GetFileSpec().GetPath();
+  }
+
+  auto it = s_cache_.find(key);
+  if (it != s_cache_.end() && it->second.initialized_) {
+    return it->second;
+  }
+
+  auto &regs = s_cache_[key];
+  regs.Initialize(module, mc_info);
+  return regs;
+}
+
+void MOSImaginaryRegisters::ClearCache() { s_cache_.clear(); }
+
+void MOSImaginaryRegisters::Initialize(Module &module,
+                                       llvm::MCRegisterInfo &mc_info) {
+  if (initialized_)
+    return;
+
+  // Query MCRegisterInfo for the base DWARF numbers by name.
+  // These come from MOSRegisterInfo.td - single source of truth.
+  // We look up "RC0" and "RS0" by name to get their DWARF numbers.
+  int rc0_dwarf = GetDwarfRegNumByName(mc_info, "RC0");
+  int rs0_dwarf = GetDwarfRegNumByName(mc_info, "RS0");
+
+  if (rc0_dwarf >= 0) {
+    rc_base_dwarf_ = static_cast<uint32_t>(rc0_dwarf);
+  } else {
+    LLDB_LOG(GetLog(LLDBLog::Expressions),
+             "MOSImaginaryRegisters: Could not find DWARF number for RC0");
+  }
+
+  if (rs0_dwarf >= 0) {
+    rs_base_dwarf_ = static_cast<uint32_t>(rs0_dwarf);
+  } else {
+    LLDB_LOG(GetLog(LLDBLog::Expressions),
+             "MOSImaginaryRegisters: Could not find DWARF number for RS0");
+  }
+
+  LLDB_LOG(GetLog(LLDBLog::Expressions),
+           "MOSImaginaryRegisters: RC base DWARF={0}, RS base DWARF={1}",
+           rc_base_dwarf_, rs_base_dwarf_);
+
+  ScanForSymbols(module);
+  initialized_ = true;
+}
+
+void MOSImaginaryRegisters::ScanForSymbols(Module &module) {
+  Symtab *symtab = module.GetSymtab();
+  if (!symtab)
+    return;
+
+  // Scan for __rc0, __rc1, ..., __rcN symbols
+  // These are absolute symbols containing the zero-page address
+  for (uint32_t i = 0; i < 256; ++i) {
+    std::string symbol_name = "__rc" + std::to_string(i);
+    Symbol *symbol = symtab->FindFirstSymbolWithNameAndType(
+        ConstString(symbol_name), eSymbolTypeAbsolute, Symtab::eDebugAny,
+        Symtab::eVisibilityAny);
+
+    if (!symbol)
+      continue;
+
+    // GetRawValue() is the correct way to get absolute symbol values
+    addr_t addr = symbol->GetRawValue();
+
+    // Extend the vector if needed
+    if (i >= rc_addresses_.size()) {
+      rc_addresses_.resize(i + 1, LLDB_INVALID_ADDRESS);
+    }
+    rc_addresses_[i] = addr;
+    num_rc_regs_ = std::max(num_rc_regs_, i + 1);
+
+    LLDB_LOG(GetLog(LLDBLog::Expressions),
+             "MOSImaginaryRegisters: {0} -> 0x{1:x}", symbol_name, addr);
+  }
+
+  // RS registers are pairs of RC registers: RS[n] = {RC[2n], RC[2n+1]}
+  // So num_rs_regs = num_rc_regs / 2
+  num_rs_regs_ = num_rc_regs_ / 2;
+
+  LLDB_LOG(GetLog(LLDBLog::Expressions),
+           "MOSImaginaryRegisters: Found {0} RC registers, {1} RS registers",
+           num_rc_regs_, num_rs_regs_);
+}
+
+bool MOSImaginaryRegisters::IsImaginary(uint32_t dwarf_num) const {
+  return IsRCRegister(dwarf_num) || IsRSRegister(dwarf_num);
+}
+
+bool MOSImaginaryRegisters::IsRCRegister(uint32_t dwarf_num) const {
+  return dwarf_num >= rc_base_dwarf_ &&
+         dwarf_num < rc_base_dwarf_ + num_rc_regs_;
+}
+
+bool MOSImaginaryRegisters::IsRSRegister(uint32_t dwarf_num) const {
+  return dwarf_num >= rs_base_dwarf_ &&
+         dwarf_num < rs_base_dwarf_ + num_rs_regs_;
+}
+
+std::optional<addr_t>
+MOSImaginaryRegisters::GetAddress(uint32_t dwarf_num) const {
+  if (IsRCRegister(dwarf_num)) {
+    uint32_t index = GetRCIndex(dwarf_num);
+    if (index < rc_addresses_.size() &&
+        rc_addresses_[index] != LLDB_INVALID_ADDRESS) {
+      return rc_addresses_[index];
+    }
+  } else if (IsRSRegister(dwarf_num)) {
+    // RS[n] is at the address of RC[2*n] (low byte)
+    uint32_t rs_index = GetRSIndex(dwarf_num);
+    uint32_t rc_index = rs_index * 2;
+    if (rc_index < rc_addresses_.size() &&
+        rc_addresses_[rc_index] != LLDB_INVALID_ADDRESS) {
+      return rc_addresses_[rc_index];
+    }
+  }
+  return std::nullopt;
+}
+
+void MOSImaginaryRegisters::AddToRegisterList(
+    std::vector<DynamicRegisterInfo::Register> &regs,
+    llvm::MCRegisterInfo &mc_info) const {
+
+  if (!HasImaginaryRegisters())
+    return;
+
+  ConstString empty_alt_name;
+  ConstString reg_set{"imaginary"};
+
+  // Find the next available offset and regnum
+  uint32_t next_offset = 0;
+  uint32_t next_regnum = 0;
+  for (const auto &reg : regs) {
+    if (reg.byte_offset != LLDB_INVALID_INDEX32)
+      next_offset = std::max(next_offset, reg.byte_offset + reg.byte_size);
+    if (reg.regnum_remote != LLDB_INVALID_REGNUM)
+      next_regnum = std::max(next_regnum, reg.regnum_remote + 1);
+  }
+
+  // Add RC registers (8-bit)
+  for (uint32_t i = 0; i < num_rc_regs_; ++i) {
+    uint32_t dwarf_num = rc_base_dwarf_ + i;
+    std::string name = "rc" + std::to_string(i);
+
+    DynamicRegisterInfo::Register reg{
+        ConstString(name),
+        empty_alt_name,
+        reg_set,
+        1, // byte_size
+        next_offset,
+        eEncodingUint,
+        eFormatHex,
+        dwarf_num,           // regnum_ehframe
+        dwarf_num,           // regnum_dwarf
+        LLDB_INVALID_REGNUM, // regnum_generic
+        LLDB_INVALID_REGNUM, // regnum_remote (will be set below)
+        {},                  // value_regs
+        {}                   // invalidate_regs
+    };
+    reg.regnum_remote = next_regnum++;
+    next_offset += 1;
+    regs.push_back(reg);
+  }
+
+  // Add RS registers (16-bit, pairs of RC registers)
+  for (uint32_t i = 0; i < num_rs_regs_; ++i) {
+    uint32_t dwarf_num = rs_base_dwarf_ + i;
+    std::string name = "rs" + std::to_string(i);
+
+    DynamicRegisterInfo::Register reg{
+        ConstString(name),
+        empty_alt_name,
+        reg_set,
+        2, // byte_size
+        next_offset,
+        eEncodingUint,
+        eFormatHex,
+        dwarf_num, // regnum_ehframe
+        dwarf_num, // regnum_dwarf
+        (i == 0) ? LLDB_REGNUM_GENERIC_FP
+                 : LLDB_INVALID_REGNUM, // RS0 is soft stack pointer
+        LLDB_INVALID_REGNUM,            // regnum_remote
+        {},                             // value_regs
+        {}                              // invalidate_regs
+    };
+    reg.regnum_remote = next_regnum++;
+    next_offset += 2;
+    regs.push_back(reg);
+  }
+}

--- a/lldb/source/Plugins/ABI/MOS/MOSImaginaryRegisters.h
+++ b/lldb/source/Plugins/ABI/MOS/MOSImaginaryRegisters.h
@@ -1,0 +1,116 @@
+//===-- MOSImaginaryRegisters.h ---------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// MOS "imaginary registers" are zero-page memory locations that the compiler
+// treats as registers. This class manages the mapping from DWARF register
+// numbers to zero-page addresses, scanned from ELF symbols (__rc0, __rc1, etc).
+//
+// The DWARF register numbering comes from MOSRegisterInfo.td via MCRegisterInfo
+// - no magic constants are hardcoded here.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_ABI_MOS_MOSIMAGINARYREGISTERS_H
+#define LLDB_SOURCE_PLUGINS_ABI_MOS_MOSIMAGINARYREGISTERS_H
+
+#include "lldb/Target/DynamicRegisterInfo.h"
+#include "lldb/lldb-types.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/MC/MCRegisterInfo.h"
+
+#include <cstdint>
+#include <optional>
+
+namespace lldb_private {
+class Module;
+} // namespace lldb_private
+
+namespace lldb_private {
+
+class MOSImaginaryRegisters {
+public:
+  /// Default constructor - needed for StringMap storage.
+  MOSImaginaryRegisters() = default;
+
+  /// Get or create the imaginary register map for a module.
+  /// Cached by module UUID (or file path as fallback).
+  static MOSImaginaryRegisters &GetOrCreate(Module &module,
+                                             llvm::MCRegisterInfo &mc_info);
+
+  /// Clear the cache (e.g., when plugin terminates).
+  static void ClearCache();
+
+  /// Check if a DWARF register number is an imaginary register (RC or RS).
+  bool IsImaginary(uint32_t dwarf_num) const;
+
+  /// Check if a DWARF register number is an 8-bit RC register.
+  bool IsRCRegister(uint32_t dwarf_num) const;
+
+  /// Check if a DWARF register number is a 16-bit RS register.
+  bool IsRSRegister(uint32_t dwarf_num) const;
+
+  /// Get the zero-page address for an imaginary register.
+  /// For RC registers, returns the single byte address.
+  /// For RS registers, returns the address of the low byte.
+  std::optional<lldb::addr_t> GetAddress(uint32_t dwarf_num) const;
+
+  /// Get the number of RC registers present in this module.
+  uint32_t GetNumRCRegisters() const { return num_rc_regs_; }
+
+  /// Get the number of RS registers present in this module.
+  uint32_t GetNumRSRegisters() const { return num_rs_regs_; }
+
+  /// Get the base DWARF number for RC registers.
+  uint32_t GetRCBaseDwarf() const { return rc_base_dwarf_; }
+
+  /// Get the base DWARF number for RS registers.
+  uint32_t GetRSBaseDwarf() const { return rs_base_dwarf_; }
+
+  /// Add imaginary registers to the register list for AugmentRegisterInfo.
+  void AddToRegisterList(std::vector<DynamicRegisterInfo::Register> &regs,
+                         llvm::MCRegisterInfo &mc_info) const;
+
+  /// Check if this module has any imaginary registers.
+  bool HasImaginaryRegisters() const { return num_rc_regs_ > 0; }
+
+private:
+  void Initialize(Module &module, llvm::MCRegisterInfo &mc_info);
+  void ScanForSymbols(Module &module);
+
+  /// Get the RC index (0-255) from a DWARF register number.
+  uint32_t GetRCIndex(uint32_t dwarf_num) const {
+    return dwarf_num - rc_base_dwarf_;
+  }
+
+  /// Get the RS index (0-127) from a DWARF register number.
+  uint32_t GetRSIndex(uint32_t dwarf_num) const {
+    return dwarf_num - rs_base_dwarf_;
+  }
+
+  // Cache keyed by module UUID or file path
+  static llvm::StringMap<MOSImaginaryRegisters> s_cache_;
+
+  // Zero-page addresses for RC registers, indexed by register number (0-255)
+  llvm::SmallVector<lldb::addr_t, 32> rc_addresses_;
+
+  // Base DWARF numbers - discovered from MCRegisterInfo at init time
+  uint32_t rc_base_dwarf_ = 0;
+  uint32_t rs_base_dwarf_ = 0;
+
+  // How many registers are present in this module
+  uint32_t num_rc_regs_ = 0;
+  uint32_t num_rs_regs_ = 0;
+
+  // Whether initialization has been done
+  bool initialized_ = false;
+};
+
+} // namespace lldb_private
+
+#endif // LLDB_SOURCE_PLUGINS_ABI_MOS_MOSIMAGINARYREGISTERS_H

--- a/lldb/source/Plugins/ABI/MOS/MOSRegisterContext.cpp
+++ b/lldb/source/Plugins/ABI/MOS/MOSRegisterContext.cpp
@@ -1,0 +1,169 @@
+//===-- MOSRegisterContext.cpp ----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "MOSRegisterContext.h"
+#include "MOSImaginaryRegisters.h"
+
+#include "lldb/Target/Process.h"
+#include "lldb/Target/Thread.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
+#include "lldb/Utility/RegisterValue.h"
+#include "lldb/Utility/Status.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+MOSRegisterContext::MOSRegisterContext(
+    lldb_private::process_gdb_remote::ThreadGDBRemote &thread,
+    uint32_t concrete_frame_idx,
+    lldb::DynamicRegisterInfoSP reg_info_sp,
+    bool read_all_registers_at_once, bool write_all_registers_at_once,
+    const MOSImaginaryRegisters &imag_regs)
+    : GDBRemoteRegisterContext(thread, concrete_frame_idx, reg_info_sp,
+                               read_all_registers_at_once,
+                               write_all_registers_at_once),
+      m_imag_regs(imag_regs) {
+  LLDB_LOG(GetLog(LLDBLog::Expressions),
+           "MOSRegisterContext: Created with {0} RC and {1} RS registers",
+           imag_regs.GetNumRCRegisters(), imag_regs.GetNumRSRegisters());
+}
+
+bool MOSRegisterContext::ReadRegister(const RegisterInfo *reg_info,
+                                      RegisterValue &value) {
+  if (!reg_info)
+    return false;
+
+  // Check if this is an imaginary register by its DWARF number
+  uint32_t dwarf_num = reg_info->kinds[eRegisterKindDWARF];
+  if (dwarf_num != LLDB_INVALID_REGNUM && m_imag_regs.IsImaginary(dwarf_num)) {
+    return ReadImaginaryRegister(dwarf_num, reg_info->byte_size, value);
+  }
+
+  // Fallback to base class for hardware registers
+  return GDBRemoteRegisterContext::ReadRegister(reg_info, value);
+}
+
+bool MOSRegisterContext::WriteRegister(const RegisterInfo *reg_info,
+                                       const RegisterValue &value) {
+  if (!reg_info)
+    return false;
+
+  // Check if this is an imaginary register by its DWARF number
+  uint32_t dwarf_num = reg_info->kinds[eRegisterKindDWARF];
+  if (dwarf_num != LLDB_INVALID_REGNUM && m_imag_regs.IsImaginary(dwarf_num)) {
+    return WriteImaginaryRegister(dwarf_num, reg_info->byte_size, value);
+  }
+
+  // Fallback to base class for hardware registers
+  return GDBRemoteRegisterContext::WriteRegister(reg_info, value);
+}
+
+bool MOSRegisterContext::ReadImaginaryRegister(uint32_t dwarf_num,
+                                               uint32_t byte_size,
+                                               RegisterValue &value) {
+  auto addr_opt = m_imag_regs.GetAddress(dwarf_num);
+  if (!addr_opt) {
+    LLDB_LOG(GetLog(LLDBLog::Expressions),
+             "MOSRegisterContext: No address for DWARF reg {0}", dwarf_num);
+    return false;
+  }
+
+  addr_t addr = *addr_opt;
+  ProcessSP process_sp = m_thread.GetProcess();
+  if (!process_sp)
+    return false;
+
+  Status error;
+
+  if (byte_size == 1) {
+    // RC register - single byte
+    uint8_t byte = 0;
+    size_t bytes_read = process_sp->ReadMemory(addr, &byte, 1, error);
+    if (bytes_read == 1 && error.Success()) {
+      value.SetUInt8(byte);
+      LLDB_LOG(GetLog(LLDBLog::Expressions),
+               "MOSRegisterContext: Read RC DWARF={0} from 0x{1:x} = 0x{2:x}",
+               dwarf_num, addr, byte);
+      return true;
+    }
+  } else if (byte_size == 2) {
+    // RS register - two bytes (little-endian)
+    // RS[n] is stored at the address of RC[2*n] (low byte) and RC[2*n+1] (high)
+    // The GetAddress for RS returns the low byte address
+    uint8_t lo = 0, hi = 0;
+    if (process_sp->ReadMemory(addr, &lo, 1, error) != 1 || !error.Success())
+      return false;
+    if (process_sp->ReadMemory(addr + 1, &hi, 1, error) != 1 ||
+        !error.Success())
+      return false;
+
+    uint16_t val = lo | (hi << 8);
+    value.SetUInt16(val);
+    LLDB_LOG(GetLog(LLDBLog::Expressions),
+             "MOSRegisterContext: Read RS DWARF={0} from 0x{1:x} = 0x{2:x}",
+             dwarf_num, addr, val);
+    return true;
+  }
+
+  LLDB_LOG(GetLog(LLDBLog::Expressions),
+           "MOSRegisterContext: Failed to read DWARF reg {0} at 0x{1:x}",
+           dwarf_num, addr);
+  return false;
+}
+
+bool MOSRegisterContext::WriteImaginaryRegister(uint32_t dwarf_num,
+                                                uint32_t byte_size,
+                                                const RegisterValue &value) {
+  auto addr_opt = m_imag_regs.GetAddress(dwarf_num);
+  if (!addr_opt) {
+    LLDB_LOG(GetLog(LLDBLog::Expressions),
+             "MOSRegisterContext: No address for DWARF reg {0}", dwarf_num);
+    return false;
+  }
+
+  addr_t addr = *addr_opt;
+  ProcessSP process_sp = m_thread.GetProcess();
+  if (!process_sp)
+    return false;
+
+  Status error;
+
+  if (byte_size == 1) {
+    // RC register - single byte
+    uint8_t byte = value.GetAsUInt8();
+    size_t bytes_written = process_sp->WriteMemory(addr, &byte, 1, error);
+    if (bytes_written == 1 && error.Success()) {
+      LLDB_LOG(GetLog(LLDBLog::Expressions),
+               "MOSRegisterContext: Wrote RC DWARF={0} to 0x{1:x} = 0x{2:x}",
+               dwarf_num, addr, byte);
+      return true;
+    }
+  } else if (byte_size == 2) {
+    // RS register - two bytes (little-endian)
+    uint16_t val = value.GetAsUInt16();
+    uint8_t lo = val & 0xFF;
+    uint8_t hi = (val >> 8) & 0xFF;
+
+    if (process_sp->WriteMemory(addr, &lo, 1, error) != 1 || !error.Success())
+      return false;
+    if (process_sp->WriteMemory(addr + 1, &hi, 1, error) != 1 ||
+        !error.Success())
+      return false;
+
+    LLDB_LOG(GetLog(LLDBLog::Expressions),
+             "MOSRegisterContext: Wrote RS DWARF={0} to 0x{1:x} = 0x{2:x}",
+             dwarf_num, addr, val);
+    return true;
+  }
+
+  LLDB_LOG(GetLog(LLDBLog::Expressions),
+           "MOSRegisterContext: Failed to write DWARF reg {0} at 0x{1:x}",
+           dwarf_num, addr);
+  return false;
+}

--- a/lldb/source/Plugins/ABI/MOS/MOSRegisterContext.h
+++ b/lldb/source/Plugins/ABI/MOS/MOSRegisterContext.h
@@ -1,0 +1,63 @@
+//===-- MOSRegisterContext.h ------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Custom register context for MOS that handles imaginary registers.
+// Imaginary registers are zero-page memory locations that the compiler
+// treats as registers. This context intercepts reads/writes to these
+// registers and translates them to memory accesses.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_ABI_MOS_MOSREGISTERCONTEXT_H
+#define LLDB_SOURCE_PLUGINS_ABI_MOS_MOSREGISTERCONTEXT_H
+
+#include "Plugins/Process/gdb-remote/GDBRemoteRegisterContext.h"
+
+namespace lldb_private {
+class MOSImaginaryRegisters;
+} // namespace lldb_private
+
+class MOSRegisterContext
+    : public lldb_private::process_gdb_remote::GDBRemoteRegisterContext {
+public:
+  MOSRegisterContext(
+      lldb_private::process_gdb_remote::ThreadGDBRemote &thread,
+      uint32_t concrete_frame_idx,
+      lldb::DynamicRegisterInfoSP reg_info_sp,
+      bool read_all_registers_at_once, bool write_all_registers_at_once,
+      const lldb_private::MOSImaginaryRegisters &imag_regs);
+
+  bool ReadRegister(const lldb_private::RegisterInfo *reg_info,
+                    lldb_private::RegisterValue &value) override;
+
+  bool WriteRegister(const lldb_private::RegisterInfo *reg_info,
+                     const lldb_private::RegisterValue &value) override;
+
+private:
+  /// Reference to the imaginary registers helper.
+  /// This provides DWARF-number-based lookup for imaginary register addresses.
+  const lldb_private::MOSImaginaryRegisters &m_imag_regs;
+
+  /// Read an imaginary register by reading from zero-page memory.
+  /// @param dwarf_num The DWARF register number.
+  /// @param byte_size 1 for RC registers, 2 for RS registers.
+  /// @param value Output register value.
+  /// @return true on success.
+  bool ReadImaginaryRegister(uint32_t dwarf_num, uint32_t byte_size,
+                             lldb_private::RegisterValue &value);
+
+  /// Write an imaginary register by writing to zero-page memory.
+  /// @param dwarf_num The DWARF register number.
+  /// @param byte_size 1 for RC registers, 2 for RS registers.
+  /// @param value The value to write.
+  /// @return true on success.
+  bool WriteImaginaryRegister(uint32_t dwarf_num, uint32_t byte_size,
+                              const lldb_private::RegisterValue &value);
+};
+
+#endif // LLDB_SOURCE_PLUGINS_ABI_MOS_MOSREGISTERCONTEXT_H

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -5613,11 +5613,17 @@ void ProcessGDBRemote::AddRemoteRegisters(
                     remote_reg_info.invalidate_regs.begin(), proc_to_lldb);
   }
 
-  // Don't use Process::GetABI, this code gets called from DidAttach, and
-  // in that context we haven't set the Target's architecture yet, so the
-  // ABI is also potentially incorrect.
-  if (ABISP abi_sp = ABI::FindPlugin(shared_from_this(), arch_to_use))
+  // ABI override for register info, if enabled
+  if (ABISP abi_sp = ABI::FindPlugin(shared_from_this(), arch_to_use)) {
+    if (abi_sp->ProvidesRegisterInfoOverride()) {
+      for (auto &reg : registers) {
+        auto canonical = abi_sp->GetCanonicalRegisterInfo(reg.name.GetStringRef());
+        if (canonical)
+          reg = *canonical;
+      }
+    }
     abi_sp->AugmentRegisterInfo(registers);
+  }
 
   m_register_info_sp->SetRegisterInfo(std::move(registers), arch_to_use);
 }

--- a/lldb/source/Plugins/Process/gdb-remote/ThreadGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ThreadGDBRemote.cpp
@@ -25,6 +25,8 @@
 #include "ProcessGDBRemote.h"
 #include "ProcessGDBRemoteLog.h"
 
+#include "lldb/Target/ABI.h"
+
 #include <memory>
 
 using namespace lldb;
@@ -314,6 +316,13 @@ ThreadGDBRemote::CreateRegisterContextForFrame(StackFrame *frame) {
       bool read_all_registers_at_once =
           !pSupported || gdb_process->m_use_g_packet_for_reading;
       bool write_all_registers_at_once = !pSupported;
+      ABI *abi = process_sp->GetABI().get();
+      if (abi) {
+        auto custom_ctx = abi->CreateRegisterContextForThread(
+            *this, concrete_frame_idx);
+        if (custom_ctx)
+          return custom_ctx;
+      }
       reg_ctx_sp = std::make_shared<GDBRemoteRegisterContext>(
           *this, concrete_frame_idx, m_reg_info_sp, read_all_registers_at_once,
           write_all_registers_at_once);

--- a/lldb/source/Plugins/Process/gdb-remote/ThreadGDBRemote.h
+++ b/lldb/source/Plugins/Process/gdb-remote/ThreadGDBRemote.h
@@ -96,6 +96,8 @@ public:
   void SetNewlyAddedBinaries(const std::vector<lldb::addr_t> &added_binaries);
   void SetDetailedBinariesInfo(StructuredData::ObjectSP &detailed_info);
 
+  lldb::DynamicRegisterInfoSP GetRegisterInfoSP() const { return m_reg_info_sp; }
+
 protected:
   friend class ProcessGDBRemote;
 


### PR DESCRIPTION
## Summary

Add the LLDB ABI plugin for MOS 6502. Third piece of the debugging trio (with #571 and #601) that lets LLDB understand MOS programs.

- `ABISysV_mos` — main plugin. Looks up DWARF register numbers dynamically via `MCRegisterInfo::getDwarfRegNumByName`, so the plugin automatically tracks whatever `MOSRegisterInfo.td` says. Rebuilds the same normalized hardware-stack expression `((S+N) & 0xFF) | 0x0100` (CFA=S+3, PC at S+1, S_prev at S+2) that the CIE in #601 emits — compiler and debugger are two ends of the same design.
- `MOSImaginaryRegisters` — RC0-RC255 byte pseudo-registers and RS0-RS127 pair pseudo-registers. Not reported by the GDB stub; the plugin reads them from target memory using addresses scanned out of ELF `__rcN` symbols.
- `MOSRegisterContext` — presents the combined view (physical from stub + imaginary from memory) to LLDB.
- Entirely under `lldb/source/Plugins/ABI/MOS/` except one line in the parent `CMakeLists.txt`.

## Dependencies

- **Requires #571** (feat(lldb): ABI extension points for custom register contexts). Uses `CreateRegisterContextForThread` and `ProvidesRegisterInfoOverride` from that PR. This PR is opened against a branch stacked on #571 and should land after #571 merges.
- **Pairs with #601** (feat(MOS): DWARF register numbering and CFI). Code-wise independent, but the two together are what enables end-to-end debugging. This plugin consumes the DWARF #601 emits.

## Test plan

- [ ] `ninja lldb` builds cleanly with #571 as base (verified locally against rebased #571 + current upstream/main)
- [ ] `lldb foo.o` (a MOS `.o` compiled with `-g` via clang/#601's llc) recognizes the architecture as `mos` and finds `main`
- [ ] `image lookup -n main --verbose` shows the correct DWARF register numbers for arguments and locals
- [ ] Attaching to MAME's GDB stub while running a compiled MOS program produces correct backtrace, source-level stepping, and local variable inspection